### PR TITLE
fix(auth): trust Privy-timeout not navigator.onLine for offline grace

### DIFF
--- a/src/components/auth-guard.tsx
+++ b/src/components/auth-guard.tsx
@@ -59,13 +59,6 @@ function isRememberedAuthValid(): boolean {
   return Date.now() - ts < REMEMBERED_AUTH_WINDOW_MS;
 }
 
-function isOffline(): boolean {
-  if (typeof navigator === "undefined") return false;
-  // navigator.onLine is `false` only when the device has no network at all,
-  // which is exactly when we want to honor the remembered session.
-  return navigator.onLine === false;
-}
-
 /**
  * Protects content behind Privy authentication.
  * Shows login prompt if user is not authenticated.
@@ -121,9 +114,15 @@ function PrivyAuthGuard({ children, fallback }: AuthGuardProps) {
     return <>{children}</>;
   }
 
-  // Offline grace: if Privy can't validate (or hasn't become ready) but the
-  // device is offline and we recently authenticated, keep the user in.
-  if (isOffline() && isRememberedAuthValid()) {
+  // Offline / network-failure grace: if Privy never became ready within the
+  // timeout, we couldn't reach its auth servers — honor the last successful
+  // Privy login for up to REMEMBERED_AUTH_WINDOW_MS so the PWA stays usable
+  // on flaky or absent networks. We intentionally do NOT use navigator.onLine
+  // here because mobile devices routinely report online === true while the
+  // radio can't actually reach the internet (captive portals, poor signal,
+  // backgrounded PWAs), which was silently locking users out. "Privy didn't
+  // become ready in 5s" is a much more reliable signal of network trouble.
+  if (readyTimedOut && isRememberedAuthValid()) {
     return <>{children}</>;
   }
 


### PR DESCRIPTION
The previous offline-auth grace required `navigator.onLine === false` to honor a remembered Privy session. On mobile (especially iOS PWAs and backgrounded apps) `navigator.onLine` frequently reports `true` even when the radio can't reach the internet, so Privy's session would silently expire, the guard would decide we were "online but unauthenticated", and the user would land on the Sign-In card with a login button that couldn't do anything (Privy's iframe can't load without network).

Switch the trigger to `readyTimedOut`: if Privy's SDK hasn't become ready within 5s we know something is wrong with the network — that's a much more reliable signal than the OS's online flag. When that fires and the user has a remembered Privy auth within the 18-day window, let them in.

https://claude.ai/code/session_01NnP2pGwWLpj6Vv1DaSf5pS

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved offline authentication handling to use a more reliable timeout-based mechanism instead of browser network detection, ensuring users remain authenticated during network connectivity issues more consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->