### PR TITLE
fix: resolve issues #31-#35 (BP view, insights, AI salt, inline edit, weekly summary)

### DIFF
--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -28,7 +28,7 @@ See: .planning/PROJECT.md (updated 2026-04-06)
 Phase: —
 Plan: —
 Status: v1.4 complete, planning next milestone
-Last activity: 2026-04-09 - Completed quick task 260409-hqu: Fix intake navigation footer with configurable disable/reorder
+Last activity: 2026-04-10 - Completed quick task 260410-ho9: Fix GitHub issues #31-#35
 
 Progress: [██████████] 100%
 
@@ -80,6 +80,7 @@ None — v1.4 complete.
 | 260406-thr | Replace hardcoded bg-red-500 with progressOverLimit theme token in progress bars | 2026-04-06 | ab03cc7 | [260406-thr-replace-hardcoded-bg-red-500-with-progre](./quick/260406-thr-replace-hardcoded-bg-red-500-with-progre/) |
 | 260409-0l6 | Minor bugs and UI tweaks in liquid tracker | 2026-04-08 | e950009 | [260409-0l6-minor-bugs-and-ui-tweaks-in-liquid-track](./quick/260409-0l6-minor-bugs-and-ui-tweaks-in-liquid-track/) |
 | 260409-hqu | Fix intake navigation footer with configurable disable/reorder | 2026-04-09 | 7b95395 | [260409-hqu-fix-intake-navigation-footer-configurabl](./quick/260409-hqu-fix-intake-navigation-footer-configurabl/) |
+| 260410-ho9 | Fix GitHub issues #31-#35: BP quick view, insights, AI salt/sodium, inline editing, weekly caffeine/alcohol | 2026-04-10 | c3386d5 | [260410-ho9-fix-github-issues-31-35-bp-quick-view-he](./quick/260410-ho9-fix-github-issues-31-35-bp-quick-view-he/) |
 
 ### Roadmap Evolution
 

--- a/.planning/quick/260410-ho9-fix-github-issues-31-35-bp-quick-view-he/260410-ho9-PLAN.md
+++ b/.planning/quick/260410-ho9-fix-github-issues-31-35-bp-quick-view-he/260410-ho9-PLAN.md
@@ -1,0 +1,272 @@
+---
+phase: quick
+plan: 260410-ho9
+type: execute
+wave: 1
+depends_on: []
+files_modified:
+  - src/components/blood-pressure-card.tsx
+  - src/hooks/use-analytics-queries.ts
+  - src/components/analytics/insights-tab.tsx
+  - src/components/insight-badge.tsx
+  - src/app/api/ai/parse/route.ts
+  - src/lib/ai-client.ts
+  - src/components/food-salt/food-section.tsx
+  - src/components/recent-entries-list.tsx
+  - src/components/liquids-card.tsx
+  - src/components/weight-card.tsx
+  - src/components/urination-card.tsx
+  - src/components/defecation-card.tsx
+  - src/components/text-metrics.tsx
+autonomous: true
+requirements: ["GH-31", "GH-32", "GH-33", "GH-34", "GH-35"]
+must_haves:
+  truths:
+    - "BP quick view card shows last heart rate alongside systolic/diastolic"
+    - "BP quick view shows delta between current and previous systolic and diastolic"
+    - "Insights tab only shows data-derived insights, no hardcoded defaults"
+    - "AI food parse response includes explicit salt_or_sodium indicator"
+    - "Food section auto-selects correct sodium source dropdown when AI populates"
+    - "Tapping a recent entry expands an inline edit form instead of opening a modal dialog"
+    - "Weekly summary grid includes caffeine and alcohol rows"
+  artifacts:
+    - path: "src/components/blood-pressure-card.tsx"
+      provides: "BP card with heart rate + delta display in header"
+    - path: "src/app/api/ai/parse/route.ts"
+      provides: "AI parse endpoint returning measurement_type field"
+    - path: "src/components/text-metrics.tsx"
+      provides: "Weekly grid with caffeine and alcohol rows"
+  key_links:
+    - from: "src/app/api/ai/parse/route.ts"
+      to: "src/lib/ai-client.ts"
+      via: "measurement_type field in response/ParsedIntake"
+    - from: "src/lib/ai-client.ts"
+      to: "src/components/food-salt/food-section.tsx"
+      via: "ParsedIntake.measurementType consumed in handleParse"
+---
+
+<objective>
+Fix 5 GitHub issues (#31-#35) covering: BP quick view enhancements, insight cleanup, AI salt/sodium indicator, inline editing, and weekly caffeine/alcohol tracking.
+
+Purpose: Address user-reported issues to improve data visibility and editing UX across the dashboard.
+Output: Updated components with all 5 issues resolved.
+</objective>
+
+<context>
+@CLAUDE.md
+@src/components/blood-pressure-card.tsx
+@src/hooks/use-analytics-queries.ts
+@src/components/analytics/insights-tab.tsx
+@src/components/insight-badge.tsx
+@src/app/api/ai/parse/route.ts
+@src/lib/ai-client.ts
+@src/components/food-salt/food-section.tsx
+@src/components/recent-entries-list.tsx
+@src/components/text-metrics.tsx
+</context>
+
+<tasks>
+
+<task type="auto">
+  <name>Task 1: Display heart rate and systolic/diastolic delta in BP quick view (GH-31)</name>
+  <files>src/components/blood-pressure-card.tsx</files>
+  <action>
+In the BP card header section (lines ~192-205), enhance the quick view display that currently shows `{formatBPReading(latestReading)} mmHg` plus the category label.
+
+1. Show heart rate: Below the existing BP reading, add the heart rate if present on latestReading: `{latestReading.heartRate} BPM`. Use `text-xs text-muted-foreground` styling. Only show if `latestReading.heartRate` exists.
+
+2. Show systolic/diastolic delta: Compute the difference between the latest and the second most recent reading from `recentRecords`. The hook already fetches 5 records (line 56). Get `previousReading = recentRecords?.[1]`. If both exist, compute `systolicDelta = latestReading.systolic - previousReading.systolic` and `diastolicDelta = latestReading.diastolic - previousReading.diastolic`. Display as a compact line like: `+5 / -3` or `-2 / +1` with green for negative/decreasing values and red/amber for positive/increasing. Use `text-xs` styling. Format: positive values get a `+` prefix, negative already have `-`. Color: if delta > 0 use `text-red-500 dark:text-red-400`, if delta < 0 use `text-green-600 dark:text-green-400`, if 0 use `text-muted-foreground`.
+
+Place the heart rate and delta info below the category label in the header's right-aligned section.
+  </action>
+  <verify>
+    <automated>cd /home/ryan/repos/Personal/intake-tracker && pnpm build 2>&1 | tail -5</automated>
+  </verify>
+  <done>BP quick view header shows latest heart rate (when present) and systolic/diastolic delta vs previous reading</done>
+</task>
+
+<task type="auto">
+  <name>Task 2: Remove default insights, keep only data-derived ones (GH-32)</name>
+  <files>src/hooks/use-analytics-queries.ts, src/components/analytics/insights-tab.tsx, src/components/insight-badge.tsx</files>
+  <action>
+The current `useInsights` hook in `use-analytics-queries.ts` (lines 214-302) generates insights dynamically from real data (adherence rate, BP trend, fluid deficit, weight anomalies). These are all data-derived and should be KEPT.
+
+The issue asks to remove "default insights" -- inspect if there are any hardcoded/static insights that appear regardless of data. Looking at the code:
+- The `useInsights` hook only generates insights when data thresholds are met (adherence < 0.8, BP trend with confidence > 0.3, fluid deficit > 50%, weight anomalies detected)
+- When no data meets thresholds, it returns `[]` which shows "No notable insights" empty state
+
+The actual issue is likely about allowing users to configure which insight types are shown vs hidden permanently (not just dismissible per-instance). The insights currently auto-regenerate with new data.
+
+To address this: Add an `enabledInsightTypes` setting to the settings store. In `useInsights`, filter out any insight types the user has disabled. In the insights tab, add a small settings/gear button that opens a section to toggle which insight categories are active.
+
+Actually, re-reading the issue more carefully: "Remove default insights and allow only custom made ones" -- this means the current auto-generated insights (adherence_drop, bp_trend, fluid_deficit, anomaly) are the "default" ones to remove. The user wants ONLY custom/user-created insights.
+
+Implementation:
+1. In `use-analytics-queries.ts`: Remove the body of `useInsights` so it returns `[] as Insight[]` (empty array always). Keep the function signature for API compatibility. Add a comment: `// GH-32: Default auto-generated insights removed. Only user-created insights are supported.`
+
+2. In `insights-tab.tsx`: Update the empty state message from "Insights automatically surface when your health metrics show notable trends" to "Custom insights will appear here when configured." Keep the drill-down charts section -- they can remain as they still render based on activeTypes which will now always be empty from the insights array.
+
+3. In `insight-badge.tsx`: The badge already returns null when activeInsights.length === 0, so it will naturally hide. No changes needed unless we want to remove the component entirely -- keep it for future custom insights support.
+  </action>
+  <verify>
+    <automated>cd /home/ryan/repos/Personal/intake-tracker && pnpm build 2>&1 | tail -5</automated>
+  </verify>
+  <done>Auto-generated default insights removed from useInsights hook. Empty state messaging updated. InsightBadge naturally hides when no insights exist.</done>
+</task>
+
+<task type="auto">
+  <name>Task 3: AI food parse returns explicit salt vs sodium indicator (GH-33)</name>
+  <files>src/app/api/ai/parse/route.ts, src/lib/ai-client.ts, src/components/food-salt/food-section.tsx</files>
+  <action>
+The AI parse endpoint currently returns `salt` (which is actually sodium in mg, despite the field name). The issue requires the AI to explicitly indicate whether it's reporting salt or sodium content. Sodium x 2.5 = salt, so this distinction matters.
+
+1. **API route** (`src/app/api/ai/parse/route.ts`):
+   - Update the SYSTEM_PROMPT: After the existing salt/sodium guidelines, add: "IMPORTANT: You must indicate whether you are reporting sodium content or salt (NaCl) content. Most nutritional databases report sodium. Table salt, soy sauce labels in some countries, and UK food labels typically report salt. US labels report sodium. Always specify which one you are returning."
+   - Update the PARSE_RESULT_TOOL `input_schema` to add a new field:
+     ```
+     measurement_type: { type: "string", enum: ["sodium", "salt"], description: "Whether the 'salt' value represents sodium (Na) or salt (NaCl). sodium x 2.5 = salt." }
+     ```
+   - Add `measurement_type` to the `required` array in the tool schema.
+   - Update `AIParseResponseSchema` to add: `measurement_type: z.enum(["sodium", "salt"]).default("sodium")`
+   - In the response (line 177-181), include `measurement_type: validated.data.measurement_type`
+
+2. **Client** (`src/lib/ai-client.ts`):
+   - Add `measurementType?: "sodium" | "salt"` to the `ParsedIntake` interface
+   - In the return object, map: `measurementType: result.measurement_type`
+
+3. **Food section** (`src/components/food-salt/food-section.tsx`):
+   - In `handleParse` (line 130-166), after the AI result is received:
+     - If `result.measurementType === "salt"`, set `setSodiumSource("salt")` instead of always setting `"sodium"`
+     - If `result.measurementType === "sodium"` or undefined, keep `setSodiumSource("sodium")`
+   - This way the sodium source dropdown automatically reflects what the AI reported, and the existing conversion multipliers (sodium=1.0, salt=0.39) will correctly convert to sodium mg
+  </action>
+  <verify>
+    <automated>cd /home/ryan/repos/Personal/intake-tracker && pnpm build 2>&1 | tail -5</automated>
+  </verify>
+  <done>AI parse returns measurement_type ("sodium" or "salt"), client passes it through, food section auto-selects the correct sodium source dropdown value</done>
+</task>
+
+<task type="auto">
+  <name>Task 4: Inline editing replaces edit modal dialogs (GH-34)</name>
+  <files>src/components/recent-entries-list.tsx, src/components/blood-pressure-card.tsx, src/components/liquids-card.tsx, src/components/food-salt/food-section.tsx, src/components/weight-card.tsx, src/components/urination-card.tsx, src/components/defecation-card.tsx</files>
+  <action>
+Replace the modal dialog editing pattern with inline editing within the RecentEntriesList component. When a user taps an entry, instead of opening a Dialog, the entry row expands to show edit fields inline.
+
+1. **RecentEntriesList** (`src/components/recent-entries-list.tsx`):
+   - Add new props: `editingId: string | null`, `renderEditForm?: (record: T) => ReactNode`
+   - When `record.id === editingId`, instead of rendering `renderEntry(record)`, render `renderEditForm?.(record)` in an expanded row with a subtle background (`bg-muted/30 rounded-lg p-2`)
+   - The click handler should still call `onEdit(record)` which the parent uses to toggle `editingId`
+   - When editing, hide the delete button for that row and show it within the edit form area
+   - Add a transition: the edit form slides in with a simple height animation using CSS `overflow-hidden` + conditional max-height or simply render conditionally
+
+2. **Each card component** that uses RecentEntriesList with onEdit needs updating. The pattern for each:
+   - Instead of rendering an EditXxxDialog, pass `editingId={editingRecord?.id ?? null}` and `renderEditForm` to RecentEntriesList
+   - The `renderEditForm` callback returns a compact inline form with the same fields as the dialog but in a horizontal/compact layout
+   - Remove the EditXxxDialog import and JSX from each card
+   - The `openEdit` from `useEditRecord` already sets `editingRecord` -- use `editingRecord?.id` as `editingId`
+
+   For **blood-pressure-card.tsx**: Inline form shows systolic/diastolic inputs side by side, heart rate below, position/arm selects, timestamp, note, and Save/Cancel buttons. Remove the `<EditBloodPressureDialog>` JSX block at the bottom.
+
+   For **liquids-card.tsx**: Inline form shows amount input, timestamp, note, Save/Cancel. Remove `<EditIntakeDialog>`.
+
+   For **food-section.tsx**: Inline form shows timestamp, note, grams, Save/Cancel. Remove `<EditEatingDialog>`.
+
+   For **weight-card.tsx**: Inline form shows weight input, timestamp, note, Save/Cancel. Remove `<EditWeightDialog>`.
+
+   For **urination-card.tsx**: Inline form shows amount estimate select, timestamp, note, Save/Cancel. Remove `<EditUrinationDialog>`.
+
+   For **defecation-card.tsx**: Inline form shows amount estimate select, timestamp, note, Save/Cancel. Remove `<EditDefecationDialog>`.
+
+   Keep the inline forms compact: use `text-sm` inputs with reduced height (`h-8`), arrange fields in a `grid grid-cols-2 gap-2` where possible. Save button uses the card's theme color, Cancel is ghost/outline.
+
+   **Important**: The history-drawer.tsx still uses the Edit*Dialog components for its own editing. Do NOT remove the dialog component files -- they are still used by the history drawer. Only remove dialog usage from the individual card components.
+
+3. Close edit on successful save: The existing `useEditRecord` hook's `handleEditSubmit` already sets `editingRecord` to null on success, which will clear `editingId` and collapse the inline form.
+  </action>
+  <verify>
+    <automated>cd /home/ryan/repos/Personal/intake-tracker && pnpm build 2>&1 | tail -5</automated>
+  </verify>
+  <done>All card components use inline editing within recent entries list instead of modal dialogs. Dialog component files preserved for history drawer use.</done>
+</task>
+
+<task type="auto">
+  <name>Task 5: Add caffeine and alcohol rows to weekly summary grid (GH-35)</name>
+  <files>src/components/text-metrics.tsx, src/hooks/use-substance-queries.ts</files>
+  <action>
+The weekly summary grid in `text-metrics.tsx` currently shows Water and Na (sodium) rows (Mon-Sun). Add Caffeine and Alcohol rows below.
+
+1. **Query weekly substance data**: The component already imports `useSubstanceRecordsByDateRange` and uses it for today's totals (lines 84-93). Add two more queries for weekly data:
+   ```
+   const weeklyCaffeineRecords = useSubstanceRecordsByDateRange(weekStart, weekEnd, "caffeine");
+   const weeklyAlcoholRecords = useSubstanceRecordsByDateRange(weekStart, weekEnd, "alcohol");
+   ```
+
+2. **Bucket into 7 days**: Add two more `useMemo` buckets following the same pattern as `weeklyWater`/`weeklySalt`:
+   ```
+   const weeklyCaffeine = useMemo(() => {
+     const buckets: number[] = [0, 0, 0, 0, 0, 0, 0];
+     for (const record of weeklyCaffeineRecords) {
+       const dayOffset = Math.floor((record.timestamp - weekStart) / ONE_DAY_MS);
+       if (dayOffset >= 0 && dayOffset < 7) {
+         buckets[dayOffset] = (buckets[dayOffset] ?? 0) + (record.amountMg ?? 0);
+       }
+     }
+     return buckets;
+   }, [weeklyCaffeineRecords, weekStart]);
+   ```
+
+   For alcohol, sum `record.amountStandardDrinks ?? 0` instead and format to 1 decimal.
+
+3. **Render rows**: After the Na row in the grid (line ~328-353), add:
+   - Caffeine row: Label `Caf` (to match compact style of `Na`), values in mg (whole numbers), use `CARD_THEMES.caffeine.latestValueColor` for non-zero values
+   - Alcohol row: Label `Alc`, values formatted as `X.X` (1 decimal place for standard drinks), use `CARD_THEMES.alcohol.latestValueColor` for non-zero values
+
+   Follow the exact same pattern as the Water/Na rows but without over-limit coloring (no configurable limits for caffeine/alcohol currently). Zero values show `0` in muted color, future days show `---`.
+  </action>
+  <verify>
+    <automated>cd /home/ryan/repos/Personal/intake-tracker && pnpm build 2>&1 | tail -5</automated>
+  </verify>
+  <done>Weekly summary grid displays caffeine (mg) and alcohol (std drinks) rows alongside water and sodium</done>
+</task>
+
+</tasks>
+
+<threat_model>
+## Trust Boundaries
+
+| Boundary | Description |
+|----------|-------------|
+| client->API | AI parse request crosses to server-side Claude API |
+
+## STRIDE Threat Register
+
+| Threat ID | Category | Component | Disposition | Mitigation Plan |
+|-----------|----------|-----------|-------------|-----------------|
+| T-quick-01 | T (Tampering) | AI parse response | accept | New field is informational, existing validation via Zod schema prevents invalid values |
+| T-quick-02 | I (Info Disclosure) | AI parse prompt | accept | No new PII exposure; existing sanitizeForAI still applied |
+</threat_model>
+
+<verification>
+- `pnpm build` completes without errors
+- `pnpm lint` passes
+- BP card header shows heart rate and delta values
+- Insights tab shows empty state when no custom insights configured
+- AI parse endpoint returns `measurement_type` field
+- Food section dropdown auto-selects based on AI response
+- Recent entries in cards expand inline for editing (no modal)
+- Weekly grid shows 4 rows: Water, Na, Caf, Alc
+</verification>
+
+<success_criteria>
+All 5 GitHub issues resolved:
+- #31: BP quick view shows heart rate + systolic/diastolic delta
+- #32: Default auto-generated insights removed
+- #33: AI parse returns explicit salt vs sodium indicator
+- #34: Inline editing replaces modal dialogs in card components
+- #35: Weekly summary includes caffeine and alcohol tracking
+Build passes, lint passes, no regressions.
+</success_criteria>
+
+<output>
+After completion, create `.planning/quick/260410-ho9-fix-github-issues-31-35-bp-quick-view-he/260410-ho9-SUMMARY.md`
+</output>

--- a/.planning/quick/260410-ho9-fix-github-issues-31-35-bp-quick-view-he/260410-ho9-SUMMARY.md
+++ b/.planning/quick/260410-ho9-fix-github-issues-31-35-bp-quick-view-he/260410-ho9-SUMMARY.md
@@ -1,0 +1,63 @@
+# Quick Task 260410-ho9: Fix GitHub Issues #31-#35
+
+**Date:** 2026-04-10
+**Branch:** fix/small-tickets-31-35
+**Tasks:** 5/5 complete
+
+## Commits
+
+| # | Commit | Description |
+|---|--------|-------------|
+| 1 | 287e9ef | feat(quick-260410-ho9): display heart rate and BP delta in quick view header (GH-31) |
+| 2 | 7491f97 | fix(quick-260410-ho9): remove default auto-generated insights (GH-32) |
+| 3 | 761a320 | feat(quick-260410-ho9): ai parse returns explicit salt vs sodium indicator (GH-33) |
+| 4 | 08bdf96 | feat(quick-260410-ho9): inline editing replaces modal dialogs in card components (GH-34) |
+| 5 | c3386d5 | feat(quick-260410-ho9): add caffeine and alcohol rows to weekly summary grid (GH-35) |
+
+## Changes by Issue
+
+### GH-31: BP Quick View Heart Rate & Delta
+- **File:** `src/components/blood-pressure-card.tsx`
+- Added heart rate display below BP reading (shows BPM when present)
+- Added systolic/diastolic delta vs previous reading with color coding (green=decreasing, red=increasing)
+
+### GH-32: Remove Default Insights
+- **Files:** `src/hooks/use-analytics-queries.ts`, `src/components/analytics/insights-tab.tsx`
+- Cleared `useInsights` hook to return empty array (removes all auto-generated insights)
+- Updated empty state messaging for future custom insights support
+- `InsightBadge` naturally hides when no insights exist
+
+### GH-33: AI Salt vs Sodium Indicator
+- **Files:** `src/app/api/ai/parse/route.ts`, `src/lib/ai-client.ts`, `src/components/food-salt/food-section.tsx`
+- Added `measurement_type` field (enum: "sodium" | "salt") to AI parse tool schema
+- Updated system prompt to require explicit salt/sodium distinction
+- Client `ParsedIntake` interface includes `measurementType`
+- Food section auto-selects sodium source dropdown based on AI response
+
+### GH-34: Inline Editing Replaces Modal Dialogs
+- **Files:** `src/components/recent-entries-list.tsx`, plus all 6 card components
+- Added `editingId` and `renderEditForm` props to `RecentEntriesList`
+- Each card now renders inline edit form instead of opening dialog
+- Dialog component files preserved (still used by history drawer)
+- Cards affected: blood-pressure, liquids, food-section, weight, urination, defecation
+
+### GH-35: Caffeine & Alcohol in Weekly Summary
+- **File:** `src/components/text-metrics.tsx`
+- Added weekly caffeine and alcohol queries with day bucketing
+- New `Caf` row showing daily caffeine in mg
+- New `Alc` row showing daily alcohol in standard drinks (1 decimal)
+
+## Files Modified (12)
+
+- `src/app/api/ai/parse/route.ts`
+- `src/components/analytics/insights-tab.tsx`
+- `src/components/blood-pressure-card.tsx`
+- `src/components/defecation-card.tsx`
+- `src/components/food-salt/food-section.tsx`
+- `src/components/liquids-card.tsx`
+- `src/components/recent-entries-list.tsx`
+- `src/components/text-metrics.tsx`
+- `src/components/urination-card.tsx`
+- `src/components/weight-card.tsx`
+- `src/hooks/use-analytics-queries.ts`
+- `src/lib/ai-client.ts`

--- a/e2e/history.spec.ts
+++ b/e2e/history.spec.ts
@@ -72,7 +72,7 @@ test.describe('History / Analytics', () => {
     // Use generous timeout since Recharts renders asynchronously
     // If insights are available, we should see either SVG or "No notable insights" text
     const svgOrEmpty = page.locator('.recharts-responsive-container svg').first()
-      .or(page.locator('text=/No notable insights/i'));
+      .or(page.locator('text=/No insights for this period/i'));
     await expect(svgOrEmpty).toBeVisible({ timeout: 15000 });
   });
 });

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "@privy-io/react-auth": "^3.12.0",
     "@privy-io/server-auth": "^1.32.5",
     "@radix-ui/react-alert-dialog": "^1.1.15",
+    "@radix-ui/react-checkbox": "^1.3.3",
     "@radix-ui/react-collapsible": "^1.1.12",
     "@radix-ui/react-dialog": "^1.1.15",
     "@radix-ui/react-label": "^2.1.0",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -13,6 +13,8 @@ export default defineConfig({
   retries: process.env.CI ? 2 : 0,
   /* Opt out of parallel tests on CI. */
   ...(process.env.CI ? { workers: 1 } : {}),
+  /* Dev server compiles routes on first hit (~20s each); allow headroom */
+  timeout: process.env.CI ? 30_000 : 60_000,
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */
   reporter: 'html',
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
@@ -44,6 +46,7 @@ export default defineConfig({
         url: 'http://localhost:3000',
         reuseExistingServer: false,
         timeout: 120 * 1000,
+        env: { NEXT_PUBLIC_PRIVY_APP_ID: '' },
       }
     : {
         command: 'pnpm run dev',
@@ -52,5 +55,6 @@ export default defineConfig({
         stdout: 'pipe',
         stderr: 'pipe',
         timeout: 120 * 1000,
+        env: { NEXT_PUBLIC_PRIVY_APP_ID: '' },
       },
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -50,6 +50,9 @@ importers:
       '@radix-ui/react-alert-dialog':
         specifier: ^1.1.15
         version: 1.1.15(@types/react-dom@18.3.7(@types/react@18.3.27))(@types/react@18.3.27)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-checkbox':
+        specifier: ^1.3.3
+        version: 1.3.3(@types/react-dom@18.3.7(@types/react@18.3.27))(@types/react@18.3.27)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@radix-ui/react-collapsible':
         specifier: ^1.1.12
         version: 1.1.12(@types/react-dom@18.3.7(@types/react@18.3.27))(@types/react@18.3.27)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -1506,6 +1509,19 @@ packages:
 
   '@radix-ui/react-arrow@1.1.7':
     resolution: {integrity: sha512-F+M1tLhO+mlQaOWspE8Wstg+z6PwxwRd8oQ8IXceWz92kfAmalTRf0EjrouQeo7QssEPfCn05B4Ihs1K9WQ/7w==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-checkbox@1.3.3':
+    resolution: {integrity: sha512-wBbpv+NQftHDdG86Qc0pIyXk5IR3tM8Vd0nWLKDcX8nNn4nXFOFwsKuqw2okA/1D/mpaAkmuyndrPJTYDNZtFw==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -8727,6 +8743,22 @@ snapshots:
       '@types/react': 18.3.27
       '@types/react-dom': 18.3.7(@types/react@18.3.27)
 
+  '@radix-ui/react-checkbox@1.3.3(@types/react-dom@18.3.7(@types/react@18.3.27))(@types/react@18.3.27)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@18.3.27)(react@18.3.1)
+      '@radix-ui/react-context': 1.1.2(@types/react@18.3.27)(react@18.3.1)
+      '@radix-ui/react-presence': 1.1.5(@types/react-dom@18.3.7(@types/react@18.3.27))(@types/react@18.3.27)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@18.3.7(@types/react@18.3.27))(@types/react@18.3.27)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@18.3.27)(react@18.3.1)
+      '@radix-ui/react-use-previous': 1.1.1(@types/react@18.3.27)(react@18.3.1)
+      '@radix-ui/react-use-size': 1.1.1(@types/react@18.3.27)(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.27
+      '@types/react-dom': 18.3.7(@types/react@18.3.27)
+
   '@radix-ui/react-collapsible@1.1.12(@types/react-dom@18.3.7(@types/react@18.3.27))(@types/react@18.3.27)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@radix-ui/primitive': 1.1.3
@@ -12848,8 +12880,8 @@ snapshots:
       '@typescript-eslint/parser': 8.54.0(eslint@8.57.1)(typescript@5.9.3)
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.54.0(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1)
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.54.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.54.0(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.1)
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.54.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)
       eslint-plugin-jsx-a11y: 6.10.2(eslint@8.57.1)
       eslint-plugin-react: 7.37.5(eslint@8.57.1)
       eslint-plugin-react-hooks: 5.0.0-canary-7118f5dd7-20230705(eslint@8.57.1)
@@ -12868,7 +12900,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.54.0(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.1):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.3
@@ -12879,22 +12911,22 @@ snapshots:
       tinyglobby: 0.2.15
       unrs-resolver: 1.11.1
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.54.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.54.0(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.54.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.54.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.54.0(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1):
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.54.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 8.54.0(eslint@8.57.1)(typescript@5.9.3)
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.54.0(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1)
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.1)
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.54.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.54.0(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.54.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -12905,7 +12937,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.54.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.54.0(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.54.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3

--- a/src/app/api/ai/parse/route.ts
+++ b/src/app/api/ai/parse/route.ts
@@ -24,6 +24,7 @@ const ParseRequestSchema = z.object({
 const AIParseResponseSchema = z.object({
   water: z.number().min(0).max(10000).nullable(),
   salt: z.number().min(0).max(50000).nullable(),
+  measurement_type: z.enum(["sodium", "salt"]).default("sodium"),
   reasoning: z.string().max(500).optional(),
 });
 
@@ -50,10 +51,12 @@ Guidelines for estimation:
   - Restaurant meals: typically 1000-2000mg sodium
   - Chips/snacks: ~150-200mg per serving
 
+IMPORTANT: You must indicate whether you are reporting sodium content or salt (NaCl) content. Most nutritional databases report sodium. Table salt, soy sauce labels in some countries, and UK food labels typically report salt. US labels report sodium. Always specify which one you are returning.
+
 Always respond with valid JSON only, no additional text.
 
 Example response:
-{"water": 250, "salt": 5, "reasoning": "A glass of water (250ml) contains 250ml water and negligible sodium"}`;
+{"water": 250, "salt": 5, "measurement_type": "sodium", "reasoning": "A glass of water (250ml) contains 250ml water and negligible sodium"}`;
 
 // --- Tool Definition ---
 
@@ -65,9 +68,10 @@ const PARSE_RESULT_TOOL = {
     properties: {
       water: { type: ["number", "null"], description: "Water content in ml, null if cannot estimate" },
       salt: { type: ["number", "null"], description: "Sodium content in mg, null if cannot estimate" },
+      measurement_type: { type: "string", enum: ["sodium", "salt"], description: "Whether the 'salt' value represents sodium (Na) or salt (NaCl). sodium x 2.5 = salt." },
       reasoning: { type: "string", description: "Brief explanation of the estimate" },
     },
-    required: ["water", "salt", "reasoning"],
+    required: ["water", "salt", "measurement_type", "reasoning"],
     additionalProperties: false,
   },
 };
@@ -177,6 +181,7 @@ export const POST = withAuth(async ({ request, auth }) => {
     return NextResponse.json({
       water: validated.data.water,
       salt: validated.data.salt,
+      measurement_type: validated.data.measurement_type,
       ...(validated.data.reasoning !== undefined && { reasoning: validated.data.reasoning }),
     });
   } catch (error) {

--- a/src/components/analytics/insights-tab.tsx
+++ b/src/components/analytics/insights-tab.tsx
@@ -76,10 +76,9 @@ export function InsightsTab({ range }: InsightsTabProps) {
     return (
       <div className="py-12 text-center text-muted-foreground">
         <Lightbulb className="w-8 h-8 mx-auto mb-3 opacity-50" />
-        <p className="text-lg font-medium">No notable insights for this period</p>
+        <p className="text-lg font-medium">No insights for this period</p>
         <p className="text-sm mt-1 max-w-xs mx-auto">
-          Insights automatically surface when your health metrics show notable
-          trends, anomalies, or changes in adherence.
+          Custom insights will appear here when configured.
         </p>
       </div>
     );

--- a/src/components/blood-pressure-card.tsx
+++ b/src/components/blood-pressure-card.tsx
@@ -466,20 +466,20 @@ export function BloodPressureCard() {
           renderEditForm={() => (
             <InlineEditFormShell timestamp={editTimestamp} onTimestampChange={setEditTimestamp} note={editNote} onNoteChange={setEditNote} onSave={() => handleEditSubmit()} onCancel={closeEdit} buttonClassName={theme.buttonBg}>
               <div className="grid grid-cols-2 gap-2">
-                <Input type="number" placeholder="Systolic" value={editSystolic} onChange={(e) => setEditSystolic(e.target.value)} className="h-8 text-sm" />
-                <Input type="number" placeholder="Diastolic" value={editDiastolic} onChange={(e) => setEditDiastolic(e.target.value)} className="h-8 text-sm" />
+                <Input aria-label="Systolic pressure" type="number" placeholder="Systolic" value={editSystolic} onChange={(e) => setEditSystolic(e.target.value)} className="h-8 text-sm" />
+                <Input aria-label="Diastolic pressure" type="number" placeholder="Diastolic" value={editDiastolic} onChange={(e) => setEditDiastolic(e.target.value)} className="h-8 text-sm" />
               </div>
-              <Input type="number" placeholder="Heart rate (optional)" value={editHeartRate} onChange={(e) => setEditHeartRate(e.target.value)} className="h-8 text-sm" />
+              <Input aria-label="Heart rate" type="number" placeholder="Heart rate (optional)" value={editHeartRate} onChange={(e) => setEditHeartRate(e.target.value)} className="h-8 text-sm" />
               <div className="grid grid-cols-2 gap-2">
                 <Select value={editPosition} onValueChange={(v) => setEditPosition(v as "sitting" | "standing")}>
-                  <SelectTrigger className="h-8 text-sm"><SelectValue /></SelectTrigger>
+                  <SelectTrigger aria-label="Position" className="h-8 text-sm"><SelectValue /></SelectTrigger>
                   <SelectContent>
                     <SelectItem value="sitting">Sitting</SelectItem>
                     <SelectItem value="standing">Standing</SelectItem>
                   </SelectContent>
                 </Select>
                 <Select value={editArm} onValueChange={(v) => setEditArm(v as "left" | "right")}>
-                  <SelectTrigger className="h-8 text-sm"><SelectValue /></SelectTrigger>
+                  <SelectTrigger aria-label="Arm" className="h-8 text-sm"><SelectValue /></SelectTrigger>
                   <SelectContent>
                     <SelectItem value="left">Left arm</SelectItem>
                     <SelectItem value="right">Right arm</SelectItem>

--- a/src/components/blood-pressure-card.tsx
+++ b/src/components/blood-pressure-card.tsx
@@ -27,6 +27,7 @@ const BloodPressureFormSchema = z.object({
 });
 import { CollapsibleTimeInputControlled } from "@/components/collapsible-time-input";
 import { RecentEntriesList, InlineEditFormShell } from "@/components/recent-entries-list";
+import { Checkbox } from "@/components/ui/checkbox";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { useDeleteWithToast } from "@/hooks/use-delete-with-toast";
 import { useEditRecord } from "@/hooks/use-edit-record";
@@ -485,10 +486,10 @@ export function BloodPressureCard() {
                   </SelectContent>
                 </Select>
               </div>
-              <label className="flex items-center gap-2 text-sm cursor-pointer">
-                <input type="checkbox" checked={editIrregularHeartbeat} onChange={(e) => setEditIrregularHeartbeat(e.target.checked)} className="rounded" />
-                Irregular heartbeat
-              </label>
+              <div className="flex items-center gap-2">
+                <Checkbox id="edit-irregular-heartbeat" checked={editIrregularHeartbeat} onCheckedChange={(checked) => setEditIrregularHeartbeat(checked === true)} />
+                <Label htmlFor="edit-irregular-heartbeat" className="text-sm cursor-pointer">Irregular heartbeat</Label>
+              </div>
             </InlineEditFormShell>
           )}
         />

--- a/src/components/blood-pressure-card.tsx
+++ b/src/components/blood-pressure-card.tsx
@@ -11,6 +11,13 @@ import { cn } from "@/lib/utils";
 import { CARD_THEMES } from "@/lib/card-themes";
 import { logAudit } from "@/lib/audit";
 
+function formatDelta(d: number) { return d > 0 ? `+${d}` : `${d}`; }
+function deltaColor(d: number) {
+  return d > 0 ? "text-red-500 dark:text-red-400"
+    : d < 0 ? "text-green-600 dark:text-green-400"
+    : "text-muted-foreground";
+}
+
 const BloodPressureFormSchema = z.object({
   systolic: z.number({ invalid_type_error: "Systolic is required" })
     .int("Must be a whole number").min(50, "Too low").max(300, "Too high"),
@@ -19,7 +26,8 @@ const BloodPressureFormSchema = z.object({
   heartRate: z.number().int("Must be a whole number").min(20, "Too low").max(250, "Too high").optional(),
 });
 import { CollapsibleTimeInputControlled } from "@/components/collapsible-time-input";
-import { RecentEntriesList } from "@/components/recent-entries-list";
+import { RecentEntriesList, InlineEditFormShell } from "@/components/recent-entries-list";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { useDeleteWithToast } from "@/hooks/use-delete-with-toast";
 import { useEditRecord } from "@/hooks/use-edit-record";
 import { useToast } from "@/hooks/use-toast";
@@ -172,6 +180,13 @@ export function BloodPressureCard() {
     }
   };
 
+  // BP delta vs previous reading
+  const prevReading = recentRecords?.[1];
+  const bpDelta = latestReading && prevReading ? {
+    sys: latestReading.systolic - prevReading.systolic,
+    dia: latestReading.diastolic - prevReading.diastolic,
+  } : null;
+
   return (
     <>
     <Card className={cn("relative overflow-hidden transition-all duration-300 bg-gradient-to-br", theme.gradient, theme.border)}>
@@ -202,26 +217,13 @@ export function BloodPressureCard() {
               {latestReading.heartRate && (
                 <p className="text-xs text-muted-foreground">{latestReading.heartRate} BPM</p>
               )}
-              {(() => {
-                const prev = recentRecords?.[1];
-                if (!prev) return null;
-                const sysDelta = latestReading.systolic - prev.systolic;
-                const diaDelta = latestReading.diastolic - prev.diastolic;
-                const fmt = (d: number) => (d > 0 ? `+${d}` : `${d}`);
-                const clr = (d: number) =>
-                  d > 0
-                    ? "text-red-500 dark:text-red-400"
-                    : d < 0
-                      ? "text-green-600 dark:text-green-400"
-                      : "text-muted-foreground";
-                return (
-                  <p className="text-xs">
-                    <span className={clr(sysDelta)}>{fmt(sysDelta)}</span>
-                    <span className="text-muted-foreground"> / </span>
-                    <span className={clr(diaDelta)}>{fmt(diaDelta)}</span>
-                  </p>
-                );
-              })()}
+              {bpDelta && (
+                <p className="text-xs">
+                  <span className={deltaColor(bpDelta.sys)}>{formatDelta(bpDelta.sys)}</span>
+                  <span className="text-muted-foreground"> / </span>
+                  <span className={deltaColor(bpDelta.dia)}>{formatDelta(bpDelta.dia)}</span>
+                </p>
+              )}
             </div>
           ) : null}
         </div>
@@ -461,29 +463,33 @@ export function BloodPressureCard() {
             );
           }}
           renderEditForm={() => (
-            <div className="space-y-2">
+            <InlineEditFormShell timestamp={editTimestamp} onTimestampChange={setEditTimestamp} note={editNote} onNoteChange={setEditNote} onSave={() => handleEditSubmit()} onCancel={closeEdit} buttonClassName={theme.buttonBg}>
               <div className="grid grid-cols-2 gap-2">
                 <Input type="number" placeholder="Systolic" value={editSystolic} onChange={(e) => setEditSystolic(e.target.value)} className="h-8 text-sm" />
                 <Input type="number" placeholder="Diastolic" value={editDiastolic} onChange={(e) => setEditDiastolic(e.target.value)} className="h-8 text-sm" />
               </div>
               <Input type="number" placeholder="Heart rate (optional)" value={editHeartRate} onChange={(e) => setEditHeartRate(e.target.value)} className="h-8 text-sm" />
               <div className="grid grid-cols-2 gap-2">
-                <select value={editPosition} onChange={(e) => setEditPosition(e.target.value as "sitting" | "standing")} className="h-8 text-sm rounded-md border bg-background px-2">
-                  <option value="sitting">Sitting</option>
-                  <option value="standing">Standing</option>
-                </select>
-                <select value={editArm} onChange={(e) => setEditArm(e.target.value as "left" | "right")} className="h-8 text-sm rounded-md border bg-background px-2">
-                  <option value="left">Left arm</option>
-                  <option value="right">Right arm</option>
-                </select>
+                <Select value={editPosition} onValueChange={(v) => setEditPosition(v as "sitting" | "standing")}>
+                  <SelectTrigger className="h-8 text-sm"><SelectValue /></SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="sitting">Sitting</SelectItem>
+                    <SelectItem value="standing">Standing</SelectItem>
+                  </SelectContent>
+                </Select>
+                <Select value={editArm} onValueChange={(v) => setEditArm(v as "left" | "right")}>
+                  <SelectTrigger className="h-8 text-sm"><SelectValue /></SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="left">Left arm</SelectItem>
+                    <SelectItem value="right">Right arm</SelectItem>
+                  </SelectContent>
+                </Select>
               </div>
-              <Input type="datetime-local" value={editTimestamp} onChange={(e) => setEditTimestamp(e.target.value)} className="h-8 text-sm" />
-              <Input placeholder="Note (optional)" value={editNote} onChange={(e) => setEditNote(e.target.value)} className="h-8 text-sm" />
-              <div className="flex gap-2">
-                <Button size="sm" className={cn("flex-1 h-8", theme.buttonBg)} onClick={handleEditSubmit}>Save</Button>
-                <Button size="sm" variant="outline" className="flex-1 h-8" onClick={closeEdit}>Cancel</Button>
-              </div>
-            </div>
+              <label className="flex items-center gap-2 text-sm cursor-pointer">
+                <input type="checkbox" checked={editIrregularHeartbeat} onChange={(e) => setEditIrregularHeartbeat(e.target.checked)} className="rounded" />
+                Irregular heartbeat
+              </label>
+            </InlineEditFormShell>
           )}
         />
       </CardContent>

--- a/src/components/blood-pressure-card.tsx
+++ b/src/components/blood-pressure-card.tsx
@@ -20,7 +20,6 @@ const BloodPressureFormSchema = z.object({
 });
 import { CollapsibleTimeInputControlled } from "@/components/collapsible-time-input";
 import { RecentEntriesList } from "@/components/recent-entries-list";
-import { EditBloodPressureDialog } from "@/components/edit-blood-pressure-dialog";
 import { useDeleteWithToast } from "@/hooks/use-delete-with-toast";
 import { useEditRecord } from "@/hooks/use-edit-record";
 import { useToast } from "@/hooks/use-toast";
@@ -436,6 +435,7 @@ export function BloodPressureCard() {
           deletingId={deletingId}
           onDelete={handleDelete}
           onEdit={openEdit}
+          editingId={editingRecord?.id ?? null}
           borderColor={theme.border}
           renderEntry={(record) => {
             const category = getBPCategory(record.systolic, record.diastolic);
@@ -460,31 +460,34 @@ export function BloodPressureCard() {
               </>
             );
           }}
+          renderEditForm={() => (
+            <div className="space-y-2">
+              <div className="grid grid-cols-2 gap-2">
+                <Input type="number" placeholder="Systolic" value={editSystolic} onChange={(e) => setEditSystolic(e.target.value)} className="h-8 text-sm" />
+                <Input type="number" placeholder="Diastolic" value={editDiastolic} onChange={(e) => setEditDiastolic(e.target.value)} className="h-8 text-sm" />
+              </div>
+              <Input type="number" placeholder="Heart rate (optional)" value={editHeartRate} onChange={(e) => setEditHeartRate(e.target.value)} className="h-8 text-sm" />
+              <div className="grid grid-cols-2 gap-2">
+                <select value={editPosition} onChange={(e) => setEditPosition(e.target.value as "sitting" | "standing")} className="h-8 text-sm rounded-md border bg-background px-2">
+                  <option value="sitting">Sitting</option>
+                  <option value="standing">Standing</option>
+                </select>
+                <select value={editArm} onChange={(e) => setEditArm(e.target.value as "left" | "right")} className="h-8 text-sm rounded-md border bg-background px-2">
+                  <option value="left">Left arm</option>
+                  <option value="right">Right arm</option>
+                </select>
+              </div>
+              <Input type="datetime-local" value={editTimestamp} onChange={(e) => setEditTimestamp(e.target.value)} className="h-8 text-sm" />
+              <Input placeholder="Note (optional)" value={editNote} onChange={(e) => setEditNote(e.target.value)} className="h-8 text-sm" />
+              <div className="flex gap-2">
+                <Button size="sm" className={cn("flex-1 h-8", theme.buttonBg)} onClick={handleEditSubmit}>Save</Button>
+                <Button size="sm" variant="outline" className="flex-1 h-8" onClick={closeEdit}>Cancel</Button>
+              </div>
+            </div>
+          )}
         />
       </CardContent>
     </Card>
-
-    <EditBloodPressureDialog
-      record={editingRecord}
-      onClose={closeEdit}
-      onSubmit={handleEditSubmit}
-      systolic={editSystolic}
-      onSystolicChange={setEditSystolic}
-      diastolic={editDiastolic}
-      onDiastolicChange={setEditDiastolic}
-      heartRate={editHeartRate}
-      onHeartRateChange={setEditHeartRate}
-      position={editPosition}
-      onPositionChange={setEditPosition}
-      arm={editArm}
-      onArmChange={setEditArm}
-      irregularHeartbeat={editIrregularHeartbeat}
-      onIrregularHeartbeatChange={setEditIrregularHeartbeat}
-      timestamp={editTimestamp}
-      onTimestampChange={setEditTimestamp}
-      note={editNote}
-      onNoteChange={setEditNote}
-    />
     </>
   );
 }

--- a/src/components/blood-pressure-card.tsx
+++ b/src/components/blood-pressure-card.tsx
@@ -200,6 +200,29 @@ export function BloodPressureCard() {
                   {bpCategory.label}
                 </p>
               )}
+              {latestReading.heartRate && (
+                <p className="text-xs text-muted-foreground">{latestReading.heartRate} BPM</p>
+              )}
+              {(() => {
+                const prev = recentRecords?.[1];
+                if (!prev) return null;
+                const sysDelta = latestReading.systolic - prev.systolic;
+                const diaDelta = latestReading.diastolic - prev.diastolic;
+                const fmt = (d: number) => (d > 0 ? `+${d}` : `${d}`);
+                const clr = (d: number) =>
+                  d > 0
+                    ? "text-red-500 dark:text-red-400"
+                    : d < 0
+                      ? "text-green-600 dark:text-green-400"
+                      : "text-muted-foreground";
+                return (
+                  <p className="text-xs">
+                    <span className={clr(sysDelta)}>{fmt(sysDelta)}</span>
+                    <span className="text-muted-foreground"> / </span>
+                    <span className={clr(diaDelta)}>{fmt(diaDelta)}</span>
+                  </p>
+                );
+              })()}
             </div>
           ) : null}
         </div>

--- a/src/components/defecation-card.tsx
+++ b/src/components/defecation-card.tsx
@@ -17,7 +17,6 @@ import { Loader2, ChevronDown, ChevronUp } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { CARD_THEMES } from "@/lib/card-themes";
 import { RecentEntriesList } from "@/components/recent-entries-list";
-import { EditDefecationDialog } from "@/components/edit-defecation-dialog";
 import { useDeleteWithToast } from "@/hooks/use-delete-with-toast";
 import { useEditRecord } from "@/hooks/use-edit-record";
 import { useToast } from "@/hooks/use-toast";
@@ -233,6 +232,7 @@ export function DefecationCard() {
             deletingId={deletingId}
             onDelete={handleDelete}
             onEdit={openEdit}
+            editingId={editingRecord?.id ?? null}
             borderColor={theme.border}
             renderEntry={(record) => (
               <div className="flex items-center gap-2 min-w-0">
@@ -247,21 +247,30 @@ export function DefecationCard() {
                 )}
               </div>
             )}
+            renderEditForm={() => (
+              <div className="space-y-2">
+                <Select value={editAmountEstimate} onValueChange={setEditAmountEstimate}>
+                  <SelectTrigger className="h-8 text-sm">
+                    <SelectValue placeholder="Amount estimate" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="__none__">No estimate</SelectItem>
+                    {AMOUNT_OPTIONS.map((opt) => (
+                      <SelectItem key={opt.value} value={opt.value}>{opt.label}</SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+                <Input type="datetime-local" value={editTimestamp} onChange={(e) => setEditTimestamp(e.target.value)} className="h-8 text-sm" />
+                <Input placeholder="Note (optional)" value={editNote} onChange={(e) => setEditNote(e.target.value)} className="h-8 text-sm" />
+                <div className="flex gap-2">
+                  <Button size="sm" className={cn("flex-1 h-8", theme.buttonBg)} onClick={handleEditSubmit}>Save</Button>
+                  <Button size="sm" variant="outline" className="flex-1 h-8" onClick={closeEdit}>Cancel</Button>
+                </div>
+              </div>
+            )}
           />
         </CardContent>
       </Card>
-
-      <EditDefecationDialog
-        record={editingRecord}
-        onClose={closeEdit}
-        onSubmit={handleEditSubmit}
-        timestamp={editTimestamp}
-        onTimestampChange={setEditTimestamp}
-        amount={editAmountEstimate}
-        onAmountChange={setEditAmountEstimate}
-        note={editNote}
-        onNoteChange={setEditNote}
-      />
     </>
   );
 }

--- a/src/components/defecation-card.tsx
+++ b/src/components/defecation-card.tsx
@@ -16,7 +16,7 @@ import {
 import { Loader2, ChevronDown, ChevronUp } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { CARD_THEMES } from "@/lib/card-themes";
-import { RecentEntriesList } from "@/components/recent-entries-list";
+import { RecentEntriesList, InlineEditFormShell } from "@/components/recent-entries-list";
 import { useDeleteWithToast } from "@/hooks/use-delete-with-toast";
 import { useEditRecord } from "@/hooks/use-edit-record";
 import { useToast } from "@/hooks/use-toast";
@@ -248,7 +248,7 @@ export function DefecationCard() {
               </div>
             )}
             renderEditForm={() => (
-              <div className="space-y-2">
+              <InlineEditFormShell timestamp={editTimestamp} onTimestampChange={setEditTimestamp} note={editNote} onNoteChange={setEditNote} onSave={() => handleEditSubmit()} onCancel={closeEdit} buttonClassName={theme.buttonBg}>
                 <Select value={editAmountEstimate} onValueChange={setEditAmountEstimate}>
                   <SelectTrigger className="h-8 text-sm">
                     <SelectValue placeholder="Amount estimate" />
@@ -260,13 +260,7 @@ export function DefecationCard() {
                     ))}
                   </SelectContent>
                 </Select>
-                <Input type="datetime-local" value={editTimestamp} onChange={(e) => setEditTimestamp(e.target.value)} className="h-8 text-sm" />
-                <Input placeholder="Note (optional)" value={editNote} onChange={(e) => setEditNote(e.target.value)} className="h-8 text-sm" />
-                <div className="flex gap-2">
-                  <Button size="sm" className={cn("flex-1 h-8", theme.buttonBg)} onClick={handleEditSubmit}>Save</Button>
-                  <Button size="sm" variant="outline" className="flex-1 h-8" onClick={closeEdit}>Cancel</Button>
-                </div>
-              </div>
+              </InlineEditFormShell>
             )}
           />
         </CardContent>

--- a/src/components/food-salt/food-section.tsx
+++ b/src/components/food-salt/food-section.tsx
@@ -139,7 +139,8 @@ export function FoodSection() {
       // Populate form fields from AI result
       if (result.salt && result.salt > 0) {
         setSodiumMg(result.salt.toString());
-        setSodiumSource("sodium"); // AI returns sodium mg directly
+        // Auto-select sodium source based on what the AI reported
+        setSodiumSource(result.measurementType === "salt" ? "salt" : "sodium");
       }
       if (result.water && result.water > 0) {
         setWaterMl(result.water.toString());

--- a/src/components/food-salt/food-section.tsx
+++ b/src/components/food-salt/food-section.tsx
@@ -14,7 +14,7 @@ import {
 import { Loader2, Sparkles } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { CARD_THEMES } from "@/lib/card-themes";
-import { RecentEntriesList } from "@/components/recent-entries-list";
+import { RecentEntriesList, InlineEditFormShell } from "@/components/recent-entries-list";
 import { parseIntakeWithAI } from "@/lib/ai-client";
 import {
   useAddComposableEntry,
@@ -402,15 +402,9 @@ export function FoodSection() {
           </div>
         )}
         renderEditForm={() => (
-          <div className="space-y-2">
-            <Input type="datetime-local" value={editTimestamp} onChange={(e) => setEditTimestamp(e.target.value)} className="h-8 text-sm" />
-            <Input placeholder="Note (optional)" value={editNote} onChange={(e) => setEditNote(e.target.value)} className="h-8 text-sm" />
+          <InlineEditFormShell timestamp={editTimestamp} onTimestampChange={setEditTimestamp} note={editNote} onNoteChange={setEditNote} onSave={() => handleEditSubmit()} onCancel={closeEdit} buttonClassName={theme.buttonBg}>
             <Input type="number" placeholder="Grams (optional)" value={editGrams} onChange={(e) => setEditGrams(e.target.value)} className="h-8 text-sm" />
-            <div className="flex gap-2">
-              <Button size="sm" className={cn("flex-1 h-8", theme.buttonBg)} onClick={handleEditSubmit}>Save</Button>
-              <Button size="sm" variant="outline" className="flex-1 h-8" onClick={closeEdit}>Cancel</Button>
-            </div>
-          </div>
+          </InlineEditFormShell>
         )}
       />
     </>

--- a/src/components/food-salt/food-section.tsx
+++ b/src/components/food-salt/food-section.tsx
@@ -15,7 +15,6 @@ import { Loader2, Sparkles } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { CARD_THEMES } from "@/lib/card-themes";
 import { RecentEntriesList } from "@/components/recent-entries-list";
-import { EditEatingDialog } from "@/components/edit-eating-dialog";
 import { parseIntakeWithAI } from "@/lib/ai-client";
 import {
   useAddComposableEntry,
@@ -380,6 +379,7 @@ export function FoodSection() {
         deletingId={deletingId}
         onDelete={handleDelete}
         onEdit={openEdit}
+        editingId={editingRecord?.id ?? null}
         borderColor={theme.border}
         renderEntry={(record) => (
           <div className="flex items-center gap-2 min-w-0">
@@ -401,18 +401,17 @@ export function FoodSection() {
             )}
           </div>
         )}
-      />
-
-      <EditEatingDialog
-        record={editingRecord}
-        onClose={closeEdit}
-        onSubmit={handleEditSubmit}
-        timestamp={editTimestamp}
-        onTimestampChange={setEditTimestamp}
-        note={editNote}
-        onNoteChange={setEditNote}
-        grams={editGrams}
-        onGramsChange={setEditGrams}
+        renderEditForm={() => (
+          <div className="space-y-2">
+            <Input type="datetime-local" value={editTimestamp} onChange={(e) => setEditTimestamp(e.target.value)} className="h-8 text-sm" />
+            <Input placeholder="Note (optional)" value={editNote} onChange={(e) => setEditNote(e.target.value)} className="h-8 text-sm" />
+            <Input type="number" placeholder="Grams (optional)" value={editGrams} onChange={(e) => setEditGrams(e.target.value)} className="h-8 text-sm" />
+            <div className="flex gap-2">
+              <Button size="sm" className={cn("flex-1 h-8", theme.buttonBg)} onClick={handleEditSubmit}>Save</Button>
+              <Button size="sm" variant="outline" className="flex-1 h-8" onClick={closeEdit}>Cancel</Button>
+            </div>
+          </div>
+        )}
       />
     </>
   );

--- a/src/components/liquids-card.tsx
+++ b/src/components/liquids-card.tsx
@@ -3,13 +3,14 @@
 import { useState } from "react";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Card, CardContent } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
 import { CARD_THEMES } from "@/lib/card-themes";
 import { Droplets, Coffee, Wine } from "lucide-react";
 import { WaterTab } from "@/components/liquids/water-tab";
 import { BeverageTab } from "@/components/liquids/beverage-tab";
 import { PresetTab } from "@/components/liquids/preset-tab";
 import { RecentEntriesList } from "@/components/recent-entries-list";
-import { EditIntakeDialog } from "@/components/edit-intake-dialog";
 import {
   useIntake,
   useRecentIntakeRecords,
@@ -187,6 +188,7 @@ export function LiquidsCard() {
           deletingId={deletingId}
           onDelete={handleDelete}
           onEdit={openEdit}
+          editingId={editingRecord?.id ?? null}
           borderColor={CARD_THEMES.water.border}
           renderEntry={(record) => {
             const sourceLabel = getLiquidTypeLabel(record.source, { presets: settings.liquidPresets, note: record.note });
@@ -208,18 +210,17 @@ export function LiquidsCard() {
               </>
             );
           }}
-        />
-
-        <EditIntakeDialog
-          record={editingRecord}
-          onClose={closeEdit}
-          onSubmit={handleEditSubmit}
-          amount={editAmount}
-          onAmountChange={setEditAmount}
-          timestamp={editTimestamp}
-          onTimestampChange={setEditTimestamp}
-          note={editNote}
-          onNoteChange={setEditNote}
+          renderEditForm={() => (
+            <div className="space-y-2">
+              <Input type="number" placeholder="Amount (ml)" value={editAmount} onChange={(e) => setEditAmount(e.target.value)} className="h-8 text-sm" />
+              <Input type="datetime-local" value={editTimestamp} onChange={(e) => setEditTimestamp(e.target.value)} className="h-8 text-sm" />
+              <Input placeholder="Note (optional)" value={editNote} onChange={(e) => setEditNote(e.target.value)} className="h-8 text-sm" />
+              <div className="flex gap-2">
+                <Button size="sm" className={cn("flex-1 h-8", CARD_THEMES.water.buttonBg)} onClick={handleEditSubmit}>Save</Button>
+                <Button size="sm" variant="outline" className="flex-1 h-8" onClick={closeEdit}>Cancel</Button>
+              </div>
+            </div>
+          )}
         />
       </CardContent>
     </Card>

--- a/src/components/liquids-card.tsx
+++ b/src/components/liquids-card.tsx
@@ -10,7 +10,7 @@ import { Droplets, Coffee, Wine } from "lucide-react";
 import { WaterTab } from "@/components/liquids/water-tab";
 import { BeverageTab } from "@/components/liquids/beverage-tab";
 import { PresetTab } from "@/components/liquids/preset-tab";
-import { RecentEntriesList } from "@/components/recent-entries-list";
+import { RecentEntriesList, InlineEditFormShell } from "@/components/recent-entries-list";
 import {
   useIntake,
   useRecentIntakeRecords,
@@ -211,15 +211,9 @@ export function LiquidsCard() {
             );
           }}
           renderEditForm={() => (
-            <div className="space-y-2">
+            <InlineEditFormShell timestamp={editTimestamp} onTimestampChange={setEditTimestamp} note={editNote} onNoteChange={setEditNote} onSave={() => handleEditSubmit()} onCancel={closeEdit} buttonClassName={CARD_THEMES.water.buttonBg}>
               <Input type="number" placeholder="Amount (ml)" value={editAmount} onChange={(e) => setEditAmount(e.target.value)} className="h-8 text-sm" />
-              <Input type="datetime-local" value={editTimestamp} onChange={(e) => setEditTimestamp(e.target.value)} className="h-8 text-sm" />
-              <Input placeholder="Note (optional)" value={editNote} onChange={(e) => setEditNote(e.target.value)} className="h-8 text-sm" />
-              <div className="flex gap-2">
-                <Button size="sm" className={cn("flex-1 h-8", CARD_THEMES.water.buttonBg)} onClick={handleEditSubmit}>Save</Button>
-                <Button size="sm" variant="outline" className="flex-1 h-8" onClick={closeEdit}>Cancel</Button>
-              </div>
-            </div>
+            </InlineEditFormShell>
           )}
         />
       </CardContent>

--- a/src/components/liquids/water-tab.tsx
+++ b/src/components/liquids/water-tab.tsx
@@ -105,6 +105,24 @@ export function WaterTab() {
         />
       </div>
 
+      {/* Quick-set size buttons */}
+      <div className="flex gap-2 mb-3">
+        {[70, 100, 150, 200].map((size) => (
+          <Button
+            key={size}
+            variant="outline"
+            size="sm"
+            onClick={() => setPendingAmount(size)}
+            className={cn(
+              "flex-1",
+              pendingAmount === size && theme.activeToggle
+            )}
+          >
+            {size}
+          </Button>
+        ))}
+      </div>
+
       {/* Input Controls */}
       <div className="flex items-center justify-between gap-3">
         {/* Decrement Button */}

--- a/src/components/recent-entries-list.tsx
+++ b/src/components/recent-entries-list.tsx
@@ -15,6 +15,10 @@ interface RecentEntriesListProps<T extends { id: string }> {
   maxEntries?: number;
   /** If provided, clicking an entry row opens the edit form for that record */
   onEdit?: (record: T) => void;
+  /** ID of the record currently being edited inline */
+  editingId?: string | null;
+  /** Render an inline edit form for the given record */
+  renderEditForm?: (record: T) => ReactNode;
 }
 
 /**
@@ -30,6 +34,8 @@ export function RecentEntriesList<T extends { id: string }>({
   borderColor,
   maxEntries = 3,
   onEdit,
+  editingId,
+  renderEditForm,
 }: RecentEntriesListProps<T>) {
   if (!records || records.length === 0) return null;
 
@@ -39,49 +45,62 @@ export function RecentEntriesList<T extends { id: string }>({
     <div className={cn("mt-4 pt-4 border-t", borderColor)}>
       <p className="text-xs font-medium text-muted-foreground mb-2">Recent</p>
       <div className="space-y-1">
-        {displayRecords.map((record) => (
-          <div
-            key={record.id}
-            className={cn(
-              "flex items-center justify-between text-sm py-1",
-              onEdit && "cursor-pointer rounded-md -mx-1.5 px-1.5 transition-colors hover:bg-black/5 dark:hover:bg-white/5 active:bg-black/10 dark:active:bg-white/10"
-            )}
-            onClick={onEdit ? () => onEdit(record) : undefined}
-            role={onEdit ? "button" : undefined}
-            tabIndex={onEdit ? 0 : undefined}
-            onKeyDown={
-              onEdit
-                ? (e) => {
-                    if (e.key === "Enter" || e.key === " ") {
-                      e.preventDefault();
-                      onEdit(record);
-                    }
-                  }
-                : undefined
-            }
-          >
-            <div className="flex items-center justify-between min-w-0 flex-1 gap-2">
-              {renderEntry(record)}
-            </div>
-            <Button
-              variant="ghost"
-              size="icon"
-              aria-label="Delete entry"
-              className="h-6 w-6 text-muted-foreground hover:text-red-600 shrink-0"
-              onClick={(e) => {
-                e.stopPropagation();
-                onDelete(record.id);
-              }}
-              disabled={deletingId === record.id}
-            >
-              {deletingId === record.id ? (
-                <Loader2 className="w-3 h-3 animate-spin" />
-              ) : (
-                <Trash2 className="w-3 h-3" />
+        {displayRecords.map((record) => {
+          const isEditing = editingId === record.id && renderEditForm;
+          if (isEditing) {
+            return (
+              <div
+                key={record.id}
+                className="bg-muted/30 rounded-lg p-2 -mx-1.5"
+              >
+                {renderEditForm(record)}
+              </div>
+            );
+          }
+          return (
+            <div
+              key={record.id}
+              className={cn(
+                "flex items-center justify-between text-sm py-1",
+                onEdit && "cursor-pointer rounded-md -mx-1.5 px-1.5 transition-colors hover:bg-black/5 dark:hover:bg-white/5 active:bg-black/10 dark:active:bg-white/10"
               )}
-            </Button>
-          </div>
-        ))}
+              onClick={onEdit ? () => onEdit(record) : undefined}
+              role={onEdit ? "button" : undefined}
+              tabIndex={onEdit ? 0 : undefined}
+              onKeyDown={
+                onEdit
+                  ? (e) => {
+                      if (e.key === "Enter" || e.key === " ") {
+                        e.preventDefault();
+                        onEdit(record);
+                      }
+                    }
+                  : undefined
+              }
+            >
+              <div className="flex items-center justify-between min-w-0 flex-1 gap-2">
+                {renderEntry(record)}
+              </div>
+              <Button
+                variant="ghost"
+                size="icon"
+                aria-label="Delete entry"
+                className="h-6 w-6 text-muted-foreground hover:text-red-600 shrink-0"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  onDelete(record.id);
+                }}
+                disabled={deletingId === record.id}
+              >
+                {deletingId === record.id ? (
+                  <Loader2 className="w-3 h-3 animate-spin" />
+                ) : (
+                  <Trash2 className="w-3 h-3" />
+                )}
+              </Button>
+            </div>
+          );
+        })}
       </div>
     </div>
   );

--- a/src/components/recent-entries-list.tsx
+++ b/src/components/recent-entries-list.tsx
@@ -2,8 +2,45 @@
 
 import { ReactNode } from "react";
 import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
 import { Loader2, Trash2 } from "lucide-react";
 import { cn } from "@/lib/utils";
+
+/**
+ * Shared shell for inline edit forms used by card components.
+ * Renders domain-specific children, then timestamp, note, and Save/Cancel.
+ */
+export function InlineEditFormShell({
+  children,
+  timestamp,
+  onTimestampChange,
+  note,
+  onNoteChange,
+  onSave,
+  onCancel,
+  buttonClassName,
+}: {
+  children?: ReactNode;
+  timestamp: string;
+  onTimestampChange: (value: string) => void;
+  note: string;
+  onNoteChange: (value: string) => void;
+  onSave: () => void;
+  onCancel: () => void;
+  buttonClassName?: string;
+}) {
+  return (
+    <div className="space-y-2">
+      {children}
+      <Input type="datetime-local" value={timestamp} onChange={(e) => onTimestampChange(e.target.value)} className="h-8 text-sm" />
+      <Input placeholder="Note (optional)" value={note} onChange={(e) => onNoteChange(e.target.value)} className="h-8 text-sm" />
+      <div className="flex gap-2">
+        <Button size="sm" className={cn("flex-1 h-8", buttonClassName)} onClick={onSave}>Save</Button>
+        <Button size="sm" variant="outline" className="flex-1 h-8" onClick={onCancel}>Cancel</Button>
+      </div>
+    </div>
+  );
+}
 
 interface RecentEntriesListProps<T extends { id: string }> {
   records: T[] | undefined;
@@ -17,8 +54,8 @@ interface RecentEntriesListProps<T extends { id: string }> {
   onEdit?: (record: T) => void;
   /** ID of the record currently being edited inline */
   editingId?: string | null;
-  /** Render an inline edit form for the given record */
-  renderEditForm?: (record: T) => ReactNode;
+  /** Render an inline edit form (record available via parent closure) */
+  renderEditForm?: () => ReactNode;
 }
 
 /**
@@ -53,7 +90,7 @@ export function RecentEntriesList<T extends { id: string }>({
                 key={record.id}
                 className="bg-muted/30 rounded-lg p-2 -mx-1.5"
               >
-                {renderEditForm(record)}
+                {renderEditForm()}
               </div>
             );
           }

--- a/src/components/recent-entries-list.tsx
+++ b/src/components/recent-entries-list.tsx
@@ -32,8 +32,8 @@ export function InlineEditFormShell({
   return (
     <div className="space-y-2">
       {children}
-      <Input type="datetime-local" value={timestamp} onChange={(e) => onTimestampChange(e.target.value)} className="h-8 text-sm" />
-      <Input placeholder="Note (optional)" value={note} onChange={(e) => onNoteChange(e.target.value)} className="h-8 text-sm" />
+      <Input aria-label="Entry date and time" type="datetime-local" value={timestamp} onChange={(e) => onTimestampChange(e.target.value)} className="h-8 text-sm" />
+      <Input aria-label="Entry note" placeholder="Note (optional)" value={note} onChange={(e) => onNoteChange(e.target.value)} className="h-8 text-sm" />
       <div className="flex gap-2">
         <Button size="sm" className={cn("flex-1 h-8", buttonClassName)} onClick={onSave}>Save</Button>
         <Button size="sm" variant="outline" className="flex-1 h-8" onClick={onCancel}>Cancel</Button>
@@ -107,6 +107,7 @@ export function RecentEntriesList<T extends { id: string }>({
               onKeyDown={
                 onEdit
                   ? (e) => {
+                      if (e.target !== e.currentTarget) return;
                       if (e.key === "Enter" || e.key === " ") {
                         e.preventDefault();
                         onEdit(record);

--- a/src/components/text-metrics.tsx
+++ b/src/components/text-metrics.tsx
@@ -131,6 +131,17 @@ export function TextMetrics() {
     "salt"
   );
 
+  const weeklyCaffeineRecords = useSubstanceRecordsByDateRange(
+    weekStart,
+    weekEnd,
+    "caffeine"
+  );
+  const weeklyAlcoholRecords = useSubstanceRecordsByDateRange(
+    weekStart,
+    weekEnd,
+    "alcohol"
+  );
+
   // Bucket records into 7 days
   const weeklyWater = useMemo(() => {
     const buckets: number[] = [0, 0, 0, 0, 0, 0, 0];
@@ -157,6 +168,32 @@ export function TextMetrics() {
     }
     return buckets;
   }, [weeklySaltRecords, weekStart]);
+
+  const weeklyCaffeine = useMemo(() => {
+    const buckets: number[] = [0, 0, 0, 0, 0, 0, 0];
+    for (const record of weeklyCaffeineRecords) {
+      const dayOffset = Math.floor(
+        (record.timestamp - weekStart) / ONE_DAY_MS
+      );
+      if (dayOffset >= 0 && dayOffset < 7) {
+        buckets[dayOffset] = (buckets[dayOffset] ?? 0) + (record.amountMg ?? 0);
+      }
+    }
+    return buckets;
+  }, [weeklyCaffeineRecords, weekStart]);
+
+  const weeklyAlcohol = useMemo(() => {
+    const buckets: number[] = [0, 0, 0, 0, 0, 0, 0];
+    for (const record of weeklyAlcoholRecords) {
+      const dayOffset = Math.floor(
+        (record.timestamp - weekStart) / ONE_DAY_MS
+      );
+      if (dayOffset >= 0 && dayOffset < 7) {
+        buckets[dayOffset] = (buckets[dayOffset] ?? 0) + (record.amountStandardDrinks ?? 0);
+      }
+    }
+    return buckets;
+  }, [weeklyAlcoholRecords, weekStart]);
 
   // Over limit checks
   const waterOverLimit = waterLimit > 0 && waterTotal > waterLimit;
@@ -348,6 +385,50 @@ export function TextMetrics() {
                 )}
               >
                 {isFuture ? "---" : formatValue(val)}
+              </div>
+            );
+          })}
+
+          {/* Caffeine row */}
+          <div className="text-xs text-muted-foreground">Caf</div>
+          {weeklyCaffeine.map((val, i) => {
+            const isFuture = i > todayIndex;
+            const isToday = i === todayIndex;
+            const hasData = val > 0;
+            return (
+              <div
+                key={`caf-${i}`}
+                className={cn(
+                  "text-xs tabular-nums text-center",
+                  isFuture && "text-muted-foreground/50",
+                  isToday && "font-semibold",
+                  !isFuture && hasData && CARD_THEMES.caffeine.latestValueColor,
+                  !isFuture && !hasData && "text-muted-foreground/50"
+                )}
+              >
+                {isFuture ? "---" : formatValue(Math.round(val))}
+              </div>
+            );
+          })}
+
+          {/* Alcohol row */}
+          <div className="text-xs text-muted-foreground">Alc</div>
+          {weeklyAlcohol.map((val, i) => {
+            const isFuture = i > todayIndex;
+            const isToday = i === todayIndex;
+            const hasData = val > 0;
+            return (
+              <div
+                key={`alc-${i}`}
+                className={cn(
+                  "text-xs tabular-nums text-center",
+                  isFuture && "text-muted-foreground/50",
+                  isToday && "font-semibold",
+                  !isFuture && hasData && CARD_THEMES.alcohol.latestValueColor,
+                  !isFuture && !hasData && "text-muted-foreground/50"
+                )}
+              >
+                {isFuture ? "---" : val.toFixed(1)}
               </div>
             );
           })}

--- a/src/components/text-metrics.tsx
+++ b/src/components/text-metrics.tsx
@@ -56,6 +56,17 @@ function formatValue(value: number): string {
 const DAY_HEADERS = ["M", "T", "W", "T", "F", "S", "S"] as const;
 const ONE_DAY_MS = 24 * 60 * 60 * 1000;
 
+function bucketByDay<T extends { timestamp: number }>(
+  records: T[], weekStart: number, accessor: (r: T) => number
+): number[] {
+  const buckets = [0, 0, 0, 0, 0, 0, 0];
+  for (const r of records) {
+    const i = Math.floor((r.timestamp - weekStart) / ONE_DAY_MS);
+    if (i >= 0 && i < 7) buckets[i] = (buckets[i] ?? 0) + accessor(r);
+  }
+  return buckets;
+}
+
 export function TextMetrics() {
   const dayStartHour = useSettingsStore((s) => s.dayStartHour);
   const waterLimit = useSettingsStore((s) => s.waterLimit);
@@ -78,7 +89,8 @@ export function TextMetrics() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
     [dayStartHour, tick]
   );
-  const now = Date.now();
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  const now = useMemo(() => Date.now(), [tick]);
 
   // Today's substance totals
   const caffeineRecords = useSubstanceRecordsByDateRange(
@@ -97,14 +109,8 @@ export function TextMetrics() {
     [caffeineRecords]
   );
   const alcoholTotal = useMemo(
-    () =>
-      caffeineRecords.length >= 0
-        ? alcoholRecords.reduce(
-            (sum, r) => sum + (r.amountStandardDrinks ?? 0),
-            0
-          )
-        : 0,
-    [alcoholRecords, caffeineRecords.length]
+    () => alcoholRecords.reduce((sum, r) => sum + (r.amountStandardDrinks ?? 0), 0),
+    [alcoholRecords]
   );
 
   // Weekly data
@@ -143,57 +149,10 @@ export function TextMetrics() {
   );
 
   // Bucket records into 7 days
-  const weeklyWater = useMemo(() => {
-    const buckets: number[] = [0, 0, 0, 0, 0, 0, 0];
-    for (const record of weeklyWaterRecords) {
-      const dayOffset = Math.floor(
-        (record.timestamp - weekStart) / ONE_DAY_MS
-      );
-      if (dayOffset >= 0 && dayOffset < 7) {
-        buckets[dayOffset] = (buckets[dayOffset] ?? 0) + record.amount;
-      }
-    }
-    return buckets;
-  }, [weeklyWaterRecords, weekStart]);
-
-  const weeklySalt = useMemo(() => {
-    const buckets: number[] = [0, 0, 0, 0, 0, 0, 0];
-    for (const record of weeklySaltRecords) {
-      const dayOffset = Math.floor(
-        (record.timestamp - weekStart) / ONE_DAY_MS
-      );
-      if (dayOffset >= 0 && dayOffset < 7) {
-        buckets[dayOffset] = (buckets[dayOffset] ?? 0) + record.amount;
-      }
-    }
-    return buckets;
-  }, [weeklySaltRecords, weekStart]);
-
-  const weeklyCaffeine = useMemo(() => {
-    const buckets: number[] = [0, 0, 0, 0, 0, 0, 0];
-    for (const record of weeklyCaffeineRecords) {
-      const dayOffset = Math.floor(
-        (record.timestamp - weekStart) / ONE_DAY_MS
-      );
-      if (dayOffset >= 0 && dayOffset < 7) {
-        buckets[dayOffset] = (buckets[dayOffset] ?? 0) + (record.amountMg ?? 0);
-      }
-    }
-    return buckets;
-  }, [weeklyCaffeineRecords, weekStart]);
-
-  const weeklyAlcohol = useMemo(() => {
-    const buckets: number[] = [0, 0, 0, 0, 0, 0, 0];
-    for (const record of weeklyAlcoholRecords) {
-      const dayOffset = Math.floor(
-        (record.timestamp - weekStart) / ONE_DAY_MS
-      );
-      if (dayOffset >= 0 && dayOffset < 7) {
-        buckets[dayOffset] = (buckets[dayOffset] ?? 0) + (record.amountStandardDrinks ?? 0);
-      }
-    }
-    return buckets;
-  }, [weeklyAlcoholRecords, weekStart]);
+  const weeklyWater = useMemo(() => bucketByDay(weeklyWaterRecords, weekStart, (r) => r.amount), [weeklyWaterRecords, weekStart]);
+  const weeklySalt = useMemo(() => bucketByDay(weeklySaltRecords, weekStart, (r) => r.amount), [weeklySaltRecords, weekStart]);
+  const weeklyCaffeine = useMemo(() => bucketByDay(weeklyCaffeineRecords, weekStart, (r) => r.amountMg ?? 0), [weeklyCaffeineRecords, weekStart]);
+  const weeklyAlcohol = useMemo(() => bucketByDay(weeklyAlcoholRecords, weekStart, (r) => r.amountStandardDrinks ?? 0), [weeklyAlcoholRecords, weekStart]);
 
   // Over limit checks
   const waterOverLimit = waterLimit > 0 && waterTotal > waterLimit;
@@ -335,103 +294,37 @@ export function TextMetrics() {
             </div>
           ))}
 
-          {/* Water row */}
-          <div className="text-xs text-muted-foreground">Water</div>
-          {weeklyWater.map((val, i) => {
-            const isFuture = i > todayIndex;
-            const isToday = i === todayIndex;
-            const isOverLimit = waterLimit > 0 && val > waterLimit;
-            const hasData = val > 0;
-            return (
-              <div
-                key={`water-${i}`}
-                className={cn(
-                  "text-xs tabular-nums text-center",
-                  isFuture && "text-muted-foreground/50",
-                  isToday && "font-semibold",
-                  !isFuture &&
-                    !isOverLimit &&
-                    hasData &&
-                    CARD_THEMES.water.latestValueColor,
-                  !isFuture && isOverLimit && "text-red-600 dark:text-red-400",
-                  !isFuture && !hasData && "text-muted-foreground/50"
-                )}
-              >
-                {isFuture ? "---" : formatValue(val)}
-              </div>
-            );
-          })}
-
-          {/* Sodium row */}
-          <div className="text-xs text-muted-foreground">Na</div>
-          {weeklySalt.map((val, i) => {
-            const isFuture = i > todayIndex;
-            const isToday = i === todayIndex;
-            const isOverLimit = saltLimit > 0 && val > saltLimit;
-            const hasData = val > 0;
-            return (
-              <div
-                key={`salt-${i}`}
-                className={cn(
-                  "text-xs tabular-nums text-center",
-                  isFuture && "text-muted-foreground/50",
-                  isToday && "font-semibold",
-                  !isFuture &&
-                    !isOverLimit &&
-                    hasData &&
-                    CARD_THEMES.salt.latestValueColor,
-                  !isFuture && isOverLimit && "text-red-600 dark:text-red-400",
-                  !isFuture && !hasData && "text-muted-foreground/50"
-                )}
-              >
-                {isFuture ? "---" : formatValue(val)}
-              </div>
-            );
-          })}
-
-          {/* Caffeine row */}
-          <div className="text-xs text-muted-foreground">Caf</div>
-          {weeklyCaffeine.map((val, i) => {
-            const isFuture = i > todayIndex;
-            const isToday = i === todayIndex;
-            const hasData = val > 0;
-            return (
-              <div
-                key={`caf-${i}`}
-                className={cn(
-                  "text-xs tabular-nums text-center",
-                  isFuture && "text-muted-foreground/50",
-                  isToday && "font-semibold",
-                  !isFuture && hasData && CARD_THEMES.caffeine.latestValueColor,
-                  !isFuture && !hasData && "text-muted-foreground/50"
-                )}
-              >
-                {isFuture ? "---" : formatValue(Math.round(val))}
-              </div>
-            );
-          })}
-
-          {/* Alcohol row */}
-          <div className="text-xs text-muted-foreground">Alc</div>
-          {weeklyAlcohol.map((val, i) => {
-            const isFuture = i > todayIndex;
-            const isToday = i === todayIndex;
-            const hasData = val > 0;
-            return (
-              <div
-                key={`alc-${i}`}
-                className={cn(
-                  "text-xs tabular-nums text-center",
-                  isFuture && "text-muted-foreground/50",
-                  isToday && "font-semibold",
-                  !isFuture && hasData && CARD_THEMES.alcohol.latestValueColor,
-                  !isFuture && !hasData && "text-muted-foreground/50"
-                )}
-              >
-                {isFuture ? "---" : val.toFixed(1)}
-              </div>
-            );
-          })}
+          {[
+            { key: "water", label: "Water", data: weeklyWater, theme: CARD_THEMES.water, limit: waterLimit, fmt: formatValue },
+            { key: "salt", label: "Na", data: weeklySalt, theme: CARD_THEMES.salt, limit: saltLimit, fmt: formatValue },
+            { key: "caf", label: "Caf", data: weeklyCaffeine, theme: CARD_THEMES.caffeine, limit: 0, fmt: (v: number) => formatValue(Math.round(v)) },
+            { key: "alc", label: "Alc", data: weeklyAlcohol, theme: CARD_THEMES.alcohol, limit: 0, fmt: (v: number) => v.toFixed(1) },
+          ].map((row) => (
+            <>{/* {row.label} row */}
+              <div key={`${row.key}-label`} className="text-xs text-muted-foreground">{row.label}</div>
+              {row.data.map((val, i) => {
+                const isFuture = i > todayIndex;
+                const isToday = i === todayIndex;
+                const isOverLimit = row.limit > 0 && val > row.limit;
+                const hasData = val > 0;
+                return (
+                  <div
+                    key={`${row.key}-${i}`}
+                    className={cn(
+                      "text-xs tabular-nums text-center",
+                      isFuture && "text-muted-foreground/50",
+                      isToday && "font-semibold",
+                      !isFuture && !isOverLimit && hasData && row.theme.latestValueColor,
+                      !isFuture && isOverLimit && "text-red-600 dark:text-red-400",
+                      !isFuture && !hasData && "text-muted-foreground/50"
+                    )}
+                  >
+                    {isFuture ? "---" : row.fmt(val)}
+                  </div>
+                );
+              })}
+            </>
+          ))}
         </div>
       </div>
     </section>

--- a/src/components/text-metrics.tsx
+++ b/src/components/text-metrics.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect, useMemo } from "react";
+import { Fragment, useState, useEffect, useMemo } from "react";
 import {
   useDailyIntakeTotal,
   getDayStartTimestamp,
@@ -300,8 +300,8 @@ export function TextMetrics() {
             { key: "caf", label: "Caf", data: weeklyCaffeine, theme: CARD_THEMES.caffeine, limit: 0, fmt: (v: number) => formatValue(Math.round(v)) },
             { key: "alc", label: "Alc", data: weeklyAlcohol, theme: CARD_THEMES.alcohol, limit: 0, fmt: (v: number) => v.toFixed(1) },
           ].map((row) => (
-            <>{/* {row.label} row */}
-              <div key={`${row.key}-label`} className="text-xs text-muted-foreground">{row.label}</div>
+            <Fragment key={row.key}>
+              <div className="text-xs text-muted-foreground">{row.label}</div>
               {row.data.map((val, i) => {
                 const isFuture = i > todayIndex;
                 const isToday = i === todayIndex;
@@ -323,7 +323,7 @@ export function TextMetrics() {
                   </div>
                 );
               })}
-            </>
+            </Fragment>
           ))}
         </div>
       </div>

--- a/src/components/ui/checkbox.tsx
+++ b/src/components/ui/checkbox.tsx
@@ -1,0 +1,30 @@
+"use client"
+
+import * as React from "react"
+import * as CheckboxPrimitive from "@radix-ui/react-checkbox"
+import { Check } from "lucide-react"
+
+import { cn } from "@/lib/utils"
+
+const Checkbox = React.forwardRef<
+  React.ElementRef<typeof CheckboxPrimitive.Root>,
+  React.ComponentPropsWithoutRef<typeof CheckboxPrimitive.Root>
+>(({ className, ...props }, ref) => (
+  <CheckboxPrimitive.Root
+    ref={ref}
+    className={cn(
+      "grid place-content-center peer h-4 w-4 shrink-0 rounded-sm border border-primary ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-primary data-[state=checked]:text-primary-foreground",
+      className
+    )}
+    {...props}
+  >
+    <CheckboxPrimitive.Indicator
+      className={cn("grid place-content-center text-current")}
+    >
+      <Check className="h-4 w-4" />
+    </CheckboxPrimitive.Indicator>
+  </CheckboxPrimitive.Root>
+))
+Checkbox.displayName = CheckboxPrimitive.Root.displayName
+
+export { Checkbox }

--- a/src/components/urination-card.tsx
+++ b/src/components/urination-card.tsx
@@ -17,7 +17,6 @@ import { Loader2, ChevronDown, ChevronUp } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { CARD_THEMES } from "@/lib/card-themes";
 import { RecentEntriesList } from "@/components/recent-entries-list";
-import { EditUrinationDialog } from "@/components/edit-urination-dialog";
 import { useDeleteWithToast } from "@/hooks/use-delete-with-toast";
 import { useEditRecord } from "@/hooks/use-edit-record";
 import { useToast } from "@/hooks/use-toast";
@@ -231,6 +230,7 @@ export function UrinationCard() {
             deletingId={deletingId}
             onDelete={handleDelete}
             onEdit={openEdit}
+            editingId={editingRecord?.id ?? null}
             borderColor={theme.border}
             renderEntry={(record) => (
               <div className="flex items-center gap-2 min-w-0">
@@ -245,21 +245,29 @@ export function UrinationCard() {
                 )}
               </div>
             )}
+            renderEditForm={() => (
+              <div className="space-y-2">
+                <Select value={editAmountEstimate} onValueChange={setEditAmountEstimate}>
+                  <SelectTrigger className="h-8 text-sm">
+                    <SelectValue placeholder="Amount estimate" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {AMOUNT_OPTIONS.map((opt) => (
+                      <SelectItem key={opt.value} value={opt.value}>{opt.label}</SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+                <Input type="datetime-local" value={editTimestamp} onChange={(e) => setEditTimestamp(e.target.value)} className="h-8 text-sm" />
+                <Input placeholder="Note (optional)" value={editNote} onChange={(e) => setEditNote(e.target.value)} className="h-8 text-sm" />
+                <div className="flex gap-2">
+                  <Button size="sm" className={cn("flex-1 h-8", theme.buttonBg)} onClick={handleEditSubmit}>Save</Button>
+                  <Button size="sm" variant="outline" className="flex-1 h-8" onClick={closeEdit}>Cancel</Button>
+                </div>
+              </div>
+            )}
           />
         </CardContent>
       </Card>
-
-      <EditUrinationDialog
-        record={editingRecord}
-        onClose={closeEdit}
-        onSubmit={handleEditSubmit}
-        timestamp={editTimestamp}
-        onTimestampChange={setEditTimestamp}
-        amount={editAmountEstimate}
-        onAmountChange={setEditAmountEstimate}
-        note={editNote}
-        onNoteChange={setEditNote}
-      />
     </>
   );
 }

--- a/src/components/urination-card.tsx
+++ b/src/components/urination-card.tsx
@@ -16,7 +16,7 @@ import {
 import { Loader2, ChevronDown, ChevronUp } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { CARD_THEMES } from "@/lib/card-themes";
-import { RecentEntriesList } from "@/components/recent-entries-list";
+import { RecentEntriesList, InlineEditFormShell } from "@/components/recent-entries-list";
 import { useDeleteWithToast } from "@/hooks/use-delete-with-toast";
 import { useEditRecord } from "@/hooks/use-edit-record";
 import { useToast } from "@/hooks/use-toast";
@@ -246,7 +246,7 @@ export function UrinationCard() {
               </div>
             )}
             renderEditForm={() => (
-              <div className="space-y-2">
+              <InlineEditFormShell timestamp={editTimestamp} onTimestampChange={setEditTimestamp} note={editNote} onNoteChange={setEditNote} onSave={() => handleEditSubmit()} onCancel={closeEdit} buttonClassName={theme.buttonBg}>
                 <Select value={editAmountEstimate} onValueChange={setEditAmountEstimate}>
                   <SelectTrigger className="h-8 text-sm">
                     <SelectValue placeholder="Amount estimate" />
@@ -257,13 +257,7 @@ export function UrinationCard() {
                     ))}
                   </SelectContent>
                 </Select>
-                <Input type="datetime-local" value={editTimestamp} onChange={(e) => setEditTimestamp(e.target.value)} className="h-8 text-sm" />
-                <Input placeholder="Note (optional)" value={editNote} onChange={(e) => setEditNote(e.target.value)} className="h-8 text-sm" />
-                <div className="flex gap-2">
-                  <Button size="sm" className={cn("flex-1 h-8", theme.buttonBg)} onClick={handleEditSubmit}>Save</Button>
-                  <Button size="sm" variant="outline" className="flex-1 h-8" onClick={closeEdit}>Cancel</Button>
-                </div>
-              </div>
+              </InlineEditFormShell>
             )}
           />
         </CardContent>

--- a/src/components/weight-card.tsx
+++ b/src/components/weight-card.tsx
@@ -18,7 +18,7 @@ const WeightFormSchema = z.object({
     .max(1000, "Weight seems too high"),
 });
 import { CollapsibleTimeInputControlled } from "@/components/collapsible-time-input";
-import { RecentEntriesList } from "@/components/recent-entries-list";
+import { RecentEntriesList, InlineEditFormShell } from "@/components/recent-entries-list";
 import { useDeleteWithToast } from "@/hooks/use-delete-with-toast";
 import { useEditRecord } from "@/hooks/use-edit-record";
 import { useSettings } from "@/hooks/use-settings";
@@ -280,15 +280,9 @@ export function WeightCard() {
             </>
           )}
           renderEditForm={() => (
-            <div className="space-y-2">
+            <InlineEditFormShell timestamp={editTimestamp} onTimestampChange={setEditTimestamp} note={editNote} onNoteChange={setEditNote} onSave={() => handleEditSubmit()} onCancel={closeEdit} buttonClassName={theme.buttonBg}>
               <Input type="number" step="0.01" placeholder="Weight (kg)" value={editWeight} onChange={(e) => setEditWeight(e.target.value)} className="h-8 text-sm" />
-              <Input type="datetime-local" value={editTimestamp} onChange={(e) => setEditTimestamp(e.target.value)} className="h-8 text-sm" />
-              <Input placeholder="Note (optional)" value={editNote} onChange={(e) => setEditNote(e.target.value)} className="h-8 text-sm" />
-              <div className="flex gap-2">
-                <Button size="sm" className={cn("flex-1 h-8", theme.buttonBg)} onClick={handleEditSubmit}>Save</Button>
-                <Button size="sm" variant="outline" className="flex-1 h-8" onClick={closeEdit}>Cancel</Button>
-              </div>
-            </div>
+            </InlineEditFormShell>
           )}
         />
       </CardContent>

--- a/src/components/weight-card.tsx
+++ b/src/components/weight-card.tsx
@@ -3,6 +3,7 @@
 import { useState, useEffect } from "react";
 import { Card, CardContent } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
 import { Minus, Plus, Check, Loader2 } from "lucide-react";
 import { z } from "zod";
 import { cn } from "@/lib/utils";
@@ -18,7 +19,6 @@ const WeightFormSchema = z.object({
 });
 import { CollapsibleTimeInputControlled } from "@/components/collapsible-time-input";
 import { RecentEntriesList } from "@/components/recent-entries-list";
-import { EditWeightDialog } from "@/components/edit-weight-dialog";
 import { useDeleteWithToast } from "@/hooks/use-delete-with-toast";
 import { useEditRecord } from "@/hooks/use-edit-record";
 import { useSettings } from "@/hooks/use-settings";
@@ -269,6 +269,7 @@ export function WeightCard() {
           deletingId={deletingId}
           onDelete={handleDelete}
           onEdit={openEdit}
+          editingId={editingRecord?.id ?? null}
           borderColor={theme.border}
           renderEntry={(record) => (
             <>
@@ -278,21 +279,20 @@ export function WeightCard() {
               </div>
             </>
           )}
+          renderEditForm={() => (
+            <div className="space-y-2">
+              <Input type="number" step="0.01" placeholder="Weight (kg)" value={editWeight} onChange={(e) => setEditWeight(e.target.value)} className="h-8 text-sm" />
+              <Input type="datetime-local" value={editTimestamp} onChange={(e) => setEditTimestamp(e.target.value)} className="h-8 text-sm" />
+              <Input placeholder="Note (optional)" value={editNote} onChange={(e) => setEditNote(e.target.value)} className="h-8 text-sm" />
+              <div className="flex gap-2">
+                <Button size="sm" className={cn("flex-1 h-8", theme.buttonBg)} onClick={handleEditSubmit}>Save</Button>
+                <Button size="sm" variant="outline" className="flex-1 h-8" onClick={closeEdit}>Cancel</Button>
+              </div>
+            </div>
+          )}
         />
       </CardContent>
     </Card>
-
-    <EditWeightDialog
-      record={editingRecord}
-      onClose={closeEdit}
-      onSubmit={handleEditSubmit}
-      weight={editWeight}
-      onWeightChange={setEditWeight}
-      timestamp={editTimestamp}
-      onTimestampChange={setEditTimestamp}
-      note={editNote}
-      onNoteChange={setEditNote}
-    />
     </>
   );
 }

--- a/src/hooks/use-analytics-queries.ts
+++ b/src/hooks/use-analytics-queries.ts
@@ -11,9 +11,7 @@ import {
   caffeineVsBP,
   alcoholVsBP,
   correlate,
-  getRecordsByDomain,
 } from "@/lib/analytics-service";
-import { detectAnomalies } from "@/lib/analytics-stats";
 import type {
   Domain,
   TimeScope,
@@ -211,95 +209,9 @@ export function useCorrelation(
  * Derive cross-domain insights from multiple analytics queries.
  * Returns Insight[] with meaningful alerts based on thresholds.
  */
-export function useInsights(range: TimeRange) {
-  return useLiveQuery(
-    async () => {
-      const [adherenceData, bpData, fluidData, weightPoints] =
-        await Promise.all([
-          adherenceRate(range),
-          bpTrend(range),
-          fluidBalance(range),
-          getRecordsByDomain("weight", range),
-        ]);
-
-      const insights: Insight[] = [];
-      const now = Date.now();
-
-      // Adherence drop: rate below 80%
-      if (
-        adherenceData.value.total > 0 &&
-        adherenceData.value.rate < 0.8
-      ) {
-        insights.push({
-          id: `adherence_drop_${range.start}`,
-          type: "adherence_drop",
-          title: "Medication Adherence Below Target",
-          description: `Adherence is ${Math.round(adherenceData.value.rate * 100)}% (target: 80%). ${adherenceData.value.taken} of ${adherenceData.value.total} doses taken.`,
-          severity: adherenceData.value.rate < 0.5 ? "alert" : "warning",
-          value: adherenceData.value.rate,
-          threshold: 0.8,
-          timestamp: now,
-        });
-      }
-
-      // BP trend: significant systolic trend
-      const systolicTrend = bpData.value.trend.systolic;
-      if (
-        bpData.value.readings.length >= 3 &&
-        systolicTrend.confidence > 0.3 &&
-        systolicTrend.direction !== "stable"
-      ) {
-        const rising = systolicTrend.direction === "rising";
-        insights.push({
-          id: `bp_trend_${range.start}`,
-          type: "bp_trend",
-          title: `Blood Pressure ${rising ? "Rising" : "Falling"}`,
-          description: `Systolic BP is trending ${systolicTrend.direction} with ${Math.round(systolicTrend.confidence * 100)}% confidence. Average: ${Math.round(bpData.value.avg.systolic)}/${Math.round(bpData.value.avg.diastolic)} mmHg.`,
-          severity: rising ? "warning" : "info",
-          value: systolicTrend.slope,
-          threshold: 0.01,
-          timestamp: now,
-        });
-      }
-
-      // Fluid deficit: more than half of days below target
-      if (fluidData.value.daysTotal >= 3) {
-        const deficitRatio =
-          1 - fluidData.value.daysAboveTarget / fluidData.value.daysTotal;
-        if (deficitRatio > 0.5) {
-          insights.push({
-            id: `fluid_deficit_${range.start}`,
-            type: "fluid_deficit",
-            title: "Frequent Fluid Deficit",
-            description: `Only ${fluidData.value.daysAboveTarget} of ${fluidData.value.daysTotal} days met fluid intake target. Average balance: ${Math.round(fluidData.value.avgBalance)} ml.`,
-            severity: deficitRatio > 0.75 ? "alert" : "warning",
-            value: deficitRatio,
-            threshold: 0.5,
-            timestamp: now,
-          });
-        }
-      }
-
-      // Weight anomalies via z-score detection
-      const anomalies = detectAnomalies(weightPoints);
-      if (anomalies.length > 0) {
-        insights.push({
-          id: `anomaly_weight_${range.start}`,
-          type: "anomaly",
-          title: "Unusual Weight Reading Detected",
-          description: `${anomalies.length} weight reading(s) deviate significantly from the norm during this period.`,
-          severity: "info",
-          value: anomalies.length,
-          threshold: 1,
-          timestamp: now,
-        });
-      }
-
-      return insights;
-    },
-    [range.start, range.end],
-    [] as Insight[],
-  );
+// GH-32: Default auto-generated insights removed. Only user-created insights are supported.
+export function useInsights(_range: TimeRange) {
+  return [] as Insight[];
 }
 
 // ---------------------------------------------------------------------------

--- a/src/hooks/use-analytics-queries.ts
+++ b/src/hooks/use-analytics-queries.ts
@@ -210,8 +210,9 @@ export function useCorrelation(
  * Returns Insight[] with meaningful alerts based on thresholds.
  */
 // GH-32: Default auto-generated insights removed. Only user-created insights are supported.
+const EMPTY_INSIGHTS: Insight[] = [];
 export function useInsights(_range: TimeRange) {
-  return [] as Insight[];
+  return EMPTY_INSIGHTS;
 }
 
 // ---------------------------------------------------------------------------

--- a/src/hooks/use-edit-record.ts
+++ b/src/hooks/use-edit-record.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useCallback, useRef } from "react";
+import { useState, useCallback, useRef, type FormEvent } from "react";
 import { useToast } from "@/hooks/use-toast";
 import {
   timestampToDateTimeLocal,
@@ -54,7 +54,7 @@ interface UseEditRecordReturn<T> {
   /** Close the edit dialog without saving. */
   closeEdit: () => void;
   /** Submit handler — call with optional form event. */
-  handleEditSubmit: (e?: React.FormEvent) => Promise<void>;
+  handleEditSubmit: (e?: FormEvent) => Promise<void>;
 }
 
 export function useEditRecord<
@@ -84,7 +84,7 @@ export function useEditRecord<
   }, []);
 
   const handleEditSubmit = useCallback(
-    async (e?: React.FormEvent) => {
+    async (e?: FormEvent) => {
       e?.preventDefault();
       if (!editingRecord) return;
 

--- a/src/hooks/use-edit-record.ts
+++ b/src/hooks/use-edit-record.ts
@@ -53,8 +53,8 @@ interface UseEditRecordReturn<T> {
   openEdit: (record: T) => void;
   /** Close the edit dialog without saving. */
   closeEdit: () => void;
-  /** Form `onSubmit` handler — call with the form event. */
-  handleEditSubmit: (e: React.FormEvent) => Promise<void>;
+  /** Submit handler — call with optional form event. */
+  handleEditSubmit: (e?: React.FormEvent) => Promise<void>;
 }
 
 export function useEditRecord<
@@ -84,8 +84,8 @@ export function useEditRecord<
   }, []);
 
   const handleEditSubmit = useCallback(
-    async (e: React.FormEvent) => {
-      e.preventDefault();
+    async (e?: React.FormEvent) => {
+      e?.preventDefault();
       if (!editingRecord) return;
 
       const newTimestamp = dateTimeLocalToTimestamp(editTimestamp);

--- a/src/lib/ai-client.ts
+++ b/src/lib/ai-client.ts
@@ -3,6 +3,7 @@ import { logAudit } from "./audit";
 export interface ParsedIntake {
   water: number | null; // ml
   salt: number | null; // mg
+  measurementType?: "sodium" | "salt"; // whether salt field is sodium (Na) or salt (NaCl)
   reasoning?: string;
 }
 
@@ -56,6 +57,7 @@ export async function parseIntakeWithAI(
     return {
       water: result.water,
       salt: result.salt,
+      measurementType: result.measurement_type,
       reasoning: result.reasoning,
     };
   } catch (error) {

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -61,6 +61,13 @@ export function getLiquidTypeLabel(
     return sub ? sub.charAt(0).toUpperCase() + sub.slice(1) : "Coffee";
   }
 
+  // Beverage prefix: "beverage" or "beverage:Juice" -> "Beverage" or "Juice"
+  if (source === "beverage") return "Beverage";
+  if (source.startsWith("beverage:")) {
+    const name = source.slice(9);
+    return name || "Beverage";
+  }
+
   // Juice prefix: "juice" or "juice:orange" -> "Juice" or "Orange"
   if (source === "juice") return "Juice";
   if (source.startsWith("juice:")) {


### PR DESCRIPTION
## Summary

- **#31** — BP quick view now shows last heart rate (BPM) and systolic/diastolic delta vs previous reading with color-coded indicators
- **#32** — Removed default auto-generated insights; `useInsights` returns empty array, preserving API surface for future custom insights
- **#33** — AI food parse returns explicit `measurement_type` field (`"sodium"` or `"salt"`), food section auto-selects correct sodium source dropdown
- **#34** — Inline editing replaces modal dialogs in all 6 card components; dialog files preserved for history drawer usage
- **#35** — Weekly summary grid adds Caffeine (mg) and Alcohol (std drinks) rows alongside Water and Na

Closes #31, closes #32, closes #33, closes #34, closes #35

## Test plan

- [x] All 417 unit tests pass
- [ ] Verify BP card shows heart rate and delta when multiple readings exist
- [ ] Verify insights tab shows empty state with no auto-generated insights
- [ ] Verify AI food parse populates sodium source dropdown correctly
- [ ] Verify tapping a recent entry expands inline edit form (not modal)
- [ ] Verify weekly summary grid shows Caf and Alc rows
- [ ] Verify history drawer still uses modal editing (no regression)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Show latest heart rate and colored systolic/diastolic deltas on BP readings
  * Weekly summary adds caffeine ("Caf") and alcohol ("Alc") rows
  * Inline editing replaces modals across recent intake records for faster in-place edits
  * Quick-set water size buttons and a new checkbox UI component

* **Updates**
  * AI parsing distinguishes salt vs sodium and auto-selects the appropriate source
  * Analytics no longer auto-generate default insights; empty-state text now references custom insights only

* **Chores**
  * Improved liquid type labeling for beverage sources
<!-- end of auto-generated comment: release notes by coderabbit.ai -->