### PR TITLE
fix(auth): unstick offline users who can't reach the bypass form

### DIFF
--- a/src/components/auth-button.tsx
+++ b/src/components/auth-button.tsx
@@ -1,8 +1,12 @@
 "use client";
 
+import { useCallback, useEffect, useState } from "react";
 import { usePrivy } from "@privy-io/react-auth";
 import { Button } from "@/components/ui/button";
 import { LogIn, LogOut, User } from "lucide-react";
+import { clearLocalAuthState } from "@/components/auth-guard";
+
+const PRIVY_READY_OFFLINE_TIMEOUT_MS = 5000;
 
 export function AuthButton() {
   if (!process.env.NEXT_PUBLIC_PRIVY_APP_ID) return null;
@@ -13,8 +17,40 @@ export function AuthButton() {
 function PrivyAuthButton() {
   const { ready, authenticated, login, logout, user } = usePrivy();
 
-  // Show nothing while Privy is initializing
-  if (!ready) {
+  // Mirrors AuthGuard's timeout pattern: when Privy can't reach its servers
+  // `ready` never flips to true, which would otherwise leave this button
+  // permanently disabled and lock users into an authenticated session they
+  // can't exit. After the timeout we enable the button so logout is
+  // clickable even offline.
+  const [readyTimedOut, setReadyTimedOut] = useState(false);
+  useEffect(() => {
+    if (ready) return;
+    const t = setTimeout(() => setReadyTimedOut(true), PRIVY_READY_OFFLINE_TIMEOUT_MS);
+    return () => clearTimeout(t);
+  }, [ready]);
+
+  const effectivelyReady = ready || readyTimedOut;
+
+  // Logs out even when offline: clears our local auth grace so AuthGuard
+  // falls back to the sign-in card, then tries Privy's own logout (which
+  // will silently no-op without network). The local clear is what actually
+  // makes the guard release the user.
+  const handleLogout = useCallback(async () => {
+    clearLocalAuthState();
+    try {
+      await logout();
+    } catch {
+      /* Privy's logout needs the network; local clear is enough to log us out */
+    }
+    if (typeof window !== "undefined") {
+      // Hard reload so AuthGuard re-evaluates without stale Privy state.
+      window.location.reload();
+    }
+  }, [logout]);
+
+  // Show a disabled placeholder only while we're still waiting for Privy —
+  // once the timeout fires we switch to the real logout/login button.
+  if (!effectivelyReady) {
     return (
       <Button variant="ghost" size="sm" disabled>
         <User className="w-4 h-4" />
@@ -24,7 +60,7 @@ function PrivyAuthButton() {
 
   if (authenticated) {
     const displayName = user?.email?.address || user?.wallet?.address?.slice(0, 8) || "User";
-    
+
     return (
       <div className="flex items-center gap-2">
         <span className="text-sm text-muted-foreground hidden sm:inline">
@@ -33,12 +69,29 @@ function PrivyAuthButton() {
         <Button
           variant="ghost"
           size="sm"
-          onClick={logout}
+          onClick={handleLogout}
           title="Sign out"
         >
           <LogOut className="w-4 h-4" />
         </Button>
       </div>
+    );
+  }
+
+  // Privy says we're not authenticated (and didn't time out, so it's
+  // reachable). If AuthGuard let us render anyway, we're running on the
+  // remembered-auth grace or the bypass — surface a logout button so the
+  // user can drop that grace and re-auth/bypass cleanly.
+  if (readyTimedOut) {
+    return (
+      <Button
+        variant="ghost"
+        size="sm"
+        onClick={handleLogout}
+        title="Clear session"
+      >
+        <LogOut className="w-4 h-4" />
+      </Button>
     );
   }
 

--- a/src/components/auth-guard.tsx
+++ b/src/components/auth-guard.tsx
@@ -16,7 +16,7 @@ interface AuthGuardProps {
 // authentication we'll keep granting access while the device is offline.
 // Lets users stay in the PWA on extended offline trips without Privy
 // access tokens silently locking them out when they refresh.
-const REMEMBERED_AUTH_KEY = "intake-tracker-last-auth";
+export const REMEMBERED_AUTH_KEY = "intake-tracker-last-auth";
 const REMEMBERED_AUTH_WINDOW_MS = 18 * 24 * 60 * 60 * 1000;
 const PRIVY_READY_OFFLINE_TIMEOUT_MS = 5000;
 
@@ -24,8 +24,14 @@ const PRIVY_READY_OFFLINE_TIMEOUT_MS = 5000;
 // screen they get the same 18-day grace as a remembered Privy auth. Intended
 // for offline trips when Privy can't reach its servers; remove once a more
 // permanent offline-auth story is in place.
-const BYPASS_KEY = "intake-tracker-bypass-auth";
+export const BYPASS_KEY = "intake-tracker-bypass-auth";
 const DEFAULT_BYPASS_CODE = "meowmeowmeow";
+
+// URL escape hatch: visiting any page with `?bypass=CODE` activates the
+// bypass and strips the query param. Works when every other button in the
+// UI is dead (e.g. offline + expired Privy session + disabled logout), so
+// users can always recover without clearing site data.
+const BYPASS_QUERY_PARAM = "bypass";
 
 function getBypassCode(): string {
   return process.env.NEXT_PUBLIC_BYPASS_CODE || DEFAULT_BYPASS_CODE;
@@ -43,6 +49,18 @@ function isBypassActive(): boolean {
 function activateBypass(): void {
   if (typeof window === "undefined") return;
   window.localStorage.setItem(BYPASS_KEY, String(Date.now()));
+}
+
+/**
+ * Clears local auth state (remembered Privy timestamp + bypass flag) so the
+ * next render of AuthGuard falls through to the sign-in card. Callable from
+ * logout flows — lets users reach the bypass form offline, since Privy's
+ * own logout() can't complete without the network.
+ */
+export function clearLocalAuthState(): void {
+  if (typeof window === "undefined") return;
+  window.localStorage.removeItem(REMEMBERED_AUTH_KEY);
+  window.localStorage.removeItem(BYPASS_KEY);
 }
 
 function readRememberedAuthTimestamp(): number | null {
@@ -93,8 +111,26 @@ function PrivyAuthGuard({ children, fallback }: AuthGuardProps) {
     }
   }, [authenticated]);
 
-  // Re-renders the guard when the bypass is activated from the sign-in card.
+  // Re-renders the guard when the bypass is activated from the sign-in card
+  // or from the `?bypass=CODE` URL escape hatch.
   const [bypassTick, setBypassTick] = useState(0);
+
+  // URL escape hatch: `?bypass=CODE` activates bypass on any page load.
+  // Strips the param from the URL so the code doesn't stick around in
+  // history/share targets after activation.
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    const url = new URL(window.location.href);
+    const code = url.searchParams.get(BYPASS_QUERY_PARAM);
+    if (!code) return;
+    if (code === getBypassCode()) {
+      activateBypass();
+      setBypassTick((n) => n + 1);
+    }
+    url.searchParams.delete(BYPASS_QUERY_PARAM);
+    const cleaned = url.pathname + (url.search ? url.search : "") + url.hash;
+    window.history.replaceState(null, "", cleaned);
+  }, []);
 
   const effectivelyReady = ready || readyTimedOut;
 

--- a/src/components/settings/account-section.tsx
+++ b/src/components/settings/account-section.tsx
@@ -1,8 +1,12 @@
 "use client";
 
+import { useCallback, useEffect, useState } from "react";
 import { usePrivy } from "@privy-io/react-auth";
 import { Button } from "@/components/ui/button";
 import { User, LogOut } from "lucide-react";
+import { clearLocalAuthState } from "@/components/auth-guard";
+
+const PRIVY_READY_OFFLINE_TIMEOUT_MS = 5000;
 
 export function AccountSection() {
   if (!process.env.NEXT_PUBLIC_PRIVY_APP_ID) return null;
@@ -11,9 +15,38 @@ export function AccountSection() {
 }
 
 function PrivyAccountSection() {
-  const { authenticated, user, logout } = usePrivy();
+  const { ready, authenticated, user, logout } = usePrivy();
 
-  if (!authenticated) return null;
+  // Same timeout as AuthGuard: if Privy can't reach its servers we still
+  // want to offer a logout path so users can reach the sign-in card and
+  // the bypass form.
+  const [readyTimedOut, setReadyTimedOut] = useState(false);
+  useEffect(() => {
+    if (ready) return;
+    const t = setTimeout(() => setReadyTimedOut(true), PRIVY_READY_OFFLINE_TIMEOUT_MS);
+    return () => clearTimeout(t);
+  }, [ready]);
+
+  const handleLogout = useCallback(async () => {
+    clearLocalAuthState();
+    try {
+      await logout();
+    } catch {
+      /* Privy's logout needs the network; local clear is enough to log us out */
+    }
+    if (typeof window !== "undefined") {
+      window.location.reload();
+    }
+  }, [logout]);
+
+  // Render the section if Privy says we're authenticated, OR if Privy never
+  // reached ready — in the offline case the user is in via the remembered
+  // auth or bypass grace and still needs a way out.
+  const showSection = authenticated || readyTimedOut;
+  if (!showSection) return null;
+
+  const displayName = user?.email?.address || "Authenticated user";
+  const sessionLabel = authenticated ? "Signed in" : "Offline session";
 
   return (
     <div className="space-y-4">
@@ -23,13 +56,13 @@ function PrivyAccountSection() {
       </div>
       <div className="space-y-3">
         <div className="p-3 rounded-lg bg-slate-50 dark:bg-slate-900 border">
-          <p className="text-sm font-medium">{user?.email?.address || "Authenticated user"}</p>
-          <p className="text-xs text-muted-foreground">Signed in</p>
+          <p className="text-sm font-medium">{displayName}</p>
+          <p className="text-xs text-muted-foreground">{sessionLabel}</p>
         </div>
         <Button
           variant="outline"
           className="w-full justify-start gap-2 text-red-600 hover:text-red-700 hover:bg-red-50 dark:hover:bg-red-950/30"
-          onClick={logout}
+          onClick={handleLogout}
         >
           <LogOut className="w-4 h-4" />
           Sign Out


### PR DESCRIPTION
## Summary

Three interlocking trapdoors made the app unrecoverable offline when Privy's session expired — the user could be past AuthGuard (via remembered-auth grace) but unable to reach the sign-in card where the emergency bypass form lives:

1. `AuthButton` used `disabled={!ready}` with no timeout, so the header logout was permanently disabled offline.
2. `AccountSection` in Settings only rendered when Privy reported `authenticated === true`, so that logout was hidden offline too.
3. Even if logout were clickable, Privy's `logout()` needs network and leaves our local `REMEMBERED_AUTH_KEY` timestamp in place, so AuthGuard would immediately grant access again.

## Fixes

- **AuthGuard**: adds `?bypass=CODE` URL escape hatch that activates the bypass on any page load and strips the param. Exports `clearLocalAuthState()` for logout handlers to call.
- **AuthButton**: mirrors AuthGuard's 5s `readyTimedOut` pattern so the logout button becomes clickable when Privy hangs. Offline logout now clears the local grace + bypass keys and reloads, landing the user on the sign-in card.
- **AccountSection**: same timeout + local-clear logout, visible even when Privy reports unauthenticated.

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm lint` clean
- [x] `pnpm test` — 417/417 pass
- [ ] Manual: airplane mode, open PWA, verify header logout becomes clickable after 5s and returns you to sign-in card
- [ ] Manual: visit `/?bypass=meowmeowmeow` offline, verify bypass activates and URL is cleaned
- [ ] Manual: online sign-out still works normally

https://claude.ai/code/session_01NnP2pGwWLpj6Vv1DaSf5pS