### PR TITLE
feat: configurable quick-nav footer with drag-reorder

### DIFF
--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -28,7 +28,7 @@ See: .planning/PROJECT.md (updated 2026-04-06)
 Phase: —
 Plan: —
 Status: v1.4 complete, planning next milestone
-Last activity: 2026-04-08 - Completed quick task 260409-0l6: Minor bugs and UI tweaks in liquid tracker
+Last activity: 2026-04-09 - Completed quick task 260409-hqu: Fix intake navigation footer with configurable disable/reorder
 
 Progress: [██████████] 100%
 
@@ -79,6 +79,7 @@ None — v1.4 complete.
 | 260406-mpb | Fix water entry name display and food entry sodium column | 2026-04-06 | cbdfd41 | [260406-mpb-fix-water-entry-name-display-and-food-en](./quick/260406-mpb-fix-water-entry-name-display-and-food-en/) |
 | 260406-thr | Replace hardcoded bg-red-500 with progressOverLimit theme token in progress bars | 2026-04-06 | ab03cc7 | [260406-thr-replace-hardcoded-bg-red-500-with-progre](./quick/260406-thr-replace-hardcoded-bg-red-500-with-progre/) |
 | 260409-0l6 | Minor bugs and UI tweaks in liquid tracker | 2026-04-08 | e950009 | [260409-0l6-minor-bugs-and-ui-tweaks-in-liquid-track](./quick/260409-0l6-minor-bugs-and-ui-tweaks-in-liquid-track/) |
+| 260409-hqu | Fix intake navigation footer with configurable disable/reorder | 2026-04-09 | 7b95395 | [260409-hqu-fix-intake-navigation-footer-configurabl](./quick/260409-hqu-fix-intake-navigation-footer-configurabl/) |
 
 ### Roadmap Evolution
 

--- a/.planning/quick/260409-hqu-fix-intake-navigation-footer-configurabl/260409-hqu-CONTEXT.md
+++ b/.planning/quick/260409-hqu-fix-intake-navigation-footer-configurabl/260409-hqu-CONTEXT.md
@@ -1,0 +1,99 @@
+---
+name: Quick Task 260409-hqu Context
+description: Decisions for fixing the intake navigation footer with configurable disable/reorder
+type: project
+---
+
+# Quick Task 260409-hqu: Fix intake navigation footer - Context
+
+**Gathered:** 2026-04-09
+**Status:** Ready for planning
+
+<domain>
+## Task Boundary
+
+Fix the intake navigation footer:
+1. Remove alcohol & caffeine entries from the footer
+2. Footer should only show entries for root cards on the main intake screen
+3. Make footer items configurable in Settings page under a new "Quick Navigation" section
+4. Allow disabling individual items
+5. Allow click-and-drag reordering of items
+</domain>
+
+<decisions>
+## Implementation Decisions
+
+### Default footer items: 6 root cards
+The footer should show ONE item per root card visible on the main page (`src/app/page.tsx`):
+1. Liquids (`section-water` — scrolls to LiquidsCard)
+2. Food & Salt (`section-food-salt` — scrolls to FoodSaltCard)
+3. Blood Pressure (`section-bp`)
+4. Weight (`section-weight`)
+5. Urination (`section-urination`)
+6. Defecation (`section-defecation`)
+
+**Removed:** caffeine, alcohol, separate water/salt/eating items (currently 9 items → 6 items).
+
+**Implementation note:** The current `quick-nav-footer.tsx` builds items by iterating ALL `CARD_THEMES` keys. The fix is to introduce a separate `ROOT_NAV_ITEMS` constant (6 items, each referencing the matching CARD_THEMES key for icon/color/label) rather than iterating CARD_THEMES wholesale. Keep `CARD_THEMES` untouched (caffeine/alcohol themes are still used inside LiquidsCard tabs).
+
+### Drag-and-drop library: shadcn if available, fallback to motion
+**Preferred:** shadcn `Sortable` component if it exists in the shadcn registry. The shadcn skill (`/home/ryan/.claude/skills/shadcn/`) is installed — planner should use it to check the registry for `sortable` and add it via `npx shadcn@latest add sortable` if available.
+
+**Fallback:** `motion/react` `Reorder.Group` + `Reorder.Item` (motion v12 already installed, no new dep).
+
+**Rejected:** Up/down buttons only (insufficient UX), `@dnd-kit/sortable` directly (use shadcn's wrapper if available instead).
+
+### Persistence: single array in settings-store
+Add to `src/stores/settings-store.ts`:
+```typescript
+quickNavItems: Array<{ id: CardThemeKey; enabled: boolean }>
+```
+- Order is implicit in array order
+- `enabled: false` hides item from footer but keeps it in settings list
+- Persisted via existing zustand persist middleware (localStorage)
+- Default value: 6 root items, all enabled, in the order matching `page.tsx` (Liquids, Food&Salt, BP, Weight, Urination, Defecation)
+- Migration: existing users get the default array on first load (no migration needed since it's a new field)
+
+### Settings UI: new "Quick Navigation" section
+- Add a new section in `src/app/settings/page.tsx` titled "Quick Navigation"
+- List shows each item in current order
+- Each row has: drag handle, icon, label, enable/disable Switch
+- Drag-to-reorder updates the settings-store array
+- Reuses existing `Switch` component (already in `src/components/ui/switch.tsx`)
+
+### Claude's Discretion
+- Exact visual style of the settings list (drag handle position, spacing) — match existing settings sections
+- Whether to show a "Reset to default" button in the Quick Nav settings section (nice-to-have, not required)
+- Whether the footer should hide entirely when zero items are enabled (yes — return null)
+
+</decisions>
+
+<specifics>
+## Specific Ideas
+
+### Files likely touched
+- `src/components/quick-nav-footer.tsx` — read from settings-store, filter by enabled, sort by stored order
+- `src/stores/settings-store.ts` — add `quickNavItems` field with default
+- `src/app/settings/page.tsx` — add "Quick Navigation" section
+- `src/components/settings/quick-nav-settings.tsx` — NEW component for the drag/disable list
+- `src/lib/quick-nav-defaults.ts` — NEW (or inline in store) — DEFAULT_QUICK_NAV_ITEMS constant
+- Possibly: `src/components/ui/sortable.tsx` (NEW, if shadcn sortable available)
+
+### Existing infrastructure to reuse
+- `CARD_THEMES` for icon/color/label per item
+- `Switch` component for enable/disable toggle
+- `motion` library already installed (fallback drag library)
+- Zustand persist middleware in settings-store
+
+</specifics>
+
+<canonical_refs>
+## Canonical References
+
+- shadcn skill: `/home/ryan/.claude/skills/shadcn/SKILL.md` — use to check for `sortable` component in registry
+- Current footer: `src/components/quick-nav-footer.tsx`
+- Current themes: `src/lib/card-themes.ts`
+- Current page composition: `src/app/page.tsx`
+- Settings store: `src/stores/settings-store.ts`
+
+</canonical_refs>

--- a/.planning/quick/260409-hqu-fix-intake-navigation-footer-configurabl/260409-hqu-PLAN.md
+++ b/.planning/quick/260409-hqu-fix-intake-navigation-footer-configurabl/260409-hqu-PLAN.md
@@ -1,0 +1,429 @@
+---
+quick_id: 260409-hqu
+type: execute
+wave: 1
+depends_on: []
+files_modified:
+  - src/lib/quick-nav-defaults.ts
+  - src/stores/settings-store.ts
+  - src/components/quick-nav-footer.tsx
+  - src/components/settings/quick-nav-section.tsx
+autonomous: false
+requirements:
+  - D-01 # 6 root-card footer items (Liquids, Food & Salt, BP, Weight, Urination, Defecation)
+  - D-02 # Remove caffeine/alcohol from footer; keep CARD_THEMES untouched
+  - D-03 # Drag library: shadcn sortable if available, else motion Reorder (CHOSEN: motion — shadcn sortable NOT in registry)
+  - D-04 # Persistence: quickNavItems array in settings-store with enabled+order
+  - D-05 # Settings UI: new "Quick Navigation" item list with drag handle + Switch
+  - D-06 # Footer hides entirely when zero items enabled
+  - D-07 # Migration: existing users get default array on first load
+
+must_haves:
+  truths:
+    - "Footer shows only the 6 root-card items by default (Liquids, Food & Salt, BP, Weight, Urination, Defecation)"
+    - "Footer no longer shows Caffeine or Alcohol icons"
+    - "User can toggle any footer item off in Settings > Quick Navigation and it disappears from the footer"
+    - "User can drag-reorder footer items in Settings and the footer reflects the new order"
+    - "Footer settings (order + enabled state) persist across page refresh via localStorage"
+    - "Footer hides entirely (returns null) when zero items are enabled"
+    - "CARD_THEMES still contains caffeine/alcohol (used by LiquidsCard tabs) and is not mutated"
+  artifacts:
+    - path: "src/lib/quick-nav-defaults.ts"
+      provides: "DEFAULT_QUICK_NAV_ITEMS constant (6 root items, all enabled)"
+      exports: ["DEFAULT_QUICK_NAV_ITEMS", "QuickNavItem"]
+    - path: "src/stores/settings-store.ts"
+      provides: "quickNavItems field, setter, migration v5"
+      contains: "quickNavItems"
+    - path: "src/components/quick-nav-footer.tsx"
+      provides: "Footer reads from settings.quickNavItems, filters enabled, preserves order"
+      contains: "quickNavItems"
+    - path: "src/components/settings/quick-nav-section.tsx"
+      provides: "New item list with motion Reorder.Group + per-row Switch"
+      contains: "Reorder.Group"
+  key_links:
+    - from: "src/stores/settings-store.ts"
+      to: "src/lib/quick-nav-defaults.ts"
+      via: "defaultSettings.quickNavItems imports DEFAULT_QUICK_NAV_ITEMS"
+      pattern: "DEFAULT_QUICK_NAV_ITEMS"
+    - from: "src/components/quick-nav-footer.tsx"
+      to: "src/stores/settings-store.ts"
+      via: "useSettings().quickNavItems"
+      pattern: "quickNavItems"
+    - from: "src/components/settings/quick-nav-section.tsx"
+      to: "src/stores/settings-store.ts"
+      via: "setQuickNavItems setter called from drag end + Switch onCheckedChange"
+      pattern: "setQuickNavItems"
+---
+
+<objective>
+Fix the intake navigation footer so it shows only the 6 root-card items on the main intake screen,
+and add a configurable "Quick Navigation" item list in Settings that lets the user drag-reorder
+and toggle individual items on/off. Currently the footer iterates all `CARD_THEMES` keys, which
+includes `caffeine`, `alcohol`, `water`, `salt`, and `eating` — 9 items, several of which are
+not root cards on the page. The fix narrows the footer to the 6 root cards and persists a
+user-editable item list (`quickNavItems`) in the settings store.
+
+Purpose: Keep the footer focused on what the user actually uses on the main screen, and give
+them control over order/visibility without the maintenance cost of a bespoke order system per item.
+Output: Updated footer, new `quickNavItems` field in settings-store with migration, and a new
+drag-and-toggle item list in the existing Quick Navigation settings section.
+
+**Drag library decision (D-03):** The planner verified via `npx shadcn@latest search @shadcn -q "sortable"`
+and `npx shadcn@latest view @shadcn/sortable` that **no `sortable` component exists in the official shadcn
+registry**. Falling back to **`motion/react`** `Reorder.Group` + `Reorder.Item` (already installed via
+`motion@^12.29.2`, no new dependency, consistent with the footer's existing use of `motion`).
+</objective>
+
+<execution_context>
+@$HOME/.claude/get-shit-done/workflows/execute-plan.md
+</execution_context>
+
+<context>
+@.planning/quick/260409-hqu-fix-intake-navigation-footer-configurabl/260409-hqu-CONTEXT.md
+@./CLAUDE.md
+
+# Current implementation (must be modified)
+@src/components/quick-nav-footer.tsx
+@src/lib/card-themes.ts
+@src/stores/settings-store.ts
+@src/app/page.tsx
+@src/components/settings/quick-nav-section.tsx
+@src/components/ui/switch.tsx
+
+<interfaces>
+<!-- Key types the executor needs. No codebase exploration required. -->
+
+From `src/lib/card-themes.ts`:
+```typescript
+export type CardThemeKey = keyof typeof CARD_THEMES;
+// Keys: "water" | "salt" | "weight" | "bp" | "eating" | "urination" | "defecation" | "caffeine" | "alcohol"
+// Each entry has: label, icon (LucideIcon), iconBg, iconColor, sectionId
+```
+
+From `src/app/page.tsx` (confirms root card sections on main screen, in visual order):
+1. `section-water`      → LiquidsCard      → theme key: "water"    → label "Liquids" (override)
+2. `section-food-salt`  → FoodSaltCard     → theme key: "eating"   → label "Food & Salt" (override)
+3. `section-bp`         → BloodPressureCard → theme key: "bp"       → label "Blood Pressure"
+4. `section-weight`     → WeightCard       → theme key: "weight"   → label "Weight"
+5. `section-urination`  → UrinationCard    → theme key: "urination" → label "Urination"
+6. `section-defecation` → DefecationCard   → theme key: "defecation" → label "Defecation"
+
+**Label overrides needed** because CARD_THEMES labels don't match the on-screen card titles:
+- `water` theme label is "Water" → footer should say "Liquids" (matches LiquidsCard)
+- `eating` theme label is "Eating" → footer should say "Food & Salt" (matches FoodSaltCard)
+The sectionId in CARD_THEMES already matches: `water.sectionId="section-water"`, `eating.sectionId="section-food-salt"`.
+
+From `src/stores/settings-store.ts`:
+```typescript
+// Current persist version is 4. New field requires version 5 + migration.
+// Zustand persist already wired; follow the existing migrate() pattern.
+interface Settings { /* ... */ }
+const defaultSettings: Settings = { /* ... */ };
+```
+
+From `motion` (v12) — drag-reorder API:
+```typescript
+import { Reorder } from "motion/react";
+// <Reorder.Group axis="y" values={items} onReorder={setItems}>
+//   {items.map(item => <Reorder.Item key={item.id} value={item}>...</Reorder.Item>)}
+// </Reorder.Group>
+```
+</interfaces>
+</context>
+
+<tasks>
+
+<task type="auto">
+  <name>Task 1: Add quickNavItems to settings-store with defaults and migration</name>
+  <files>
+    - src/lib/quick-nav-defaults.ts (NEW)
+    - src/stores/settings-store.ts (MODIFY)
+  </files>
+  <action>
+    Per D-01, D-04, D-07:
+
+    **Step 1 — Create `src/lib/quick-nav-defaults.ts`:**
+
+    ```typescript
+    import type { CardThemeKey } from "@/lib/card-themes";
+
+    export interface QuickNavItem {
+      /** CardThemeKey the item references for icon/color. */
+      id: CardThemeKey;
+      /** When false, item is hidden from the footer but kept in settings list. */
+      enabled: boolean;
+    }
+
+    /**
+     * Default footer items — one per root card visible on the main intake screen.
+     * Order matches the visual order in src/app/page.tsx (top-to-bottom).
+     * NOTE: "water" theme is used for the Liquids root card; "eating" theme for the
+     * Food & Salt root card. Label overrides for these two keys are applied in
+     * quick-nav-footer.tsx so the footer reads "Liquids" / "Food & Salt".
+     */
+    export const DEFAULT_QUICK_NAV_ITEMS: QuickNavItem[] = [
+      { id: "water", enabled: true },      // Liquids
+      { id: "eating", enabled: true },     // Food & Salt
+      { id: "bp", enabled: true },         // Blood Pressure
+      { id: "weight", enabled: true },     // Weight
+      { id: "urination", enabled: true },  // Urination
+      { id: "defecation", enabled: true }, // Defecation
+    ];
+
+    /** Labels overridden for the footer to match on-screen card titles. */
+    export const QUICK_NAV_LABEL_OVERRIDES: Partial<Record<CardThemeKey, string>> = {
+      water: "Liquids",
+      eating: "Food & Salt",
+    };
+    ```
+
+    **Step 2 — Update `src/stores/settings-store.ts`:**
+    - Import `DEFAULT_QUICK_NAV_ITEMS` and `QuickNavItem` from `@/lib/quick-nav-defaults`.
+    - Re-export `QuickNavItem` type for convenience: `export type { QuickNavItem } from "@/lib/quick-nav-defaults";`
+    - Add to `Settings` interface (place immediately after `quickNavOrder`):
+      ```typescript
+      // Quick Nav configurable item list (order + enabled state per item)
+      quickNavItems: QuickNavItem[];
+      ```
+    - Add to `SettingsActions` interface:
+      ```typescript
+      setQuickNavItems: (items: QuickNavItem[]) => void;
+      ```
+    - Add to `defaultSettings` (immediately after `quickNavOrder`): `quickNavItems: DEFAULT_QUICK_NAV_ITEMS,`
+    - Add action inside the `create` body:
+      ```typescript
+      setQuickNavItems: (items) => set({ quickNavItems: items }),
+      ```
+    - Bump persist `version: 4` → `version: 5`.
+    - Add migration in the `migrate` function (append at end, before the final return):
+      ```typescript
+      if (version < 5) {
+        // D-07: New quickNavItems field. Seed existing users with defaults.
+        state.quickNavItems = DEFAULT_QUICK_NAV_ITEMS;
+      }
+      ```
+
+    Do NOT modify any other existing fields. Keep the existing `showQuickNav` and `quickNavOrder` fields untouched — they remain valid controls orthogonal to the new item list.
+  </action>
+  <verify>
+    <automated>pnpm lint 2>&1 | grep -E "(quick-nav-defaults|settings-store)" || pnpm tsc --noEmit 2>&1 | grep -E "(quick-nav-defaults|settings-store)" || echo "OK: no type/lint errors in modified files"</automated>
+  </verify>
+  <done>
+    - `src/lib/quick-nav-defaults.ts` exists and exports `DEFAULT_QUICK_NAV_ITEMS`, `QuickNavItem`, `QUICK_NAV_LABEL_OVERRIDES`
+    - `src/stores/settings-store.ts` has `quickNavItems` field (default = 6 root items, all enabled) and `setQuickNavItems` setter
+    - Persist version bumped to 5 with migration seeding `quickNavItems` for pre-v5 users
+    - `pnpm lint` passes with no new errors in the two modified files
+  </done>
+</task>
+
+<task type="auto">
+  <name>Task 2: Rewrite quick-nav-footer to read from settings and render configured items</name>
+  <files>
+    - src/components/quick-nav-footer.tsx (MODIFY)
+  </files>
+  <action>
+    Per D-01, D-02, D-06:
+
+    Rewrite the component so it:
+    1. Reads `quickNavItems` from `useSettings()` (via the existing `useSettings` hook — the footer already consumes `settings.showQuickNav` from `page.tsx`; pass `quickNavItems` through as a prop instead so the footer stays a pure presentational component, OR import `useSettings` directly — **match whatever the existing footer does for consistency**. Currently the footer receives `order` as a prop, so follow the same pattern: add a `quickNavItems: QuickNavItem[]` prop).
+    2. Removes `buildSectionItems()` and the `SECTION_ITEMS` constant entirely. Do NOT iterate `CARD_THEMES` wholesale anymore.
+    3. Builds the render list by mapping `quickNavItems` → `{ theme = CARD_THEMES[item.id] }`, filtering out `enabled === false`.
+    4. Applies `QUICK_NAV_LABEL_OVERRIDES` (imported from `@/lib/quick-nav-defaults`) so `water` shows "Liquids" and `eating` shows "Food & Salt" — fall back to `theme.label` for everything else.
+    5. Returns `null` when the filtered list is empty (D-06).
+    6. Continues to apply the existing `order === "rtl"` reverse logic AFTER filtering (so RTL reversal works against the user's configured order).
+    7. Keeps all existing styling, `motion.footer` wrapper, `hidden` prop behavior, and click handler wiring unchanged.
+
+    Update `src/app/page.tsx` to pass `quickNavItems={settings.quickNavItems}` alongside the existing props. Remove the `settings.showQuickNav && ...` guard ONLY if it still makes sense — actually, **keep it**. `showQuickNav` is the master toggle; `quickNavItems` is the per-item list. Both must be respected: if `showQuickNav` is false OR all items disabled, footer is hidden.
+
+    Concrete new prop shape:
+    ```typescript
+    interface QuickNavFooterProps {
+      hidden: boolean;
+      order: "ltr" | "rtl";
+      transitionDuration?: number;
+      quickNavItems: QuickNavItem[]; // NEW
+      onScrollTo: (sectionId: string) => void;
+    }
+    ```
+
+    Inside the component, replace the old `orderedSections` useMemo with:
+    ```typescript
+    const orderedSections = useMemo(() => {
+      const enabled = quickNavItems
+        .filter((item) => item.enabled)
+        .map((item) => {
+          const theme = CARD_THEMES[item.id];
+          return {
+            id: theme.sectionId,
+            icon: theme.icon,
+            label: QUICK_NAV_LABEL_OVERRIDES[item.id] ?? theme.label,
+            iconColor: theme.iconColor,
+            bgColor: theme.iconBg,
+          };
+        });
+      return order === "rtl" ? enabled.reverse() : enabled;
+    }, [quickNavItems, order]);
+
+    if (orderedSections.length === 0) return null;
+    ```
+
+    Do NOT touch `CARD_THEMES` — caffeine/alcohol themes are still used by LiquidsCard tabs (verified in `src/components/liquids-card.tsx` consumers).
+  </action>
+  <verify>
+    <automated>pnpm lint 2>&1 | grep -E "quick-nav-footer" || pnpm tsc --noEmit 2>&1 | grep -E "(quick-nav-footer|page\.tsx)" || echo "OK: no type/lint errors in footer"</automated>
+  </verify>
+  <done>
+    - `quick-nav-footer.tsx` no longer imports or iterates `Object.keys(CARD_THEMES)`; it maps over `quickNavItems` prop instead
+    - Footer returns `null` when no items are enabled
+    - Label overrides applied: water→"Liquids", eating→"Food & Salt"
+    - `src/app/page.tsx` passes `quickNavItems={settings.quickNavItems}` prop
+    - `pnpm lint` and `pnpm tsc --noEmit` produce no new errors
+    - Default behavior (fresh localStorage): footer shows 6 items in order Defecation/Urination/Weight/BP/Food & Salt/Liquids (RTL default), no caffeine/alcohol
+  </done>
+</task>
+
+<task type="auto">
+  <name>Task 3: Add drag-reorder + enable/disable item list to Quick Navigation settings section</name>
+  <files>
+    - src/components/settings/quick-nav-section.tsx (MODIFY)
+  </files>
+  <action>
+    Per D-05:
+
+    Extend the existing `QuickNavSection` component by inserting a new subsection ABOVE the existing "Icon Order" select and animation timings — place it immediately after the "Quick Nav Footer" on/off button (around line 51), inside the `{settings.showQuickNav && (<>...</>)}` conditional so it only shows when the footer is enabled.
+
+    Required imports (add to existing imports at top of file):
+    ```typescript
+    import { Reorder } from "motion/react";
+    import { GripVertical } from "lucide-react";
+    import { Switch } from "@/components/ui/switch";
+    import { CARD_THEMES } from "@/lib/card-themes";
+    import { QUICK_NAV_LABEL_OVERRIDES } from "@/lib/quick-nav-defaults";
+    import { cn } from "@/lib/utils";
+    ```
+
+    New subsection markup (insert after the Quick Nav Footer on/off row, inside the `{settings.showQuickNav && ...}` block, before the "Icon Order" select):
+
+    ```tsx
+    <div className="space-y-2">
+      <Label>
+        <span className="flex items-center gap-1.5">
+          <GripVertical className="w-3.5 h-3.5" />
+          Footer Items
+        </span>
+      </Label>
+      <p className="text-xs text-muted-foreground">
+        Drag to reorder. Toggle to show/hide in the footer.
+      </p>
+      <Reorder.Group
+        axis="y"
+        values={settings.quickNavItems}
+        onReorder={settings.setQuickNavItems}
+        className="flex flex-col gap-1.5 rounded-lg border bg-background/50 p-2"
+      >
+        {settings.quickNavItems.map((item) => {
+          const theme = CARD_THEMES[item.id];
+          const Icon = theme.icon;
+          const label = QUICK_NAV_LABEL_OVERRIDES[item.id] ?? theme.label;
+          return (
+            <Reorder.Item
+              key={item.id}
+              value={item}
+              className={cn(
+                "flex items-center gap-3 rounded-md border bg-card px-2 py-1.5",
+                "cursor-grab active:cursor-grabbing touch-none select-none",
+                !item.enabled && "opacity-50"
+              )}
+            >
+              <GripVertical className="w-4 h-4 text-muted-foreground shrink-0" />
+              <div className={cn("p-1 rounded", theme.iconBg)}>
+                <Icon className={cn("w-3.5 h-3.5", theme.iconColor)} />
+              </div>
+              <span className="flex-1 text-sm font-medium">{label}</span>
+              <Switch
+                checked={item.enabled}
+                onCheckedChange={(checked) => {
+                  const next = settings.quickNavItems.map((i) =>
+                    i.id === item.id ? { ...i, enabled: checked } : i
+                  );
+                  settings.setQuickNavItems(next);
+                }}
+                onClick={(e) => e.stopPropagation()}
+                onPointerDown={(e) => e.stopPropagation()}
+              />
+            </Reorder.Item>
+          );
+        })}
+      </Reorder.Group>
+    </div>
+    ```
+
+    **Important notes:**
+    - `touch-none` on the Reorder.Item is required for mobile drag to work with motion.
+    - `onPointerDown` stopPropagation on the Switch is critical — without it the Switch click initiates a drag instead of toggling.
+    - Use `cn()` with conditional `opacity-50` for disabled visual state (do NOT write manual template literal ternaries per project's shadcn conventions).
+    - Do NOT introduce `space-y-*` classes — use `flex flex-col gap-*` per shadcn styling rules.
+    - Do NOT remove or restructure the existing "Icon Order" select or animation timings inputs — only insert the new subsection.
+
+    **Claude's discretion (per CONTEXT.md):** Skip the optional "Reset to default" button for now — keeps scope tight and the existing "Reset to Defaults" at the bottom of the settings page already covers it.
+  </action>
+  <verify>
+    <automated>pnpm lint 2>&1 | grep -E "quick-nav-section" || pnpm tsc --noEmit 2>&1 | grep -E "quick-nav-section" || echo "OK: no type/lint errors in settings section"</automated>
+  </verify>
+  <done>
+    - `QuickNavSection` renders a new "Footer Items" list using `Reorder.Group` from `motion/react`
+    - Each row shows drag handle, themed icon, label (with water→Liquids / eating→Food & Salt overrides), and Switch
+    - Dragging a row calls `setQuickNavItems` with the new order
+    - Toggling a Switch calls `setQuickNavItems` with updated `enabled` flag; clicking the Switch does NOT initiate a drag
+    - Disabled rows visually dim (opacity-50)
+    - Existing "Icon Order" select and animation timings are untouched
+    - `pnpm lint` passes
+  </done>
+</task>
+
+<task type="checkpoint:human-verify" gate="blocking">
+  <name>Task 4: Verify footer + settings behavior end-to-end</name>
+  <what-built>
+    - Footer now shows only the 6 root-card items (Liquids, Food & Salt, BP, Weight, Urination, Defecation) — no more caffeine/alcohol
+    - New `quickNavItems` field in settings-store with default and v5 migration
+    - New drag-reorder + Switch list in Settings > Quick Navigation > Footer Items
+    - Footer hides entirely when zero items are enabled
+  </what-built>
+  <how-to-verify>
+    1. `pnpm dev` and open http://localhost:3000 on a fresh browser profile (or clear `intake-tracker-settings` in localStorage)
+    2. Confirm footer shows exactly 6 icons: Liquids, Food & Salt, Blood Pressure, Weight, Urination, Defecation (RTL order by default, so rightmost = Liquids)
+    3. Confirm Caffeine and Alcohol are NOT in the footer
+    4. Tap each footer icon — should scroll to the correct card
+    5. Navigate to /settings → Quick Navigation section → "Footer Items" list should show 6 rows in order: Liquids, Food & Salt, Blood Pressure, Weight, Urination, Defecation
+    6. Drag "Weight" above "Blood Pressure" — verify the footer on / updates immediately (go back to main page)
+    7. Toggle "Defecation" Switch OFF in settings — verify Defecation disappears from the footer on /
+    8. Toggle all 6 Switches OFF — verify the footer disappears entirely (returns null)
+    9. Refresh the page — verify order and enabled state persist (check localStorage `intake-tracker-settings` has `quickNavItems` array and `version: 5`)
+    10. (Optional) Open DevTools Application > Local Storage, manually edit a v4-shaped state to remove `quickNavItems`, reload — verify migration seeds the defaults
+    11. Confirm LiquidsCard tabs (caffeine/alcohol) still work correctly — CARD_THEMES should be unmutated
+  </how-to-verify>
+  <resume-signal>Type "approved" if all checks pass, or describe any issues found</resume-signal>
+</task>
+
+</tasks>
+
+<verification>
+Overall phase checks:
+- `pnpm lint` passes with no new warnings
+- `pnpm tsc --noEmit` passes with no new type errors
+- Manual UAT in the human-verify checkpoint above confirms all 6 must-have truths
+</verification>
+
+<success_criteria>
+- Footer default state matches the 6 root cards (D-01, D-02)
+- `quickNavItems` persists across refresh (D-04)
+- Drag-reorder works via `motion/react` `Reorder` (D-03)
+- Enable/disable via Switch works (D-05)
+- Footer hides when all items disabled (D-06)
+- Migration v4→v5 seeds defaults for existing users (D-07)
+- `CARD_THEMES` unmodified (caffeine/alcohol still available for LiquidsCard tabs)
+</success_criteria>
+
+<output>
+After completion, create `.planning/quick/260409-hqu-fix-intake-navigation-footer-configurabl/260409-hqu-SUMMARY.md`
+</output>

--- a/.planning/quick/260409-hqu-fix-intake-navigation-footer-configurabl/260409-hqu-SUMMARY.md
+++ b/.planning/quick/260409-hqu-fix-intake-navigation-footer-configurabl/260409-hqu-SUMMARY.md
@@ -1,0 +1,130 @@
+---
+quick_id: 260409-hqu
+type: summary
+one_liner: "Narrowed intake footer to 6 root-card items and added drag-reorder + enable/disable list in Quick Nav settings"
+tags: [ui, settings, footer, quick-nav, drag-drop]
+dependency_graph:
+  requires:
+    - src/lib/card-themes.ts
+    - src/stores/settings-store.ts
+    - motion/react (Reorder primitives)
+  provides:
+    - src/lib/quick-nav-defaults.ts
+    - settings.quickNavItems (persisted)
+    - settings.setQuickNavItems
+  affects:
+    - src/components/quick-nav-footer.tsx
+    - src/app/page.tsx
+    - src/components/settings/quick-nav-section.tsx
+tech_stack:
+  added: []
+  patterns:
+    - motion/react Reorder.Group for drag-reorder lists
+    - zustand persist v5 migration seeding new field for existing users
+key_files:
+  created:
+    - src/lib/quick-nav-defaults.ts
+  modified:
+    - src/stores/settings-store.ts
+    - src/components/quick-nav-footer.tsx
+    - src/app/page.tsx
+    - src/components/settings/quick-nav-section.tsx
+decisions:
+  - "Used motion/react Reorder primitives instead of shadcn sortable (not in registry) or @dnd-kit (avoids new dep)"
+  - "Kept label overrides (water->Liquids, eating->Food & Salt) in quick-nav-defaults.ts so footer and settings row share the same source of truth"
+  - "RTL reversal applied after enabled filtering so the user's configured order is preserved on both axes"
+  - "CARD_THEMES left untouched — caffeine/alcohol entries are still consumed by LiquidsCard tabs"
+metrics:
+  completed_date: "2026-04-09"
+  tasks_completed: 3
+  human_verify_pending: true
+---
+
+# Quick Task 260409-hqu: Fix Intake Navigation Footer (Configurable) Summary
+
+## One-liner
+
+Narrowed the intake footer to the 6 root-card items (Liquids, Food & Salt, BP, Weight, Urination, Defecation), removed caffeine/alcohol entries, and added a drag-reorder + enable/disable list in Settings > Quick Navigation.
+
+## What Was Built
+
+**Tasks completed:** 3 of 4 (task 4 is a human-verify checkpoint pending manual UAT).
+
+### Task 1 — Settings store + defaults (commit `838c181`)
+
+- Created `src/lib/quick-nav-defaults.ts`:
+  - `QuickNavItem` interface (`id: CardThemeKey`, `enabled: boolean`)
+  - `DEFAULT_QUICK_NAV_ITEMS` constant (6 root cards in visual order, all enabled)
+  - `QUICK_NAV_LABEL_OVERRIDES` map (water→"Liquids", eating→"Food & Salt") — shared by footer and settings
+- Updated `src/stores/settings-store.ts`:
+  - Added `quickNavItems: QuickNavItem[]` to `Settings` interface (immediately after `quickNavOrder`)
+  - Added `setQuickNavItems` to `SettingsActions` and to the `create` body
+  - Seeded `defaultSettings.quickNavItems = DEFAULT_QUICK_NAV_ITEMS`
+  - Bumped persist version `4 → 5` with migration seeding `quickNavItems` for pre-v5 users (D-07)
+  - Re-exported `QuickNavItem` for convenience
+
+### Task 2 — Rewrite footer to read from settings (commit `5ec7f83`)
+
+- Rewrote `src/components/quick-nav-footer.tsx`:
+  - Removed `buildSectionItems()` + `SECTION_ITEMS` constant (no longer iterates `CARD_THEMES`)
+  - Added `quickNavItems: QuickNavItem[]` prop
+  - New `useMemo` builds render list: filter `enabled`, map to `{theme = CARD_THEMES[id]}`, apply `QUICK_NAV_LABEL_OVERRIDES`, then RTL reverse
+  - Returns `null` when filtered list is empty (D-06)
+  - All existing styling, `motion.footer` wrapper, `hidden` behavior, and click handling preserved
+- Updated `src/app/page.tsx`:
+  - Passes `quickNavItems={settings.quickNavItems}` to `<QuickNavFooter>` alongside existing props
+  - `settings.showQuickNav` master toggle retained as an outer guard
+
+### Task 3 — Settings drag-reorder + toggle list (commit `7b95395`)
+
+- Extended `src/components/settings/quick-nav-section.tsx`:
+  - New "Footer Items" subsection inserted above "Icon Order" (inside the `showQuickNav` conditional)
+  - Uses `motion/react` `Reorder.Group` / `Reorder.Item` with `axis="y"`
+  - Each row: `GripVertical` handle, themed icon (from `CARD_THEMES[id]`), label (with overrides), `Switch`
+  - Dragging calls `settings.setQuickNavItems(newOrder)`
+  - Toggling calls `setQuickNavItems` with updated `enabled` flag
+  - `Switch` uses `onClick` and `onPointerDown` stopPropagation so clicking the toggle doesn't start a drag
+  - Disabled rows visually dim via `opacity-50` (conditional through `cn()`)
+  - `touch-none` on `Reorder.Item` enables mobile drag
+  - Animation timings and "Icon Order" select untouched
+
+## Verification Run
+
+- `pnpm lint` — passes (only pre-existing warning in `src/components/medications/schedule-view.tsx` which is out of scope)
+- `pnpm tsc --noEmit` — clean, no new type errors
+- Manual UAT deferred to Task 4 (human-verify checkpoint)
+
+## Deviations from Plan
+
+None — plan executed exactly as written. No Rule 1/2/3 auto-fixes required.
+
+## Known Stubs
+
+None.
+
+## Threat Flags
+
+None — no new network endpoints, auth paths, or trust-boundary changes. All state is client-side localStorage, scoped to the existing `intake-tracker-settings` store.
+
+## Pending
+
+- **Task 4 (human-verify):** Manual UAT per the 11 steps in `260409-hqu-PLAN.md`. Confirm footer shows 6 icons (no caffeine/alcohol), drag-reorder works, Switch toggle hides items, all-disabled returns null, v5 migration seeds defaults for pre-existing storage, CARD_THEMES-dependent LiquidsCard tabs still function.
+
+## Commits
+
+| Task | Commit    | Message                                                          |
+| ---- | --------- | ---------------------------------------------------------------- |
+| 1    | `838c181` | feat(260409-hqu): add quickNavItems to settings store             |
+| 2    | `5ec7f83` | fix(260409-hqu): narrow quick-nav footer to 6 root-card items    |
+| 3    | `7b95395` | feat(260409-hqu): add Footer Items drag-reorder list to Quick Nav settings |
+
+## Self-Check: PASSED
+
+- `src/lib/quick-nav-defaults.ts` — FOUND
+- `src/stores/settings-store.ts` — FOUND (modified)
+- `src/components/quick-nav-footer.tsx` — FOUND (modified)
+- `src/app/page.tsx` — FOUND (modified)
+- `src/components/settings/quick-nav-section.tsx` — FOUND (modified)
+- commit `838c181` — FOUND in git log
+- commit `5ec7f83` — FOUND in git log
+- commit `7b95395` — FOUND in git log

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -97,6 +97,7 @@ function HomeContent() {
           hidden={isHidden}
           order={settings.quickNavOrder}
           transitionDuration={barTransitionSec}
+          quickNavItems={settings.quickNavItems}
           onScrollTo={handleQuickNav}
         />
       )}

--- a/src/components/liquids/preset-tab.tsx
+++ b/src/components/liquids/preset-tab.tsx
@@ -227,10 +227,9 @@ export function PresetTab({ tab }: PresetTabProps) {
       groupSource: `preset:${presetIdOverride ?? selectedPresetId ?? "manual"}`,
     };
 
-    // Water intake from waterContentPercent
-    const waterAmount = Math.round(
-      (volumeMl * waterContentPercent) / 100
-    );
+    // Water intake: full drink volume counts as water
+    // (caffeine/alcohol content does not reduce the water volume)
+    const waterAmount = volumeMl;
     const intakes: ComposableEntryInput["intakes"] = [];
     if (waterAmount > 0) {
       intakes.push({

--- a/src/components/quick-nav-footer.tsx
+++ b/src/components/quick-nav-footer.tsx
@@ -3,33 +3,11 @@
 import { useMemo } from "react";
 import { motion } from "motion/react";
 import { cn } from "@/lib/utils";
-import { CARD_THEMES, type CardThemeKey } from "@/lib/card-themes";
-import type { LucideIcon } from "lucide-react";
-
-// ── Section nav items (scrollable gallery) ──────────────────
-
-interface SectionNavItem {
-  id: string;
-  icon: LucideIcon;
-  label: string;
-  iconColor: string;
-  bgColor: string;
-}
-
-function buildSectionItems(): SectionNavItem[] {
-  return (Object.keys(CARD_THEMES) as CardThemeKey[]).map((key) => {
-    const theme = CARD_THEMES[key];
-    return {
-      id: theme.sectionId,
-      icon: theme.icon,
-      label: theme.label,
-      iconColor: theme.iconColor,
-      bgColor: theme.iconBg,
-    };
-  });
-}
-
-const SECTION_ITEMS = buildSectionItems();
+import { CARD_THEMES } from "@/lib/card-themes";
+import {
+  QUICK_NAV_LABEL_OVERRIDES,
+  type QuickNavItem,
+} from "@/lib/quick-nav-defaults";
 
 // ── Component ───────────────────────────────────────────────
 
@@ -37,6 +15,7 @@ interface QuickNavFooterProps {
   hidden: boolean;
   order: "ltr" | "rtl";
   transitionDuration?: number;
+  quickNavItems: QuickNavItem[];
   onScrollTo: (sectionId: string) => void;
 }
 
@@ -44,13 +23,30 @@ export function QuickNavFooter({
   hidden,
   order,
   transitionDuration = 0.2,
+  quickNavItems,
   onScrollTo,
 }: QuickNavFooterProps) {
-  // Order section items based on LTR/RTL preference
-  const orderedSections = useMemo(
-    () => (order === "rtl" ? [...SECTION_ITEMS].reverse() : SECTION_ITEMS),
-    [order]
-  );
+  // Build the render list from the configured items, filtering out disabled
+  // entries. RTL reversal is applied AFTER filtering so the user's configured
+  // order is preserved on both axes.
+  const orderedSections = useMemo(() => {
+    const enabled = quickNavItems
+      .filter((item) => item.enabled)
+      .map((item) => {
+        const theme = CARD_THEMES[item.id];
+        return {
+          id: theme.sectionId,
+          icon: theme.icon,
+          label: QUICK_NAV_LABEL_OVERRIDES[item.id] ?? theme.label,
+          iconColor: theme.iconColor,
+          bgColor: theme.iconBg,
+        };
+      });
+    return order === "rtl" ? enabled.reverse() : enabled;
+  }, [quickNavItems, order]);
+
+  // D-06: hide entirely when zero items are enabled
+  if (orderedSections.length === 0) return null;
 
   return (
     <motion.footer

--- a/src/components/settings/quick-nav-section.tsx
+++ b/src/components/settings/quick-nav-section.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useEffect } from "react";
+import { Reorder } from "motion/react";
 import { Button } from "@/components/ui/button";
 import { Label } from "@/components/ui/label";
 import {
@@ -10,10 +11,14 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
-import { Navigation, ArrowRightLeft, Timer } from "lucide-react";
+import { Switch } from "@/components/ui/switch";
+import { Navigation, ArrowRightLeft, Timer, GripVertical } from "lucide-react";
 import { NumericInput } from "@/components/ui/numeric-input";
 import { useSettings } from "@/hooks/use-settings";
 import { validateAndSave, incrementSetting, decrementSetting } from "@/lib/settings-helpers";
+import { CARD_THEMES } from "@/lib/card-themes";
+import { QUICK_NAV_LABEL_OVERRIDES } from "@/lib/quick-nav-defaults";
+import { cn } from "@/lib/utils";
 
 export function QuickNavSection() {
   const settings = useSettings();
@@ -52,6 +57,58 @@ export function QuickNavSection() {
 
         {settings.showQuickNav && (
           <>
+            <div className="space-y-2">
+              <Label>
+                <span className="flex items-center gap-1.5">
+                  <GripVertical className="w-3.5 h-3.5" />
+                  Footer Items
+                </span>
+              </Label>
+              <p className="text-xs text-muted-foreground">
+                Drag to reorder. Toggle to show/hide in the footer.
+              </p>
+              <Reorder.Group
+                axis="y"
+                values={settings.quickNavItems}
+                onReorder={settings.setQuickNavItems}
+                className="flex flex-col gap-1.5 rounded-lg border bg-background/50 p-2"
+              >
+                {settings.quickNavItems.map((item) => {
+                  const theme = CARD_THEMES[item.id];
+                  const Icon = theme.icon;
+                  const label = QUICK_NAV_LABEL_OVERRIDES[item.id] ?? theme.label;
+                  return (
+                    <Reorder.Item
+                      key={item.id}
+                      value={item}
+                      className={cn(
+                        "flex items-center gap-3 rounded-md border bg-card px-2 py-1.5",
+                        "cursor-grab active:cursor-grabbing touch-none select-none",
+                        !item.enabled && "opacity-50"
+                      )}
+                    >
+                      <GripVertical className="w-4 h-4 text-muted-foreground shrink-0" />
+                      <div className={cn("p-1 rounded", theme.iconBg)}>
+                        <Icon className={cn("w-3.5 h-3.5", theme.iconColor)} />
+                      </div>
+                      <span className="flex-1 text-sm font-medium">{label}</span>
+                      <Switch
+                        checked={item.enabled}
+                        onCheckedChange={(checked) => {
+                          const next = settings.quickNavItems.map((i) =>
+                            i.id === item.id ? { ...i, enabled: checked } : i
+                          );
+                          settings.setQuickNavItems(next);
+                        }}
+                        onClick={(e) => e.stopPropagation()}
+                        onPointerDown={(e) => e.stopPropagation()}
+                      />
+                    </Reorder.Item>
+                  );
+                })}
+              </Reorder.Group>
+            </div>
+
             <div className="space-y-2">
               <Label htmlFor="quick-nav-order">
                 <span className="flex items-center gap-1.5">

--- a/src/lib/quick-nav-defaults.ts
+++ b/src/lib/quick-nav-defaults.ts
@@ -1,0 +1,30 @@
+import type { CardThemeKey } from "@/lib/card-themes";
+
+export interface QuickNavItem {
+  /** CardThemeKey the item references for icon/color. */
+  id: CardThemeKey;
+  /** When false, item is hidden from the footer but kept in settings list. */
+  enabled: boolean;
+}
+
+/**
+ * Default footer items -- one per root card visible on the main intake screen.
+ * Order matches the visual order in src/app/page.tsx (top-to-bottom).
+ * NOTE: "water" theme is used for the Liquids root card; "eating" theme for the
+ * Food & Salt root card. Label overrides for these two keys are applied in
+ * quick-nav-footer.tsx so the footer reads "Liquids" / "Food & Salt".
+ */
+export const DEFAULT_QUICK_NAV_ITEMS: QuickNavItem[] = [
+  { id: "water", enabled: true },      // Liquids
+  { id: "eating", enabled: true },     // Food & Salt
+  { id: "bp", enabled: true },         // Blood Pressure
+  { id: "weight", enabled: true },     // Weight
+  { id: "urination", enabled: true },  // Urination
+  { id: "defecation", enabled: true }, // Defecation
+];
+
+/** Labels overridden for the footer to match on-screen card titles. */
+export const QUICK_NAV_LABEL_OVERRIDES: Partial<Record<CardThemeKey, string>> = {
+  water: "Liquids",
+  eating: "Food & Salt",
+};

--- a/src/stores/settings-store.ts
+++ b/src/stores/settings-store.ts
@@ -6,8 +6,10 @@ import {
   sanitizeNumericInput
 } from "@/lib/security";
 import { DEFAULT_LIQUID_PRESETS, type LiquidPreset } from "@/lib/constants";
+import { DEFAULT_QUICK_NAV_ITEMS, type QuickNavItem } from "@/lib/quick-nav-defaults";
 
 export type { LiquidPreset } from "@/lib/constants";
+export type { QuickNavItem } from "@/lib/quick-nav-defaults";
 
 export interface SubstanceConfig {
   caffeine: {
@@ -46,6 +48,8 @@ export interface Settings {
   // Quick Nav footer
   showQuickNav: boolean;
   quickNavOrder: "ltr" | "rtl";
+  // Quick Nav configurable item list (order + enabled state per item)
+  quickNavItems: QuickNavItem[];
 
   // Animation timing settings (ms)
   scrollDurationMs: number;        // how fast page scrolls to section (100-1000)
@@ -98,6 +102,7 @@ interface SettingsActions {
   setDayStartHour: (hour: number) => void;
   setShowQuickNav: (value: boolean) => void;
   setQuickNavOrder: (order: "ltr" | "rtl") => void;
+  setQuickNavItems: (items: QuickNavItem[]) => void;
   setScrollDurationMs: (value: number) => void;
   setAutoHideDelayMs: (value: number) => void;
   setBarTransitionDurationMs: (value: number) => void;
@@ -140,6 +145,7 @@ const defaultSettings: Settings = {
   dayStartHour: 2, // Default: 2am - day starts at 2am for budget tracking
   showQuickNav: true,
   quickNavOrder: "rtl" as const,
+  quickNavItems: DEFAULT_QUICK_NAV_ITEMS,
   scrollDurationMs: 300,
   autoHideDelayMs: 500,
   barTransitionDurationMs: 200,
@@ -211,6 +217,7 @@ export const useSettingsStore = create<Settings & SettingsActions>()(
 
       setShowQuickNav: (value) => set({ showQuickNav: value }),
       setQuickNavOrder: (order) => set({ quickNavOrder: order }),
+      setQuickNavItems: (items) => set({ quickNavItems: items }),
       setScrollDurationMs: (value) =>
         set({ scrollDurationMs: sanitizeNumericInput(value, 100, 1000) }),
       setAutoHideDelayMs: (value) =>
@@ -280,7 +287,7 @@ export const useSettingsStore = create<Settings & SettingsActions>()(
     {
       name: "intake-tracker-settings",
       storage: createJSONStorage(() => localStorage),
-      version: 4,
+      version: 5,
       migrate: (persisted, version) => {
         const state = persisted as Record<string, unknown>;
         if (version === 0) {
@@ -315,6 +322,10 @@ export const useSettingsStore = create<Settings & SettingsActions>()(
           }
         }
         // version < 4 migration: sodiumPresets removed in Phase 39 (no longer needed)
+        if (version < 5) {
+          // D-07: New quickNavItems field. Seed existing users with defaults.
+          state.quickNavItems = DEFAULT_QUICK_NAV_ITEMS;
+        }
         return state as unknown as Settings & SettingsActions;
       },
     }


### PR DESCRIPTION
## Summary

- Quick task `260409-hqu`: narrow the intake nav footer to the 6 root-card items (removes Caffeine/Alcohol/Water/Salt/Eating duplicates) and make footer items user-configurable in Settings.
- New `quickNavItems` field in `settings-store` (Zustand persist v4 → v5 migration) — array of `{ id: CardThemeKey, enabled: boolean }`.
- New "Footer Items" subsection in Settings → Quick Navigation: drag-reorder via `motion/react` `Reorder.Group` + per-row `Switch` to enable/disable.
- Footer reads from `settings.quickNavItems`, applies label overrides (`water` → "Liquids", `eating` → "Food & Salt"), returns `null` when zero items enabled.
- `CARD_THEMES` left untouched — caffeine/alcohol entries are still consumed by `LiquidsCard` tabs.

## Notes

- **Drag library:** `motion/react` `Reorder` (already installed via `motion@^12.29.2`, no new dependency). The official `@shadcn` registry has no `sortable` component; community shadcn registries weren't checked but could be a future swap.
- **Mobile-safe drag:** `touch-none` on `Reorder.Item` + `onPointerDown` `stopPropagation` on the inner `Switch` so toggling doesn't initiate a drag.

## Test plan

- [x] `pnpm lint` — clean (only pre-existing warning in `schedule-view.tsx`, out of scope)
- [x] `pnpm tsc --noEmit` — clean
- [x] **Manual UAT (verified by user):**
  - [x] Footer shows 6 root icons, no caffeine/alcohol
  - [x] Tap each footer icon scrolls to the matching card
  - [x] Drag-reorder in Settings reflects on main page
  - [x] Toggle off removes item from footer
  - [x] All-off hides footer entirely
  - [x] Order/enabled state persist across hard refresh
  - [x] LiquidsCard caffeine/alcohol tabs still render correctly (regression check)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configurable Quick Navigation footer with per-item enable/disable and drag-and-drop reordering
  * Footer settings persist and reflect immediately across sessions

* **Changes**
  * Water intake presets now record the full drink volume for water entries (affects generated intake records)

* **Chores**
  * Updated project planning documentation
<!-- end of auto-generated comment: release notes by coderabbit.ai -->