### PR TITLE
fix(pwa): auto-bypass when offline + SPA nav online

### DIFF
--- a/src/components/app-header.tsx
+++ b/src/components/app-header.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { usePathname } from "next/navigation";
+import { usePathname, useRouter } from "next/navigation";
 import { motion } from "motion/react";
 import { Button } from "@/components/ui/button";
 import { Droplets, Pill, BarChart3, Settings } from "lucide-react";
@@ -24,6 +24,7 @@ export function AppHeader({
   transitionDuration = 0.2,
 }: AppHeaderProps) {
   const pathname = usePathname();
+  const router = useRouter();
 
   const current = NAV_ITEMS.find((item) => item.path === pathname) ?? NAV_ITEMS[0];
 
@@ -50,7 +51,7 @@ export function AppHeader({
                 isActive && "bg-primary/10 text-primary"
               )}
               onClick={() => {
-                if (!isActive) navigateTo(item.path);
+                if (!isActive) navigateTo(item.path, router);
               }}
             >
               <item.icon className={cn("w-5 h-5", isActive && "text-primary")} />

--- a/src/components/insight-badge.tsx
+++ b/src/components/insight-badge.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useMemo } from "react";
+import { useRouter } from "next/navigation";
 import { Lightbulb } from "lucide-react";
 import { useInsights, useTimeScopeRange } from "@/hooks/use-analytics-queries";
 import { useSettingsStore } from "@/stores/settings-store";
@@ -14,6 +15,7 @@ const severityColors = {
 } as const;
 
 export function InsightBadge() {
+  const router = useRouter();
   const range = useTimeScopeRange("7d");
   const insights = useInsights(range);
   const isDismissed = useSettingsStore((s) => s.isDismissed);
@@ -38,7 +40,7 @@ export function InsightBadge() {
 
   return (
     <button
-      onClick={() => navigateTo("/analytics?tab=insights")}
+      onClick={() => navigateTo("/analytics?tab=insights", router)}
       className={cn(
         "inline-flex items-center gap-1.5 rounded-full px-3 py-1 text-xs font-medium transition-colors",
         severityColors[highestSeverity],

--- a/src/components/service-worker-bootstrap.tsx
+++ b/src/components/service-worker-bootstrap.tsx
@@ -10,56 +10,78 @@ function getBypassCode(): string {
   return process.env.NEXT_PUBLIC_BYPASS_CODE || DEFAULT_BYPASS_CODE;
 }
 
+function activateBypass(): void {
+  if (typeof window === "undefined") return;
+  window.localStorage.setItem(BYPASS_KEY, String(Date.now()));
+}
+
 /**
- * Belt-and-suspenders SW registration + early-boot URL bypass trigger.
+ * Belt-and-suspenders SW registration + offline survival.
  *
- * Two jobs bundled here because both need to run as early as possible on
- * the client, before AuthGuard, Privy, or anything else:
+ * Runs as early as possible on every client boot, before AuthGuard or
+ * anything else that might hang:
  *
- * 1) Register `/sw.js`. next-pwa normally injects its own register script
- *    into main.js, but that has silently failed in some builds. Re-register
- *    is idempotent, so this is safe either way. Guarded to production
- *    Vercel env to match the build-time gate in next.config.js.
+ * 1) Register `/sw.js`. next-pwa injects its own register into main.js,
+ *    but that has silently failed on some builds. Idempotent if
+ *    next-pwa's auto-register is already working.
  *
- * 2) Detect `?bypass=CODE` in the URL and activate the emergency bypass
- *    grace before any AuthGuard renders. Previously this ran inside
- *    AuthGuard, but that meant a URL like `/medications?bypass=xxx`
- *    wouldn't activate it until AuthGuard mounted, and offline users who
- *    were locked out of AuthGuard couldn't reach it at all. Now it runs
- *    unconditionally on every page boot. Strips the param from the URL
- *    after activation so the code doesn't stick in history or share URLs.
+ * 2) Handle `?bypass=CODE` URL escape hatch. Previously this lived in
+ *    AuthGuard, which meant users locked out by AuthGuard couldn't
+ *    reach it. Now fires on every page, including /offline.
+ *
+ * 3) Auto-activate bypass when the device is offline. `navigator.onLine`
+ *    is imperfect but when it reports `false` we're definitely offline,
+ *    and in that case Privy absolutely cannot validate a session — so
+ *    unconditionally extending the bypass grace is strictly better than
+ *    locking the user into a dead sign-in card with nothing they can do.
  */
 export function ServiceWorkerBootstrap() {
   useEffect(() => {
     if (typeof window === "undefined") return;
 
-    // URL bypass trigger — runs before SW registration side-effects matter.
+    // 1. URL bypass trigger
     const url = new URL(window.location.href);
     const code = url.searchParams.get(BYPASS_QUERY_PARAM);
     if (code) {
       if (code === getBypassCode()) {
-        window.localStorage.setItem(BYPASS_KEY, String(Date.now()));
+        activateBypass();
       }
       url.searchParams.delete(BYPASS_QUERY_PARAM);
       const cleaned = url.pathname + (url.search ? url.search : "") + url.hash;
       window.history.replaceState(null, "", cleaned);
     }
 
-    if (!("serviceWorker" in navigator)) return;
+    // 2. Auto-activate bypass when offline. `navigator.onLine === false`
+    // is the one case where we know with certainty Privy can't reach its
+    // servers; no reason to leave the user staring at a disabled login.
+    const maybeBypassOffline = () => {
+      if (typeof navigator !== "undefined" && navigator.onLine === false) {
+        activateBypass();
+      }
+    };
+    maybeBypassOffline();
+    window.addEventListener("offline", maybeBypassOffline);
 
-    const env = process.env.NEXT_PUBLIC_VERCEL_ENV;
-    if (env && env !== "production") return;
+    // 3. SW registration
+    if ("serviceWorker" in navigator) {
+      const env = process.env.NEXT_PUBLIC_VERCEL_ENV;
+      if (!env || env === "production") {
+        navigator.serviceWorker
+          .register("/sw.js", { scope: "/" })
+          .then((reg) => {
+            reg.update().catch(() => {
+              /* offline or transient — fine, next load will retry */
+            });
+          })
+          .catch((err) => {
+            console.error("[SW] Registration failed:", err);
+          });
+      }
+    }
 
-    navigator.serviceWorker
-      .register("/sw.js", { scope: "/" })
-      .then((reg) => {
-        reg.update().catch(() => {
-          /* offline or transient — fine, next load will retry */
-        });
-      })
-      .catch((err) => {
-        console.error("[SW] Registration failed:", err);
-      });
+    return () => {
+      window.removeEventListener("offline", maybeBypassOffline);
+    };
   }, []);
 
   return null;

--- a/src/lib/navigation.ts
+++ b/src/lib/navigation.ts
@@ -1,18 +1,29 @@
 /**
- * Offline-safe navigation.
+ * Offline-safe navigation helper.
  *
  * App Router's `router.push` fetches the RSC payload for the target page
  * before switching, so it dies silently when offline and the RSC endpoint
- * can't be reached. Instead of hacking around that, we just do a hard
- * navigation via `window.location.assign`: the browser issues a plain
- * navigation request for the URL, our SW's precache serves the cached HTML,
- * and the page loads — online or offline.
+ * can't be reached. But doing a hard nav unconditionally causes the
+ * next-themes script to re-run on every click, producing a visible
+ * light-mode flash.
  *
- * Slightly less snappy online (full document swap), but reliably works
- * offline, which matters more for a health-tracking PWA on a multi-week
- * offline trip.
+ * Compromise: when `navigator.onLine` reports true, attempt a SPA
+ * navigation via the passed-in router. When offline, bypass the router
+ * and do a hard `window.location.assign()` so the browser issues a plain
+ * navigation request that our SW precache serves.
+ *
+ * The online flag is imperfect on mobile, so when it says "online" and
+ * the SPA nav actually fails we just accept that as a rare edge case;
+ * the user can refresh.
  */
-export function navigateTo(path: string): void {
+type RouterLike = { push: (href: string) => void };
+
+export function navigateTo(path: string, router?: RouterLike): void {
   if (typeof window === "undefined") return;
+  const online = typeof navigator === "undefined" ? true : navigator.onLine !== false;
+  if (online && router) {
+    router.push(path);
+    return;
+  }
   window.location.assign(path);
 }


### PR DESCRIPTION
## Summary

Two targeted follow-ups to the offline work. Both address concrete symptoms reported on Chrome Android:

### 1. Light-mode flash on every navigation
The previous PR hard-navigated on every nav click, which forces next-themes' inline theme-apply script to re-run and produces a visible flash of the default (light) theme before dark mode reapplies. Bad UX online where SPA nav is actually available.

`navigateTo()` now takes an optional router and prefers `router.push()` when `navigator.onLine === true`, falling back to hard `window.location.assign()` only when offline. Online: smooth SPA nav, no theme flash. Offline: hard-nav path that actually hits the SW precache.

### 2. User shouldn't have to type the bypass URL
Every time the device drops offline we now auto-activate the bypass grace inside `ServiceWorkerBootstrap`, which runs at the top of every page boot. `navigator.onLine === false` is the one case where Privy absolutely cannot validate a session, so unconditionally extending the bypass grace is strictly safer than locking the user into a dead sign-in card they can't interact with.

Also listens for the `offline` event, so mid-session disconnects auto-activate the bypass without a reload.

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm lint` clean
- [x] `pnpm test` — 417/417 pass
- [ ] Manual: Chrome Android online — tap nav icons, no theme flash, smooth SPA nav
- [ ] Manual: airplane mode — open PWA, see home page with interactive buttons (no manual bypass URL typing needed)
- [ ] Manual: while using PWA online, flip airplane mode on — `offline` listener activates bypass automatically

https://claude.ai/code/session_01NnP2pGwWLpj6Vv1DaSf5pS