### PR TITLE
feat(pwa): full offline support + service worker control panel

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -4,6 +4,7 @@ import "./globals.css";
 import { Toaster } from "@/components/ui/toaster";
 import { Providers } from "./providers";
 import { UpdateNotification } from "@/components/update-notification";
+import { OfflineIndicator } from "@/components/offline-indicator";
 
 const outfit = Outfit({ 
   subsets: ["latin"],
@@ -45,6 +46,7 @@ export default function RootLayout({
       </head>
       <body className={`${outfit.variable} font-sans antialiased`}>
         <Providers>
+          <OfflineIndicator />
           <main className="min-h-screen bg-gradient-to-b from-slate-50 to-slate-100 dark:from-slate-950 dark:to-slate-900">
             <div className="container mx-auto px-4 py-6 max-w-lg">
               {children}

--- a/src/components/auth-guard.tsx
+++ b/src/components/auth-guard.tsx
@@ -96,11 +96,23 @@ function PrivyAuthGuard({ children, fallback }: AuthGuardProps) {
   // Privy can hang on `ready === false` when offline because its init calls
   // never resolve. Treat the SDK as "ready enough" after a short delay so we
   // can fall through to the remembered-auth check instead of spinning forever.
-  const [readyTimedOut, setReadyTimedOut] = useState(false);
+  // When the device is explicitly offline (navigator.onLine === false — a
+  // reliable false-positive-free signal), we don't wait for the timer at all
+  // because Privy definitely cannot reach its servers and the bootstrap has
+  // already activated the bypass.
+  const [readyTimedOut, setReadyTimedOut] = useState(() => {
+    if (typeof navigator !== "undefined" && navigator.onLine === false) return true;
+    return false;
+  });
   useEffect(() => {
     if (ready) return;
     const t = setTimeout(() => setReadyTimedOut(true), PRIVY_READY_OFFLINE_TIMEOUT_MS);
-    return () => clearTimeout(t);
+    const handleOffline = () => setReadyTimedOut(true);
+    window.addEventListener("offline", handleOffline);
+    return () => {
+      clearTimeout(t);
+      window.removeEventListener("offline", handleOffline);
+    };
   }, [ready]);
 
   // Persist a timestamp on every successful authentication so an offline

--- a/src/components/auth-guard.tsx
+++ b/src/components/auth-guard.tsx
@@ -6,26 +6,23 @@ import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { LogIn, Shield, Loader2, AlertTriangle } from "lucide-react";
+import {
+  BYPASS_KEY,
+  BYPASS_TTL_MS,
+  REMEMBERED_AUTH_KEY,
+  getBypassCode,
+} from "@/lib/auth-bypass";
 
 interface AuthGuardProps {
   children: React.ReactNode;
   fallback?: React.ReactNode;
 }
 
-// Remembered-auth window: how long after the last successful Privy
-// authentication we'll keep granting access while the device is offline.
-// Lets users stay in the PWA on extended offline trips without Privy
-// access tokens silently locking them out when they refresh.
-export const REMEMBERED_AUTH_KEY = "intake-tracker-last-auth";
-const REMEMBERED_AUTH_WINDOW_MS = 18 * 24 * 60 * 60 * 1000;
-const PRIVY_READY_OFFLINE_TIMEOUT_MS = 5000;
+// Re-exported for backwards compatibility — the canonical source is
+// `@/lib/auth-bypass`.
+export { BYPASS_KEY, REMEMBERED_AUTH_KEY };
 
-// TEMPORARY emergency bypass: if the user enters this code on the sign-in
-// screen they get the same 18-day grace as a remembered Privy auth. Intended
-// for offline trips when Privy can't reach its servers; remove once a more
-// permanent offline-auth story is in place.
-export const BYPASS_KEY = "intake-tracker-bypass-auth";
-const DEFAULT_BYPASS_CODE = "meowmeowmeow";
+const PRIVY_READY_OFFLINE_TIMEOUT_MS = 5000;
 
 // URL escape hatch: visiting any page with `?bypass=CODE` activates the
 // bypass and strips the query param. Works when every other button in the
@@ -33,17 +30,13 @@ const DEFAULT_BYPASS_CODE = "meowmeowmeow";
 // users can always recover without clearing site data.
 const BYPASS_QUERY_PARAM = "bypass";
 
-function getBypassCode(): string {
-  return process.env.NEXT_PUBLIC_BYPASS_CODE || DEFAULT_BYPASS_CODE;
-}
-
 function isBypassActive(): boolean {
   if (typeof window === "undefined") return false;
   const raw = window.localStorage.getItem(BYPASS_KEY);
   if (!raw) return false;
   const ts = Number(raw);
   if (!Number.isFinite(ts)) return false;
-  return Date.now() - ts < REMEMBERED_AUTH_WINDOW_MS;
+  return Date.now() - ts < BYPASS_TTL_MS;
 }
 
 function activateBypass(): void {
@@ -74,7 +67,7 @@ function readRememberedAuthTimestamp(): number | null {
 function isRememberedAuthValid(): boolean {
   const ts = readRememberedAuthTimestamp();
   if (ts === null) return false;
-  return Date.now() - ts < REMEMBERED_AUTH_WINDOW_MS;
+  return Date.now() - ts < BYPASS_TTL_MS;
 }
 
 /**
@@ -105,7 +98,10 @@ function PrivyAuthGuard({ children, fallback }: AuthGuardProps) {
   useEffect(() => {
     if (ready) return;
     if (typeof navigator !== "undefined" && navigator.onLine === false) {
+      // Already explicitly offline — skip the timer and "offline" listener
+      // entirely. The next render falls through to remembered-auth/bypass.
       setReadyTimedOut(true);
+      return;
     }
     const t = setTimeout(() => setReadyTimedOut(true), PRIVY_READY_OFFLINE_TIMEOUT_MS);
     const handleOffline = () => setReadyTimedOut(true);
@@ -165,7 +161,7 @@ function PrivyAuthGuard({ children, fallback }: AuthGuardProps) {
 
   // Offline / network-failure grace: if Privy never became ready within the
   // timeout, we couldn't reach its auth servers — honor the last successful
-  // Privy login for up to REMEMBERED_AUTH_WINDOW_MS so the PWA stays usable
+  // Privy login for up to BYPASS_TTL_MS so the PWA stays usable
   // on flaky or absent networks. We intentionally do NOT use navigator.onLine
   // here because mobile devices routinely report online === true while the
   // radio can't actually reach the internet (captive portals, poor signal,

--- a/src/components/auth-guard.tsx
+++ b/src/components/auth-guard.tsx
@@ -8,6 +8,7 @@ import { Input } from "@/components/ui/input";
 import { LogIn, Shield, Loader2, AlertTriangle } from "lucide-react";
 import {
   BYPASS_KEY,
+  BYPASS_TTL_DAYS,
   BYPASS_TTL_MS,
   REMEMBERED_AUTH_KEY,
   activateBypass,
@@ -270,7 +271,7 @@ function EmergencyBypassForm({ onUnlock }: { onUnlock: () => void }) {
         Unlock
       </Button>
       <p className="text-[11px] leading-snug text-muted-foreground">
-        Grants access for 18 days without verifying with the auth server.
+        Grants access for {BYPASS_TTL_DAYS} {BYPASS_TTL_DAYS === 1 ? "day" : "days"} without verifying with the auth server.
         Remove this bypass once normal sign-in works again.
       </p>
     </form>

--- a/src/components/auth-guard.tsx
+++ b/src/components/auth-guard.tsx
@@ -97,15 +97,16 @@ function PrivyAuthGuard({ children, fallback }: AuthGuardProps) {
   // never resolve. Treat the SDK as "ready enough" after a short delay so we
   // can fall through to the remembered-auth check instead of spinning forever.
   // When the device is explicitly offline (navigator.onLine === false — a
-  // reliable false-positive-free signal), we don't wait for the timer at all
-  // because Privy definitely cannot reach its servers and the bootstrap has
-  // already activated the bypass.
-  const [readyTimedOut, setReadyTimedOut] = useState(() => {
-    if (typeof navigator !== "undefined" && navigator.onLine === false) return true;
-    return false;
-  });
+  // reliable false-positive-free signal), we skip the timer entirely because
+  // Privy definitely cannot reach its servers and the bootstrap has already
+  // activated the bypass. Initialized to false so the SSR pass and the first
+  // client render produce the same markup; the effect below promotes it.
+  const [readyTimedOut, setReadyTimedOut] = useState(false);
   useEffect(() => {
     if (ready) return;
+    if (typeof navigator !== "undefined" && navigator.onLine === false) {
+      setReadyTimedOut(true);
+    }
     const t = setTimeout(() => setReadyTimedOut(true), PRIVY_READY_OFFLINE_TIMEOUT_MS);
     const handleOffline = () => setReadyTimedOut(true);
     window.addEventListener("offline", handleOffline);

--- a/src/components/auth-guard.tsx
+++ b/src/components/auth-guard.tsx
@@ -10,6 +10,7 @@ import {
   BYPASS_KEY,
   BYPASS_TTL_MS,
   REMEMBERED_AUTH_KEY,
+  activateBypass,
   getBypassCode,
 } from "@/lib/auth-bypass";
 
@@ -37,11 +38,6 @@ function isBypassActive(): boolean {
   const ts = Number(raw);
   if (!Number.isFinite(ts)) return false;
   return Date.now() - ts < BYPASS_TTL_MS;
-}
-
-function activateBypass(): void {
-  if (typeof window === "undefined") return;
-  window.localStorage.setItem(BYPASS_KEY, String(Date.now()));
 }
 
 /**
@@ -132,7 +128,8 @@ function PrivyAuthGuard({ children, fallback }: AuthGuardProps) {
     const url = new URL(window.location.href);
     const code = url.searchParams.get(BYPASS_QUERY_PARAM);
     if (!code) return;
-    if (code === getBypassCode()) {
+    const expected = getBypassCode();
+    if (expected !== null && code === expected) {
       activateBypass();
       setBypassTick((n) => n + 1);
     }
@@ -219,9 +216,16 @@ function EmergencyBypassForm({ onUnlock }: { onUnlock: () => void }) {
   const [code, setCode] = useState("");
   const [error, setError] = useState(false);
 
+  // Bypass is disabled when no code is configured. Hide the entry point
+  // entirely so users don't see a dead form.
+  if (getBypassCode() === null) {
+    return null;
+  }
+
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
-    if (code.trim() === getBypassCode()) {
+    const expected = getBypassCode();
+    if (expected !== null && code.trim() === expected) {
       activateBypass();
       onUnlock();
     } else {

--- a/src/components/debug-panel.tsx
+++ b/src/components/debug-panel.tsx
@@ -39,7 +39,9 @@ import {
   Database,
   FileText,
   Package,
+  HardDriveDownload,
 } from "lucide-react";
+import { ServiceWorkerPanel } from "@/components/debug/service-worker-panel";
 
 // ---------------------------------------------------------------------------
 // Audit action options for filter
@@ -520,11 +522,39 @@ export function DebugPanel() {
         <DialogHeader>
           <DialogTitle>Debug Panel</DialogTitle>
           <DialogDescription>
-            Audit logs, stock management, and raw database records.
+            Service worker, audit logs, stock management, and raw database records.
           </DialogDescription>
         </DialogHeader>
 
         <div className="space-y-4">
+          {/* Section 0: Service Worker / Offline */}
+          <Collapsible
+            open={activeSection === "sw"}
+            onOpenChange={(open) =>
+              setActiveSection(open ? "sw" : null)
+            }
+          >
+            <CollapsibleTrigger asChild>
+              <Button
+                variant="ghost"
+                className="w-full justify-between h-9 text-sm"
+              >
+                <span className="flex items-center gap-2">
+                  <HardDriveDownload className="h-4 w-4" />
+                  Service Worker &amp; Offline
+                </span>
+                {activeSection === "sw" ? (
+                  <ChevronDown className="h-4 w-4" />
+                ) : (
+                  <ChevronRight className="h-4 w-4" />
+                )}
+              </Button>
+            </CollapsibleTrigger>
+            <CollapsibleContent className="pt-2">
+              <ServiceWorkerPanel />
+            </CollapsibleContent>
+          </Collapsible>
+
           {/* Section 1: Audit Log Viewer */}
           <Collapsible
             open={activeSection === "audit"}

--- a/src/components/debug/service-worker-panel.tsx
+++ b/src/components/debug/service-worker-panel.tsx
@@ -1,0 +1,486 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import { Button } from "@/components/ui/button";
+import { Card } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import {
+  CheckCircle2,
+  XCircle,
+  AlertTriangle,
+  RefreshCw,
+  Trash2,
+  Wifi,
+  WifiOff,
+  Download,
+  Power,
+} from "lucide-react";
+import { useServiceWorker } from "@/hooks/use-service-worker";
+import { useOnlineStatus } from "@/hooks/use-online-status";
+
+interface CacheEntry {
+  name: string;
+  size: number;
+}
+
+const BYPASS_KEY = "intake-tracker-bypass-auth";
+const REMEMBERED_AUTH_KEY = "intake-tracker-last-auth";
+
+function formatTimestamp(ts: number | null): string {
+  if (!ts) return "never";
+  return new Date(ts).toLocaleString();
+}
+
+export function ServiceWorkerPanel() {
+  const {
+    isRegistered,
+    registrationError,
+    registration,
+    isUpdateAvailable,
+    isUpdating,
+    registerServiceWorker,
+    unregisterServiceWorker,
+    forceSkipWaiting,
+    checkForUpdates,
+    applyUpdate,
+  } = useServiceWorker();
+  const isOnline = useOnlineStatus();
+
+  const [caches, setCaches] = useState<CacheEntry[]>([]);
+  const [activeWorkerState, setActiveWorkerState] = useState<string>("none");
+  const [waitingWorkerState, setWaitingWorkerState] = useState<string>("none");
+  const [scope, setScope] = useState<string>("");
+  const [scriptUrl, setScriptUrl] = useState<string>("");
+  const [busyAction, setBusyAction] = useState<string | null>(null);
+  const [lastResult, setLastResult] = useState<{
+    kind: "info" | "success" | "error";
+    message: string;
+  } | null>(null);
+  const [bypassActive, setBypassActive] = useState(false);
+  const [rememberedAuth, setRememberedAuth] = useState<number | null>(null);
+
+  const refreshCacheList = useCallback(async () => {
+    if (typeof window === "undefined" || !("caches" in window)) {
+      setCaches([]);
+      return;
+    }
+    try {
+      const names = await window.caches.keys();
+      const entries: CacheEntry[] = [];
+      for (const name of names) {
+        try {
+          const cache = await window.caches.open(name);
+          const keys = await cache.keys();
+          entries.push({ name, size: keys.length });
+        } catch {
+          entries.push({ name, size: 0 });
+        }
+      }
+      entries.sort((a, b) => a.name.localeCompare(b.name));
+      setCaches(entries);
+    } catch {
+      setCaches([]);
+    }
+  }, []);
+
+  const refreshRegistration = useCallback(async () => {
+    if (typeof navigator === "undefined" || !("serviceWorker" in navigator)) {
+      return;
+    }
+    try {
+      const reg = await navigator.serviceWorker.getRegistration();
+      setActiveWorkerState(reg?.active?.state ?? "none");
+      setWaitingWorkerState(reg?.waiting?.state ?? "none");
+      setScope(reg?.scope ?? "");
+      setScriptUrl(reg?.active?.scriptURL ?? reg?.installing?.scriptURL ?? "");
+    } catch {
+      setActiveWorkerState("error");
+      setWaitingWorkerState("error");
+    }
+  }, []);
+
+  const refreshAuthState = useCallback(() => {
+    if (typeof window === "undefined") return;
+    const bypass = window.localStorage.getItem(BYPASS_KEY);
+    setBypassActive(!!bypass);
+    const remembered = window.localStorage.getItem(REMEMBERED_AUTH_KEY);
+    const ts = remembered ? Number(remembered) : NaN;
+    setRememberedAuth(Number.isFinite(ts) ? ts : null);
+  }, []);
+
+  useEffect(() => {
+    refreshCacheList();
+    refreshRegistration();
+    refreshAuthState();
+  }, [refreshCacheList, refreshRegistration, refreshAuthState, registration, isRegistered]);
+
+  const runAction = useCallback(
+    async (key: string, fn: () => Promise<{ success: boolean; message: string }>) => {
+      setBusyAction(key);
+      setLastResult(null);
+      try {
+        const result = await fn();
+        setLastResult({
+          kind: result.success ? "success" : "error",
+          message: result.message,
+        });
+      } catch (e) {
+        setLastResult({
+          kind: "error",
+          message: e instanceof Error ? e.message : "Unknown error",
+        });
+      } finally {
+        setBusyAction(null);
+        await refreshCacheList();
+        await refreshRegistration();
+        refreshAuthState();
+      }
+    },
+    [refreshCacheList, refreshRegistration, refreshAuthState],
+  );
+
+  const handleRegister = () =>
+    runAction("register", async () => {
+      const result = await registerServiceWorker();
+      return {
+        success: result.success,
+        message: result.success
+          ? "Service worker registered."
+          : `Registration failed: ${result.error ?? "unknown"}`,
+      };
+    });
+
+  const handleUnregister = () =>
+    runAction("unregister", async () => {
+      const ok = await unregisterServiceWorker();
+      return {
+        success: ok,
+        message: ok
+          ? "Service worker unregistered. Reload the page to take effect."
+          : "Failed to unregister service worker.",
+      };
+    });
+
+  const handleCheck = () =>
+    runAction("check", async () => {
+      const found = await checkForUpdates();
+      return {
+        success: true,
+        message: found
+          ? "Update available — use 'Apply update' to install."
+          : "No update available — already on the latest service worker.",
+      };
+    });
+
+  const handleApplyUpdate = () =>
+    runAction("apply-update", async () => {
+      await applyUpdate();
+      return {
+        success: true,
+        message: "Update applied. The page will reload when the new worker takes control.",
+      };
+    });
+
+  const handleSkipWaiting = () =>
+    runAction("skip-waiting", async () => {
+      const ok = await forceSkipWaiting();
+      return {
+        success: ok,
+        message: ok
+          ? "Skip-waiting message sent. The waiting worker will activate."
+          : "No waiting worker to activate.",
+      };
+    });
+
+  const handleClearCaches = () =>
+    runAction("clear-caches", async () => {
+      if (typeof window === "undefined" || !("caches" in window)) {
+        return { success: false, message: "Cache API not available." };
+      }
+      const names = await window.caches.keys();
+      let cleared = 0;
+      for (const name of names) {
+        const ok = await window.caches.delete(name);
+        if (ok) cleared++;
+      }
+      return {
+        success: true,
+        message: `Cleared ${cleared} cache${cleared === 1 ? "" : "s"}.`,
+      };
+    });
+
+  const handleNuke = () =>
+    runAction("nuke", async () => {
+      let unregistered = 0;
+      let cleared = 0;
+      if ("serviceWorker" in navigator) {
+        const regs = await navigator.serviceWorker.getRegistrations();
+        for (const reg of regs) {
+          if (await reg.unregister()) unregistered++;
+        }
+      }
+      if (typeof window !== "undefined" && "caches" in window) {
+        const names = await window.caches.keys();
+        for (const name of names) {
+          if (await window.caches.delete(name)) cleared++;
+        }
+      }
+      return {
+        success: true,
+        message: `Unregistered ${unregistered} worker${unregistered === 1 ? "" : "s"}, cleared ${cleared} cache${cleared === 1 ? "" : "s"}. Reload to start fresh.`,
+      };
+    });
+
+  const handleActivateBypass = () =>
+    runAction("activate-bypass", async () => {
+      window.localStorage.setItem(BYPASS_KEY, String(Date.now()));
+      return {
+        success: true,
+        message: "Auth bypass activated for 18 days.",
+      };
+    });
+
+  const handleClearBypass = () =>
+    runAction("clear-bypass", async () => {
+      window.localStorage.removeItem(BYPASS_KEY);
+      return {
+        success: true,
+        message: "Auth bypass cleared.",
+      };
+    });
+
+  const swSupported =
+    typeof navigator !== "undefined" && "serviceWorker" in navigator;
+  const cacheSupported = typeof window !== "undefined" && "caches" in window;
+  const totalCacheEntries = caches.reduce((acc, c) => acc + c.size, 0);
+
+  return (
+    <div className="space-y-3">
+      {/* Status overview */}
+      <Card className="p-3 text-xs space-y-2">
+        <div className="flex items-center justify-between">
+          <span className="font-medium">Status</span>
+          <div className="flex items-center gap-1.5">
+            {isOnline ? (
+              <Badge variant="outline" className="gap-1 text-[10px]">
+                <Wifi className="h-3 w-3 text-emerald-600 dark:text-emerald-400" />
+                Online
+              </Badge>
+            ) : (
+              <Badge variant="outline" className="gap-1 text-[10px]">
+                <WifiOff className="h-3 w-3 text-amber-600 dark:text-amber-400" />
+                Offline
+              </Badge>
+            )}
+            {!swSupported ? (
+              <Badge variant="destructive" className="text-[10px]">
+                Not supported
+              </Badge>
+            ) : isRegistered ? (
+              <Badge variant="outline" className="gap-1 text-[10px]">
+                <CheckCircle2 className="h-3 w-3 text-emerald-600 dark:text-emerald-400" />
+                Registered
+              </Badge>
+            ) : (
+              <Badge variant="outline" className="gap-1 text-[10px]">
+                <XCircle className="h-3 w-3 text-muted-foreground" />
+                Not registered
+              </Badge>
+            )}
+            {isUpdateAvailable && (
+              <Badge variant="outline" className="gap-1 text-[10px]">
+                <Download className="h-3 w-3 text-blue-600 dark:text-blue-400" />
+                Update ready
+              </Badge>
+            )}
+          </div>
+        </div>
+
+        <div className="grid grid-cols-2 gap-x-3 gap-y-0.5 font-mono text-[11px]">
+          <span className="text-muted-foreground">Active worker:</span>
+          <span>{activeWorkerState}</span>
+          <span className="text-muted-foreground">Waiting worker:</span>
+          <span>{waitingWorkerState}</span>
+          <span className="text-muted-foreground">Scope:</span>
+          <span className="truncate">{scope || "—"}</span>
+          <span className="text-muted-foreground">Script:</span>
+          <span className="truncate">
+            {scriptUrl ? scriptUrl.replace(window.location.origin, "") : "—"}
+          </span>
+          <span className="text-muted-foreground">Caches:</span>
+          <span>
+            {caches.length} ({totalCacheEntries} entries)
+          </span>
+        </div>
+
+        {registrationError && (
+          <div className="flex items-start gap-1.5 text-[11px] text-amber-700 dark:text-amber-300">
+            <AlertTriangle className="h-3 w-3 mt-0.5 shrink-0" />
+            <span>{registrationError}</span>
+          </div>
+        )}
+      </Card>
+
+      {/* Actions */}
+      <div className="space-y-2">
+        <div className="text-[11px] font-medium uppercase tracking-wide text-muted-foreground">
+          Worker
+        </div>
+        <div className="flex flex-wrap gap-2">
+          <Button
+            size="sm"
+            variant="outline"
+            className="h-8 text-xs"
+            onClick={handleRegister}
+            disabled={busyAction !== null || !swSupported}
+          >
+            <Power className="h-3 w-3 mr-1" />
+            {isRegistered ? "Re-register" : "Register"}
+          </Button>
+          <Button
+            size="sm"
+            variant="outline"
+            className="h-8 text-xs"
+            onClick={handleUnregister}
+            disabled={busyAction !== null || !swSupported || !isRegistered}
+          >
+            <XCircle className="h-3 w-3 mr-1" />
+            Unregister
+          </Button>
+          <Button
+            size="sm"
+            variant="outline"
+            className="h-8 text-xs"
+            onClick={handleCheck}
+            disabled={busyAction !== null || !swSupported || !isRegistered}
+          >
+            <RefreshCw
+              className={`h-3 w-3 mr-1 ${busyAction === "check" ? "animate-spin" : ""}`}
+            />
+            Check for update
+          </Button>
+          <Button
+            size="sm"
+            variant="outline"
+            className="h-8 text-xs"
+            onClick={handleApplyUpdate}
+            disabled={busyAction !== null || !isUpdateAvailable || isUpdating}
+          >
+            <Download className="h-3 w-3 mr-1" />
+            Apply update
+          </Button>
+          <Button
+            size="sm"
+            variant="outline"
+            className="h-8 text-xs"
+            onClick={handleSkipWaiting}
+            disabled={busyAction !== null || waitingWorkerState === "none"}
+          >
+            Skip waiting
+          </Button>
+        </div>
+      </div>
+
+      <div className="space-y-2">
+        <div className="text-[11px] font-medium uppercase tracking-wide text-muted-foreground">
+          Caches
+        </div>
+        <div className="flex flex-wrap gap-2">
+          <Button
+            size="sm"
+            variant="outline"
+            className="h-8 text-xs"
+            onClick={refreshCacheList}
+            disabled={busyAction !== null || !cacheSupported}
+          >
+            <RefreshCw className="h-3 w-3 mr-1" />
+            Refresh list
+          </Button>
+          <Button
+            size="sm"
+            variant="outline"
+            className="h-8 text-xs"
+            onClick={handleClearCaches}
+            disabled={busyAction !== null || !cacheSupported || caches.length === 0}
+          >
+            <Trash2 className="h-3 w-3 mr-1" />
+            Clear all caches
+          </Button>
+          <Button
+            size="sm"
+            variant="destructive"
+            className="h-8 text-xs"
+            onClick={handleNuke}
+            disabled={busyAction !== null || !swSupported}
+          >
+            <Trash2 className="h-3 w-3 mr-1" />
+            Nuke (unregister + clear)
+          </Button>
+        </div>
+        {caches.length > 0 && (
+          <Card className="p-3 text-[11px] font-mono space-y-1">
+            {caches.map((c) => (
+              <div key={c.name} className="flex justify-between gap-2">
+                <span className="truncate" title={c.name}>{c.name}</span>
+                <span className="text-muted-foreground shrink-0">{c.size} entries</span>
+              </div>
+            ))}
+          </Card>
+        )}
+      </div>
+
+      <div className="space-y-2">
+        <div className="text-[11px] font-medium uppercase tracking-wide text-muted-foreground">
+          Auth (offline mode)
+        </div>
+        <Card className="p-3 text-[11px] space-y-2">
+          <div className="grid grid-cols-2 gap-x-3 gap-y-0.5">
+            <span className="text-muted-foreground">Bypass active:</span>
+            <span>{bypassActive ? "yes" : "no"}</span>
+            <span className="text-muted-foreground">Last Privy login:</span>
+            <span>{formatTimestamp(rememberedAuth)}</span>
+          </div>
+          <div className="flex flex-wrap gap-2">
+            <Button
+              size="sm"
+              variant="outline"
+              className="h-8 text-xs"
+              onClick={handleActivateBypass}
+              disabled={busyAction !== null}
+            >
+              Activate bypass (18 days)
+            </Button>
+            <Button
+              size="sm"
+              variant="outline"
+              className="h-8 text-xs"
+              onClick={handleClearBypass}
+              disabled={busyAction !== null || !bypassActive}
+            >
+              Clear bypass
+            </Button>
+          </div>
+          <p className="text-[10px] text-muted-foreground leading-snug">
+            The bypass code grants 18 days of offline access. The bootstrap
+            activates it automatically when the device is offline so the
+            sign-in screen never traps the user.
+          </p>
+        </Card>
+      </div>
+
+      {lastResult && (
+        <Card
+          className={`p-2.5 text-[11px] ${
+            lastResult.kind === "success"
+              ? "border-emerald-300 bg-emerald-50 text-emerald-900 dark:border-emerald-800 dark:bg-emerald-950/40 dark:text-emerald-200"
+              : lastResult.kind === "error"
+                ? "border-red-300 bg-red-50 text-red-900 dark:border-red-800 dark:bg-red-950/40 dark:text-red-200"
+                : ""
+          }`}
+        >
+          {lastResult.message}
+        </Card>
+      )}
+    </div>
+  );
+}

--- a/src/components/debug/service-worker-panel.tsx
+++ b/src/components/debug/service-worker-panel.tsx
@@ -19,6 +19,7 @@ import { useServiceWorker } from "@/hooks/use-service-worker";
 import { useOnlineStatus } from "@/hooks/use-online-status";
 import {
   BYPASS_KEY,
+  BYPASS_TTL_DAYS,
   REMEMBERED_AUTH_KEY,
   activateBypass,
   clearBypass,
@@ -208,6 +209,12 @@ export function ServiceWorkerPanel() {
           message: "No service worker registered — register first.",
         };
       }
+      if (result.updateInProgress) {
+        return {
+          success: true,
+          message: "Update is installing — try 'Apply update' again once it's ready.",
+        };
+      }
       if (!result.activated) {
         return {
           success: false,
@@ -275,7 +282,7 @@ export function ServiceWorkerPanel() {
       activateBypass();
       return {
         success: true,
-        message: "Auth bypass activated for 18 days.",
+        message: `Auth bypass activated for ${BYPASS_TTL_DAYS} ${BYPASS_TTL_DAYS === 1 ? "day" : "days"}.`,
       };
     });
 
@@ -491,7 +498,7 @@ export function ServiceWorkerPanel() {
               onClick={handleActivateBypass}
               disabled={busyAction !== null}
             >
-              Activate bypass (18 days)
+              Activate bypass ({BYPASS_TTL_DAYS} {BYPASS_TTL_DAYS === 1 ? "day" : "days"})
             </Button>
             <Button
               size="sm"
@@ -504,7 +511,7 @@ export function ServiceWorkerPanel() {
             </Button>
           </div>
           <p className="text-[10px] text-muted-foreground leading-snug">
-            The bypass code grants 18 days of offline access. The bootstrap
+            The bypass code grants {BYPASS_TTL_DAYS} {BYPASS_TTL_DAYS === 1 ? "day" : "days"} of offline access. The bootstrap
             activates it automatically when the device is offline so the
             sign-in screen never traps the user.
           </p>

--- a/src/components/debug/service-worker-panel.tsx
+++ b/src/components/debug/service-worker-panel.tsx
@@ -112,6 +112,19 @@ export function ServiceWorkerPanel() {
     refreshCacheList();
     refreshRegistration();
     refreshAuthState();
+
+    // Cross-tab sync: another tab activating/clearing the bypass should be
+    // reflected here without requiring the user to reopen the panel.
+    if (typeof window === "undefined") return;
+    const handleStorage = (e: StorageEvent) => {
+      if (e.key === BYPASS_KEY || e.key === REMEMBERED_AUTH_KEY || e.key === null) {
+        refreshAuthState();
+      }
+    };
+    window.addEventListener("storage", handleStorage);
+    return () => {
+      window.removeEventListener("storage", handleStorage);
+    };
   }, [refreshCacheList, refreshRegistration, refreshAuthState, registration, isRegistered]);
 
   const runAction = useCallback(
@@ -174,7 +187,16 @@ export function ServiceWorkerPanel() {
 
   const handleApplyUpdate = () =>
     runAction("apply-update", async () => {
-      await applyUpdate();
+      const result = await applyUpdate();
+      if (result.error) {
+        return { success: false, message: `Failed to apply update: ${result.error}` };
+      }
+      if (!result.activated) {
+        return {
+          success: false,
+          message: "No waiting worker to activate — already up to date.",
+        };
+      }
       return {
         success: true,
         message: "Update applied. The page will reload when the new worker takes control.",
@@ -253,6 +275,12 @@ export function ServiceWorkerPanel() {
     typeof navigator !== "undefined" && "serviceWorker" in navigator;
   const cacheSupported = typeof window !== "undefined" && "caches" in window;
   const totalCacheEntries = caches.reduce((acc, c) => acc + c.size, 0);
+  const safeOrigin = typeof window !== "undefined" ? window.location.origin : "";
+  const displayedScriptUrl = scriptUrl
+    ? safeOrigin
+      ? scriptUrl.replace(safeOrigin, "")
+      : scriptUrl
+    : "—";
 
   return (
     <div className="space-y-3">
@@ -304,9 +332,7 @@ export function ServiceWorkerPanel() {
           <span className="text-muted-foreground">Scope:</span>
           <span className="truncate">{scope || "—"}</span>
           <span className="text-muted-foreground">Script:</span>
-          <span className="truncate">
-            {scriptUrl ? scriptUrl.replace(window.location.origin, "") : "—"}
-          </span>
+          <span className="truncate">{displayedScriptUrl}</span>
           <span className="text-muted-foreground">Caches:</span>
           <span>
             {caches.length} ({totalCacheEntries} entries)

--- a/src/components/debug/service-worker-panel.tsx
+++ b/src/components/debug/service-worker-panel.tsx
@@ -17,14 +17,12 @@ import {
 } from "lucide-react";
 import { useServiceWorker } from "@/hooks/use-service-worker";
 import { useOnlineStatus } from "@/hooks/use-online-status";
+import { BYPASS_KEY, REMEMBERED_AUTH_KEY } from "@/lib/auth-bypass";
 
 interface CacheEntry {
   name: string;
   size: number;
 }
-
-const BYPASS_KEY = "intake-tracker-bypass-auth";
-const REMEMBERED_AUTH_KEY = "intake-tracker-last-auth";
 
 function formatTimestamp(ts: number | null): string {
   if (!ts) return "never";
@@ -66,16 +64,17 @@ export function ServiceWorkerPanel() {
     }
     try {
       const names = await window.caches.keys();
-      const entries: CacheEntry[] = [];
-      for (const name of names) {
-        try {
-          const cache = await window.caches.open(name);
-          const keys = await cache.keys();
-          entries.push({ name, size: keys.length });
-        } catch {
-          entries.push({ name, size: 0 });
-        }
-      }
+      const entries = await Promise.all(
+        names.map(async (name): Promise<CacheEntry> => {
+          try {
+            const cache = await window.caches.open(name);
+            const keys = await cache.keys();
+            return { name, size: keys.length };
+          } catch {
+            return { name, size: 0 };
+          }
+        }),
+      );
       entries.sort((a, b) => a.name.localeCompare(b.name));
       setCaches(entries);
     } catch {
@@ -112,9 +111,13 @@ export function ServiceWorkerPanel() {
     refreshCacheList();
     refreshRegistration();
     refreshAuthState();
+  }, [refreshCacheList, refreshRegistration, refreshAuthState, registration, isRegistered]);
 
-    // Cross-tab sync: another tab activating/clearing the bypass should be
-    // reflected here without requiring the user to reopen the panel.
+  // Cross-tab sync: another tab activating/clearing the bypass should be
+  // reflected here without requiring the user to reopen the panel. Mounted
+  // once for the lifetime of the component so it isn't re-attached on every
+  // SW state change.
+  useEffect(() => {
     if (typeof window === "undefined") return;
     const handleStorage = (e: StorageEvent) => {
       if (e.key === BYPASS_KEY || e.key === REMEMBERED_AUTH_KEY || e.key === null) {
@@ -125,7 +128,10 @@ export function ServiceWorkerPanel() {
     return () => {
       window.removeEventListener("storage", handleStorage);
     };
-  }, [refreshCacheList, refreshRegistration, refreshAuthState, registration, isRegistered]);
+    // refreshAuthState is a stable useCallback (no deps), so an empty array
+    // is correct here.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   const runAction = useCallback(
     async (key: string, fn: () => Promise<{ success: boolean; message: string }>) => {

--- a/src/components/debug/service-worker-panel.tsx
+++ b/src/components/debug/service-worker-panel.tsx
@@ -17,7 +17,12 @@ import {
 } from "lucide-react";
 import { useServiceWorker } from "@/hooks/use-service-worker";
 import { useOnlineStatus } from "@/hooks/use-online-status";
-import { BYPASS_KEY, REMEMBERED_AUTH_KEY } from "@/lib/auth-bypass";
+import {
+  BYPASS_KEY,
+  REMEMBERED_AUTH_KEY,
+  activateBypass,
+  clearBypass,
+} from "@/lib/auth-bypass";
 
 interface CacheEntry {
   name: string;
@@ -197,6 +202,12 @@ export function ServiceWorkerPanel() {
       if (result.error) {
         return { success: false, message: `Failed to apply update: ${result.error}` };
       }
+      if (result.noRegistration) {
+        return {
+          success: false,
+          message: "No service worker registered — register first.",
+        };
+      }
       if (!result.activated) {
         return {
           success: false,
@@ -261,7 +272,7 @@ export function ServiceWorkerPanel() {
 
   const handleActivateBypass = () =>
     runAction("activate-bypass", async () => {
-      window.localStorage.setItem(BYPASS_KEY, String(Date.now()));
+      activateBypass();
       return {
         success: true,
         message: "Auth bypass activated for 18 days.",
@@ -270,7 +281,7 @@ export function ServiceWorkerPanel() {
 
   const handleClearBypass = () =>
     runAction("clear-bypass", async () => {
-      window.localStorage.removeItem(BYPASS_KEY);
+      clearBypass();
       return {
         success: true,
         message: "Auth bypass cleared.",

--- a/src/components/food-salt/food-section.tsx
+++ b/src/components/food-salt/food-section.tsx
@@ -15,7 +15,7 @@ import { Loader2, Sparkles } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { CARD_THEMES } from "@/lib/card-themes";
 import { RecentEntriesList, InlineEditFormShell } from "@/components/recent-entries-list";
-import { parseIntakeWithAI } from "@/lib/ai-client";
+import { parseIntakeWithAI, OfflineError } from "@/lib/ai-client";
 import {
   useAddComposableEntry,
   type ComposableEntryInput,
@@ -165,12 +165,20 @@ export function FoodSection() {
           variant: "default",
         });
       }
-    } catch {
-      toast({
-        title: "AI parsing failed",
-        description: "Try again or add details manually.",
-        variant: "destructive",
-      });
+    } catch (err) {
+      if (err instanceof OfflineError) {
+        toast({
+          title: "AI offline",
+          description: "You're offline — fill the fields manually.",
+          variant: "default",
+        });
+      } else {
+        toast({
+          title: "AI parsing failed",
+          description: "Try again or add details manually.",
+          variant: "destructive",
+        });
+      }
     } finally {
       setIsParsing(false);
     }

--- a/src/components/food-salt/food-section.tsx
+++ b/src/components/food-salt/food-section.tsx
@@ -31,6 +31,7 @@ import { useSaltTotalsByGroupIds, useDeleteIntake, useUpdateIntake } from "@/hoo
 import { useEditRecord } from "@/hooks/use-edit-record";
 import { useToast } from "@/hooks/use-toast";
 import { useAuth } from "@/components/auth-guard";
+import { useOnlineStatus } from "@/hooks/use-online-status";
 import { type EatingRecord } from "@/lib/db";
 import {
   getCurrentDateTimeLocal,
@@ -53,6 +54,7 @@ const SODIUM_MULTIPLIERS: Record<SodiumSource, number> = {
 export function FoodSection() {
   const { toast } = useToast();
   const { getAuthHeader } = useAuth();
+  const isOnline = useOnlineStatus();
   const addComposableEntry = useAddComposableEntry();
 
   // ─── Mutations ────────────────────────────────────────────────────
@@ -130,6 +132,15 @@ export function FoodSection() {
     const trimmed = foodText.trim();
     if (!trimmed || isParsing) return;
 
+    if (!isOnline) {
+      toast({
+        title: "AI offline",
+        description: "Connect to the internet to parse food, or fill the fields manually.",
+        variant: "default",
+      });
+      return;
+    }
+
     setIsParsing(true);
     try {
       const authHeaders = await getAuthHeader();
@@ -163,7 +174,7 @@ export function FoodSection() {
     } finally {
       setIsParsing(false);
     }
-  }, [foodText, isParsing, toast, getAuthHeader]);
+  }, [foodText, isParsing, isOnline, toast, getAuthHeader]);
 
   const handleDetailSubmit = useCallback(async () => {
     if (isSubmitting) return;
@@ -271,8 +282,9 @@ export function FoodSection() {
         <button
           type="button"
           onClick={handleParse}
-          disabled={!foodText.trim() || isParsing}
-          aria-label="Parse food with AI"
+          disabled={!foodText.trim() || isParsing || !isOnline}
+          aria-label={isOnline ? "Parse food with AI" : "AI parse unavailable while offline"}
+          title={isOnline ? "Parse food with AI" : "AI parse unavailable while offline"}
           className={cn(
             "absolute right-2 top-1/2 -translate-y-1/2 p-1 rounded-md transition-colors",
             "text-muted-foreground hover:text-orange-600 dark:hover:text-orange-400",

--- a/src/components/liquids/preset-tab.tsx
+++ b/src/components/liquids/preset-tab.tsx
@@ -14,6 +14,7 @@ import { useIntake } from "@/hooks/use-intake-queries";
 import { useAddComposableEntry, type ComposableEntryInput } from "@/hooks/use-composable-entry";
 import { useToast } from "@/hooks/use-toast";
 import { useAuth } from "@/components/auth-guard";
+import { useOnlineStatus } from "@/hooks/use-online-status";
 import {
   AlertDialog,
   AlertDialogAction,
@@ -53,6 +54,7 @@ export function PresetTab({ tab }: PresetTabProps) {
   const addEntry = useAddComposableEntry();
   const { toast } = useToast();
   const { getAuthHeader } = useAuth();
+  const isOnline = useOnlineStatus();
 
   // Water progress data
   const settings = useSettings();
@@ -180,6 +182,14 @@ export function PresetTab({ tab }: PresetTabProps) {
 
   const handleAiLookup = async () => {
     if (!searchText.trim() || isLookingUp) return;
+    if (!isOnline) {
+      toast({
+        title: "AI offline",
+        description: "Connect to the internet to look up beverages, or fill the fields manually.",
+        variant: "default",
+      });
+      return;
+    }
     setIsLookingUp(true);
     setSelectedPresetId(null);
     try {
@@ -445,9 +455,10 @@ export function PresetTab({ tab }: PresetTabProps) {
         <button
           type="button"
           onClick={handleAiLookup}
-          disabled={!searchText.trim() || isLookingUp}
+          disabled={!searchText.trim() || isLookingUp || !isOnline}
           className="absolute right-2 top-1/2 -translate-y-1/2 p-1 rounded-md text-muted-foreground hover:text-foreground disabled:opacity-50 disabled:cursor-not-allowed"
-          aria-label="Look up substance content"
+          aria-label={isOnline ? "Look up substance content" : "AI lookup unavailable while offline"}
+          title={isOnline ? "Look up substance content" : "AI lookup unavailable while offline"}
         >
           {isLookingUp ? (
             <Loader2 className="w-4 h-4 animate-spin" />

--- a/src/components/medications/add-medication-wizard.tsx
+++ b/src/components/medications/add-medication-wizard.tsx
@@ -916,6 +916,7 @@ function IndicationStep({
                   size="sm"
                   onClick={onRefreshAI}
                   disabled={isRefreshing || !isOnline}
+                  aria-label={isOnline ? "AI Suggest" : "AI offline — suggestions unavailable"}
                   title={isOnline ? "AI Suggest" : "AI offline — suggestions unavailable"}
                   className="h-7 text-xs gap-1 text-teal-600"
                 >

--- a/src/components/medications/add-medication-wizard.tsx
+++ b/src/components/medications/add-medication-wizard.tsx
@@ -15,6 +15,7 @@ import { useMedicineSearch, type MedicineSearchResult } from "@/hooks/use-medici
 import { useAddPrescription, usePrescriptions, useAddMedicationToPrescription, usePhasesForPrescription } from "@/hooks/use-medication-queries";
 import { useToast } from "@/hooks/use-toast";
 import { useOnlineStatus } from "@/hooks/use-online-status";
+import { OfflineError } from "@/lib/ai-client";
 import { Switch } from "@/components/ui/switch";
 import type { PillShape, FoodInstruction, Prescription, MedicationPhase } from "@/lib/db";
 import { ArrowLeft, ArrowRight, Search, Loader2, Check, Plus, X, AlertTriangle } from "lucide-react";
@@ -254,8 +255,19 @@ export function AddMedicationWizard({ open, onOpenChange }: AddMedicationWizardP
         const shape = result.pillShape.toLowerCase() as PillShape;
         if (PILL_SHAPES.some((s) => s.value === shape)) setPillShape(shape);
       }
-    } catch {
-      // error is in searchMutation.error
+    } catch (err) {
+      // searchMutation.error already drives the inline message under the
+      // search input; add a toast for the offline case so the reason is
+      // hard to miss when the device drops connection mid-request.
+      if (err instanceof OfflineError) {
+        toast({
+          title: "AI offline",
+          description: "Medication search needs an internet connection. Fill the fields below manually.",
+          variant: "default",
+        });
+      } else {
+        console.error("Medicine search failed:", err);
+      }
     }
   };
 
@@ -707,6 +719,7 @@ function SearchStep({
             onClick={onSearch}
             disabled={isSearching || !query.trim() || !isOnline}
             size="icon"
+            aria-label={isOnline ? "Search with AI" : "AI search unavailable while offline"}
             title={isOnline ? "Search with AI" : "AI search unavailable while offline"}
             className="shrink-0 bg-teal-600 hover:bg-teal-700"
           >

--- a/src/components/medications/add-medication-wizard.tsx
+++ b/src/components/medications/add-medication-wizard.tsx
@@ -14,6 +14,7 @@ import { PillIcon } from "./pill-icon";
 import { useMedicineSearch, type MedicineSearchResult } from "@/hooks/use-medicine-search";
 import { useAddPrescription, usePrescriptions, useAddMedicationToPrescription, usePhasesForPrescription } from "@/hooks/use-medication-queries";
 import { useToast } from "@/hooks/use-toast";
+import { useOnlineStatus } from "@/hooks/use-online-status";
 import { Switch } from "@/components/ui/switch";
 import type { PillShape, FoodInstruction, Prescription, MedicationPhase } from "@/lib/db";
 import { ArrowLeft, ArrowRight, Search, Loader2, Check, Plus, X, AlertTriangle } from "lucide-react";
@@ -112,6 +113,7 @@ function capitalizeWords(str: string) {
 
 export function AddMedicationWizard({ open, onOpenChange }: AddMedicationWizardProps) {
   const { toast } = useToast();
+  const isOnline = useOnlineStatus();
   const [step, setStep] = useState<WizardStep>("search");
   const searchMutation = useMedicineSearch();
   const addPrescriptionMutation = useAddPrescription();
@@ -538,6 +540,7 @@ export function AddMedicationWizard({ open, onOpenChange }: AddMedicationWizardP
                 onQueryChange={setSearchQuery}
                 onSearch={handleSearch}
                 isSearching={searchMutation.isPending}
+                isOnline={isOnline}
                 result={searchResult}
                 {...(searchMutation.error?.message && { error: searchMutation.error.message })}
                 brandName={brandName}
@@ -649,14 +652,14 @@ export function AddMedicationWizard({ open, onOpenChange }: AddMedicationWizardP
 // ── Step Components ──────────────────────────────────────────
 
 function SearchStep({
-  query, onQueryChange, onSearch, isSearching, result, error,
+  query, onQueryChange, onSearch, isSearching, isOnline, result, error,
   brandName, onBrandNameChange, genericName, onGenericNameChange,
   dosageStrength, onDosageStrengthChange,
   selectedPrescriptionId, onSelectedPrescriptionIdChange,
   existingPrescriptions, fieldErrors = {},
 }: {
   query: string; onQueryChange: (v: string) => void;
-  onSearch: () => void; isSearching: boolean;
+  onSearch: () => void; isSearching: boolean; isOnline: boolean;
   result: MedicineSearchResult | null; error?: string;
   brandName: string; onBrandNameChange: (v: string) => void;
   genericName: string; onGenericNameChange: (v: string) => void;
@@ -701,13 +704,19 @@ function SearchStep({
           />
           <Button
             onClick={onSearch}
-            disabled={isSearching || !query.trim()}
+            disabled={isSearching || !query.trim() || !isOnline}
             size="icon"
+            title={isOnline ? "Search with AI" : "AI search unavailable while offline"}
             className="shrink-0 bg-teal-600 hover:bg-teal-700"
           >
             {isSearching ? <Loader2 className="w-4 h-4 animate-spin" /> : <Search className="w-4 h-4" />}
           </Button>
         </div>
+        {!isOnline && (
+          <p className="text-xs text-muted-foreground mt-1">
+            Offline — fill the fields below manually.
+          </p>
+        )}
         {error && <p className="text-xs text-red-500 mt-1">{error}</p>}
       </div>
 

--- a/src/components/medications/add-medication-wizard.tsx
+++ b/src/components/medications/add-medication-wizard.tsx
@@ -582,6 +582,7 @@ export function AddMedicationWizard({ open, onOpenChange }: AddMedicationWizardP
                 isExistingPrescription={selectedPrescriptionId !== "new"}
                 onRefreshAI={handleSearch}
                 isRefreshing={searchMutation.isPending}
+                isOnline={isOnline}
               />
             )}
 
@@ -871,6 +872,7 @@ function IndicationStep({
   notes, onNotesChange,
   isExistingPrescription = false,
   onRefreshAI, isRefreshing = false,
+  isOnline = true,
 }: {
   indication: string; onIndicationChange: (v: string) => void;
   contraindications: string[]; warnings: string[];
@@ -880,6 +882,7 @@ function IndicationStep({
   isExistingPrescription?: boolean;
   onRefreshAI?: () => void;
   isRefreshing?: boolean;
+  isOnline?: boolean;
 }) {
   const foodOptions: { value: FoodInstruction; label: string }[] = [
     { value: "before", label: "Before eating" },
@@ -899,7 +902,8 @@ function IndicationStep({
                   variant="ghost"
                   size="sm"
                   onClick={onRefreshAI}
-                  disabled={isRefreshing}
+                  disabled={isRefreshing || !isOnline}
+                  title={isOnline ? "AI Suggest" : "AI offline — suggestions unavailable"}
                   className="h-7 text-xs gap-1 text-teal-600"
                 >
                   {isRefreshing ? <Loader2 className="w-3 h-3 animate-spin" /> : <Search className="w-3 h-3" />}

--- a/src/components/medications/edit-medication-drawer.tsx
+++ b/src/components/medications/edit-medication-drawer.tsx
@@ -25,6 +25,7 @@ import type { Prescription, MedicationPhase } from "@/lib/db";
 import { Loader2, Plus, Clock, Pill, Edit2, Check, X, Trash2, Play } from "lucide-react";
 import { format } from "date-fns";
 import { useMedicineSearch } from "@/hooks/use-medicine-search";
+import { useOnlineStatus } from "@/hooks/use-online-status";
 
 interface PrescriptionViewDrawerProps {
   prescription: Prescription | null;
@@ -233,6 +234,7 @@ function InfoTab({ prescription }: { prescription: Prescription }) {
   const [isEditingAiData, setIsEditingAiData] = useState(false);
   const [editContraindications, setEditContraindications] = useState("");
   const [editWarnings, setEditWarnings] = useState("");
+  const isOnline = useOnlineStatus();
 
   const updatePrescription = useUpdatePrescription();
   const searchMutation = useMedicineSearch();
@@ -381,7 +383,14 @@ function InfoTab({ prescription }: { prescription: Prescription }) {
     <div className="space-y-6">
       <div className="flex items-center justify-between">
         <h3 className="font-semibold text-sm">AI Information</h3>
-        <Button size="sm" variant="outline" className="gap-1 h-8 text-xs" onClick={handleRefresh} disabled={isRefreshing || updatePrescription.isPending}>
+        <Button
+          size="sm"
+          variant="outline"
+          className="gap-1 h-8 text-xs"
+          onClick={handleRefresh}
+          disabled={isRefreshing || updatePrescription.isPending || !isOnline}
+          title={isOnline ? "Refresh AI data" : "Offline — AI refresh unavailable"}
+        >
           {isRefreshing || updatePrescription.isPending ? <Loader2 className="w-3 h-3 animate-spin" /> : <Clock className="w-3 h-3" />}
           Refresh AI Data
         </Button>

--- a/src/components/medications/edit-medication-drawer.tsx
+++ b/src/components/medications/edit-medication-drawer.tsx
@@ -26,6 +26,8 @@ import { Loader2, Plus, Clock, Pill, Edit2, Check, X, Trash2, Play } from "lucid
 import { format } from "date-fns";
 import { useMedicineSearch } from "@/hooks/use-medicine-search";
 import { useOnlineStatus } from "@/hooks/use-online-status";
+import { useToast } from "@/hooks/use-toast";
+import { OfflineError } from "@/lib/ai-client";
 
 interface PrescriptionViewDrawerProps {
   prescription: Prescription | null;
@@ -238,6 +240,7 @@ function InfoTab({ prescription }: { prescription: Prescription }) {
 
   const updatePrescription = useUpdatePrescription();
   const searchMutation = useMedicineSearch();
+  const { toast } = useToast();
 
   const handleRefresh = async () => {
     setIsRefreshing(true);
@@ -250,7 +253,20 @@ function InfoTab({ prescription }: { prescription: Prescription }) {
         });
       }
     } catch (e) {
-      console.error("Failed to refresh AI data", e);
+      if (e instanceof OfflineError) {
+        toast({
+          title: "AI offline",
+          description: "You're offline — try refreshing AI data when connected.",
+          variant: "default",
+        });
+      } else {
+        console.error("Failed to refresh AI data", e);
+        toast({
+          title: "Refresh failed",
+          description: "Couldn't refresh AI data. Try again later.",
+          variant: "destructive",
+        });
+      }
     } finally {
       setIsRefreshing(false);
     }
@@ -389,6 +405,7 @@ function InfoTab({ prescription }: { prescription: Prescription }) {
           className="gap-1 h-8 text-xs"
           onClick={handleRefresh}
           disabled={isRefreshing || updatePrescription.isPending || !isOnline}
+          aria-label={isOnline ? "Refresh AI data" : "Offline — AI refresh unavailable"}
           title={isOnline ? "Refresh AI data" : "Offline — AI refresh unavailable"}
         >
           {isRefreshing || updatePrescription.isPending ? <Loader2 className="w-3 h-3 animate-spin" /> : <Clock className="w-3 h-3" />}

--- a/src/components/medications/interactions-section.tsx
+++ b/src/components/medications/interactions-section.tsx
@@ -6,6 +6,7 @@ import { Button } from "@/components/ui/button";
 import { useRefreshInteractions } from "@/hooks/use-interaction-check";
 import { usePrescriptions } from "@/hooks/use-medication-queries";
 import { useToast } from "@/hooks/use-toast";
+import { useOnlineStatus } from "@/hooks/use-online-status";
 import type { Prescription } from "@/lib/db";
 
 interface InteractionsSectionProps {
@@ -16,12 +17,18 @@ export function InteractionsSection({ prescription }: InteractionsSectionProps) 
   const { refresh, isRefreshing } = useRefreshInteractions();
   const prescriptions = usePrescriptions();
   const { toast } = useToast();
+  const isOnline = useOnlineStatus();
 
   const hasData =
     (prescription.contraindications?.length ?? 0) > 0 ||
     (prescription.warnings?.length ?? 0) > 0;
 
   const handleRefresh = async () => {
+    if (!isOnline) {
+      // Disabled state should prevent this; belt-and-braces in case the
+      // device drops connection between render and click.
+      return;
+    }
     const activePrescriptions = prescriptions.filter(
       (p) => p.id !== prescription.id && p.isActive
     );
@@ -107,7 +114,15 @@ export function InteractionsSection({ prescription }: InteractionsSectionProps) 
             size="sm"
             className="text-xs mt-2 w-full"
             onClick={handleRefresh}
-            disabled={isRefreshing || otherActiveCount === 0}
+            disabled={isRefreshing || otherActiveCount === 0 || !isOnline}
+            aria-label={
+              !isOnline
+                ? "Offline — refresh unavailable"
+                : otherActiveCount === 0
+                  ? "Add more prescriptions to check interactions"
+                  : "Refresh interactions"
+            }
+            title={!isOnline ? "Offline — refresh unavailable" : undefined}
           >
             {isRefreshing ? (
               <Loader2 className="w-3 h-3 animate-spin mr-1" />
@@ -116,7 +131,9 @@ export function InteractionsSection({ prescription }: InteractionsSectionProps) 
             )}
             {otherActiveCount === 0
               ? "Add more prescriptions to check interactions"
-              : "Refresh interactions"}
+              : !isOnline
+                ? "Offline — refresh unavailable"
+                : "Refresh interactions"}
           </Button>
         </div>
       ) : (
@@ -128,7 +145,15 @@ export function InteractionsSection({ prescription }: InteractionsSectionProps) 
               size="sm"
               className="text-xs"
               onClick={handleRefresh}
-              disabled={isRefreshing || otherActiveCount === 0}
+              disabled={isRefreshing || otherActiveCount === 0 || !isOnline}
+              aria-label={
+                !isOnline
+                  ? "Offline — refresh unavailable"
+                  : otherActiveCount === 0
+                    ? "Add more prescriptions to check interactions"
+                    : "Refresh interactions"
+              }
+              title={!isOnline ? "Offline — refresh unavailable" : undefined}
             >
               {isRefreshing ? (
                 <Loader2 className="w-3 h-3 animate-spin mr-1" />
@@ -137,7 +162,9 @@ export function InteractionsSection({ prescription }: InteractionsSectionProps) 
               )}
               {otherActiveCount === 0
                 ? "Add more prescriptions to check interactions"
-                : "Refresh interactions"}
+                : !isOnline
+                  ? "Offline — refresh unavailable"
+                  : "Refresh interactions"}
             </Button>
           </div>
         </div>

--- a/src/components/medications/interactions-section.tsx
+++ b/src/components/medications/interactions-section.tsx
@@ -5,6 +5,7 @@ import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { useRefreshInteractions } from "@/hooks/use-interaction-check";
 import { usePrescriptions } from "@/hooks/use-medication-queries";
+import { useToast } from "@/hooks/use-toast";
 import type { Prescription } from "@/lib/db";
 
 interface InteractionsSectionProps {
@@ -14,12 +15,13 @@ interface InteractionsSectionProps {
 export function InteractionsSection({ prescription }: InteractionsSectionProps) {
   const { refresh, isRefreshing } = useRefreshInteractions();
   const prescriptions = usePrescriptions();
+  const { toast } = useToast();
 
   const hasData =
     (prescription.contraindications?.length ?? 0) > 0 ||
     (prescription.warnings?.length ?? 0) > 0;
 
-  const handleRefresh = () => {
+  const handleRefresh = async () => {
     const activePrescriptions = prescriptions.filter(
       (p) => p.id !== prescription.id && p.isActive
     );
@@ -29,11 +31,25 @@ export function InteractionsSection({ prescription }: InteractionsSectionProps) 
       return;
     }
 
-    refresh(
+    const result = await refresh(
       prescription.id,
       prescription.genericName,
       activePrescriptions.map((p) => ({ genericName: p.genericName }))
     );
+
+    if (result && "error" in result && result.error === "offline") {
+      toast({
+        title: "AI offline",
+        description: "Connect to the internet to refresh interactions.",
+        variant: "default",
+      });
+    } else if (result === null) {
+      toast({
+        title: "Refresh failed",
+        description: "Couldn't refresh interactions. Try again later.",
+        variant: "destructive",
+      });
+    }
   };
 
   const otherActiveCount = prescriptions.filter(

--- a/src/components/medications/titrations-view.tsx
+++ b/src/components/medications/titrations-view.tsx
@@ -50,7 +50,6 @@ import {
 } from "@/hooks/use-medication-queries";
 import type { TitrationPlan, MedicationPhase, Prescription } from "@/lib/db";
 import { useAuth } from "@/components/auth-guard";
-import { isOffline } from "@/lib/ai-client";
 import { useToast } from "@/hooks/use-toast";
 import { useOnlineStatus } from "@/hooks/use-online-status";
 import {
@@ -647,7 +646,7 @@ function TitrationDrawer({
       }));
 
     if (changingRx.length === 0) return;
-    if (isOffline()) {
+    if (!isOnline) {
       toast({
         title: "AI offline",
         description: "Connect to the internet to generate suggestions, or write warnings manually.",

--- a/src/components/medications/titrations-view.tsx
+++ b/src/components/medications/titrations-view.tsx
@@ -51,6 +51,8 @@ import {
 import type { TitrationPlan, MedicationPhase, Prescription } from "@/lib/db";
 import { useAuth } from "@/components/auth-guard";
 import { isOffline } from "@/lib/ai-client";
+import { useToast } from "@/hooks/use-toast";
+import { useOnlineStatus } from "@/hooks/use-online-status";
 import {
   Plus,
   Play,
@@ -495,6 +497,8 @@ function TitrationDrawer({
   const createMutation = useCreateTitrationPlan();
   const updateMutation = useUpdateTitrationPlan();
   const { getAuthHeader } = useAuth();
+  const { toast } = useToast();
+  const isOnline = useOnlineStatus();
   const isEditing = editingPlan !== null;
 
   // Load existing phases for editing
@@ -643,7 +647,14 @@ function TitrationDrawer({
       }));
 
     if (changingRx.length === 0) return;
-    if (isOffline()) return;
+    if (isOffline()) {
+      toast({
+        title: "AI offline",
+        description: "Connect to the internet to generate suggestions, or write warnings manually.",
+        variant: "default",
+      });
+      return;
+    }
 
     setAiLoading(true);
     try {
@@ -847,7 +858,13 @@ function TitrationDrawer({
                 size="sm"
                 className="h-7 text-xs gap-1"
                 onClick={handleGenerateWarnings}
-                disabled={aiLoading || entries.filter((e) => e.prescriptionId).length === 0}
+                disabled={
+                  aiLoading ||
+                  !isOnline ||
+                  entries.filter((e) => e.prescriptionId).length === 0
+                }
+                aria-label={isOnline ? "AI Suggest" : "AI offline — suggestions unavailable"}
+                title={isOnline ? "AI Suggest" : "AI offline — suggestions unavailable"}
               >
                 {aiLoading ? (
                   <Loader2 className="w-3 h-3 animate-spin" />

--- a/src/components/medications/titrations-view.tsx
+++ b/src/components/medications/titrations-view.tsx
@@ -50,6 +50,7 @@ import {
 } from "@/hooks/use-medication-queries";
 import type { TitrationPlan, MedicationPhase, Prescription } from "@/lib/db";
 import { useAuth } from "@/components/auth-guard";
+import { isOffline } from "@/lib/ai-client";
 import {
   Plus,
   Play,
@@ -642,6 +643,7 @@ function TitrationDrawer({
       }));
 
     if (changingRx.length === 0) return;
+    if (isOffline()) return;
 
     setAiLoading(true);
     try {

--- a/src/components/offline-indicator.tsx
+++ b/src/components/offline-indicator.tsx
@@ -1,0 +1,25 @@
+"use client";
+
+import { WifiOff } from "lucide-react";
+import { useOnlineStatus } from "@/hooks/use-online-status";
+
+/**
+ * Small persistent banner that surfaces when the device reports it is
+ * offline. All record-taking still works — only AI-assisted lookups and
+ * push notification subscription require the network.
+ */
+export function OfflineIndicator() {
+  const isOnline = useOnlineStatus();
+  if (isOnline) return null;
+
+  return (
+    <div
+      role="status"
+      aria-live="polite"
+      className="flex items-center justify-center gap-1.5 px-3 py-1 text-[11px] font-medium bg-amber-100 text-amber-900 border-b border-amber-200 dark:bg-amber-950/60 dark:text-amber-200 dark:border-amber-800"
+    >
+      <WifiOff className="h-3 w-3" aria-hidden="true" />
+      <span>Offline — all logging works locally. AI lookups will resume online.</span>
+    </div>
+  );
+}

--- a/src/components/service-worker-bootstrap.tsx
+++ b/src/components/service-worker-bootstrap.tsx
@@ -1,14 +1,9 @@
 "use client";
 
 import { useEffect } from "react";
+import { BYPASS_KEY, getBypassCode } from "@/lib/auth-bypass";
 
 const BYPASS_QUERY_PARAM = "bypass";
-const BYPASS_KEY = "intake-tracker-bypass-auth";
-const DEFAULT_BYPASS_CODE = "meowmeowmeow";
-
-function getBypassCode(): string {
-  return process.env.NEXT_PUBLIC_BYPASS_CODE || DEFAULT_BYPASS_CODE;
-}
 
 function activateBypass(): void {
   if (typeof window === "undefined") return;

--- a/src/components/service-worker-bootstrap.tsx
+++ b/src/components/service-worker-bootstrap.tsx
@@ -1,14 +1,9 @@
 "use client";
 
 import { useEffect } from "react";
-import { BYPASS_KEY, getBypassCode } from "@/lib/auth-bypass";
+import { activateBypass, getBypassCode } from "@/lib/auth-bypass";
 
 const BYPASS_QUERY_PARAM = "bypass";
-
-function activateBypass(): void {
-  if (typeof window === "undefined") return;
-  window.localStorage.setItem(BYPASS_KEY, String(Date.now()));
-}
 
 /**
  * Belt-and-suspenders SW registration + offline survival.
@@ -38,7 +33,8 @@ export function ServiceWorkerBootstrap() {
     const url = new URL(window.location.href);
     const code = url.searchParams.get(BYPASS_QUERY_PARAM);
     if (code) {
-      if (code === getBypassCode()) {
+      const expected = getBypassCode();
+      if (expected !== null && code === expected) {
         activateBypass();
       }
       url.searchParams.delete(BYPASS_QUERY_PARAM);

--- a/src/components/substance/substance-type-picker.tsx
+++ b/src/components/substance/substance-type-picker.tsx
@@ -111,6 +111,7 @@ export function SubstanceTypePicker({
 
   const populateOtherDefaults = () => {
     setAiResult(null);
+    setReasoning(null);
     const otherType =
       type === "caffeine"
         ? substanceConfig.caffeine.types.find((t) => t.name === "Other")

--- a/src/components/substance/substance-type-picker.tsx
+++ b/src/components/substance/substance-type-picker.tsx
@@ -54,6 +54,10 @@ export function SubstanceTypePicker({
   const [isEnriching, setIsEnriching] = useState(false);
   const [aiResult, setAiResult] = useState<AiResult | null>(null);
   const [reasoning, setReasoning] = useState<string | null>(null);
+  // Why we're showing default values instead of an AI result. Lets the
+  // banner explain "you're offline" vs. "the AI failed" rather than a
+  // single generic message.
+  const [fallbackReason, setFallbackReason] = useState<"offline" | "error" | null>(null);
 
   // Manual override fields
   const [overrideAmount, setOverrideAmount] = useState("");
@@ -65,6 +69,7 @@ export function SubstanceTypePicker({
     setIsEnriching(false);
     setAiResult(null);
     setReasoning(null);
+    setFallbackReason(null);
     setOverrideAmount("");
     setOverrideVolume("");
   };
@@ -109,9 +114,10 @@ export function SubstanceTypePicker({
     }
   };
 
-  const populateOtherDefaults = () => {
+  const populateOtherDefaults = (reason: "offline" | "error") => {
     setAiResult(null);
     setReasoning(null);
+    setFallbackReason(reason);
     const otherType =
       type === "caffeine"
         ? substanceConfig.caffeine.types.find((t) => t.name === "Other")
@@ -133,7 +139,7 @@ export function SubstanceTypePicker({
     // Offline: skip the network call entirely (and the loading state) and
     // fall through to defaults.
     if (isOffline()) {
-      populateOtherDefaults();
+      populateOtherDefaults("offline");
       return;
     }
 
@@ -154,6 +160,7 @@ export function SubstanceTypePicker({
         const data = await response.json();
         setAiResult(data);
         setReasoning(data.reasoning || null);
+        setFallbackReason(null);
 
         if (type === "caffeine") {
           setOverrideAmount(String(data.caffeineMg ?? ""));
@@ -164,11 +171,11 @@ export function SubstanceTypePicker({
         }
         setStep("other-result");
       } else {
-        populateOtherDefaults();
+        populateOtherDefaults("error");
       }
     } catch {
       // Network error -- fallback to defaults
-      populateOtherDefaults();
+      populateOtherDefaults("error");
     } finally {
       setIsEnriching(false);
     }
@@ -315,9 +322,11 @@ export function SubstanceTypePicker({
                   </div>
                 )}
 
-                {!aiResult && (
+                {!aiResult && fallbackReason && (
                   <div className="rounded-md bg-yellow-50 dark:bg-yellow-950/30 p-3 text-xs text-yellow-700 dark:text-yellow-400">
-                    AI estimation unavailable. Using default values -- you can adjust below.
+                    {fallbackReason === "offline"
+                      ? "You're offline — using default values. Adjust below."
+                      : "AI estimation unavailable. Using default values -- you can adjust below."}
                   </div>
                 )}
 

--- a/src/components/substance/substance-type-picker.tsx
+++ b/src/components/substance/substance-type-picker.tsx
@@ -109,30 +109,34 @@ export function SubstanceTypePicker({
     }
   };
 
+  const populateOtherDefaults = () => {
+    setAiResult(null);
+    const otherType =
+      type === "caffeine"
+        ? substanceConfig.caffeine.types.find((t) => t.name === "Other")
+        : substanceConfig.alcohol.types.find((t) => t.name === "Other");
+
+    if (type === "caffeine" && otherType && "defaultMg" in otherType) {
+      setOverrideAmount(String(otherType.defaultMg));
+      setOverrideVolume(String(otherType.defaultVolumeMl));
+    } else if (type === "alcohol" && otherType && "defaultDrinks" in otherType) {
+      setOverrideAmount(String(otherType.defaultDrinks));
+      setOverrideVolume(String(otherType.defaultVolumeMl));
+    }
+    setStep("other-result");
+  };
+
   const handleOtherSubmit = async () => {
     if (!customDescription.trim()) return;
 
-    setIsEnriching(true);
-
-    // Offline: skip the network call entirely and fall through to defaults.
+    // Offline: skip the network call entirely (and the loading state) and
+    // fall through to defaults.
     if (isOffline()) {
-      setAiResult(null);
-      const otherType =
-        type === "caffeine"
-          ? substanceConfig.caffeine.types.find((t) => t.name === "Other")
-          : substanceConfig.alcohol.types.find((t) => t.name === "Other");
-
-      if (type === "caffeine" && otherType && "defaultMg" in otherType) {
-        setOverrideAmount(String(otherType.defaultMg));
-        setOverrideVolume(String(otherType.defaultVolumeMl));
-      } else if (type === "alcohol" && otherType && "defaultDrinks" in otherType) {
-        setOverrideAmount(String(otherType.defaultDrinks));
-        setOverrideVolume(String(otherType.defaultVolumeMl));
-      }
-      setIsEnriching(false);
-      setStep("other-result");
+      populateOtherDefaults();
       return;
     }
+
+    setIsEnriching(true);
 
     try {
       const authHeaders = await getAuthHeader();
@@ -157,40 +161,15 @@ export function SubstanceTypePicker({
           setOverrideAmount(String(data.standardDrinks ?? ""));
           setOverrideVolume(String(data.volumeMl ?? ""));
         }
+        setStep("other-result");
       } else {
-        // Fallback to defaults on error
-        setAiResult(null);
-        const otherType =
-          type === "caffeine"
-            ? substanceConfig.caffeine.types.find((t) => t.name === "Other")
-            : substanceConfig.alcohol.types.find((t) => t.name === "Other");
-
-        if (type === "caffeine" && otherType && "defaultMg" in otherType) {
-          setOverrideAmount(String(otherType.defaultMg));
-          setOverrideVolume(String(otherType.defaultVolumeMl));
-        } else if (type === "alcohol" && otherType && "defaultDrinks" in otherType) {
-          setOverrideAmount(String(otherType.defaultDrinks));
-          setOverrideVolume(String(otherType.defaultVolumeMl));
-        }
+        populateOtherDefaults();
       }
     } catch {
-      // Offline or network error -- fallback to defaults
-      setAiResult(null);
-      const otherType =
-        type === "caffeine"
-          ? substanceConfig.caffeine.types.find((t) => t.name === "Other")
-          : substanceConfig.alcohol.types.find((t) => t.name === "Other");
-
-      if (type === "caffeine" && otherType && "defaultMg" in otherType) {
-        setOverrideAmount(String(otherType.defaultMg));
-        setOverrideVolume(String(otherType.defaultVolumeMl));
-      } else if (type === "alcohol" && otherType && "defaultDrinks" in otherType) {
-        setOverrideAmount(String(otherType.defaultDrinks));
-        setOverrideVolume(String(otherType.defaultVolumeMl));
-      }
+      // Network error -- fallback to defaults
+      populateOtherDefaults();
     } finally {
       setIsEnriching(false);
-      setStep("other-result");
     }
   };
 

--- a/src/components/substance/substance-type-picker.tsx
+++ b/src/components/substance/substance-type-picker.tsx
@@ -14,6 +14,7 @@ import {
 import { Loader2, Sparkles, Edit3 } from "lucide-react";
 import { useSettingsStore } from "@/stores/settings-store";
 import { useAuth } from "@/components/auth-guard";
+import { isOffline } from "@/lib/ai-client";
 
 export interface SubstanceTypeSelection {
   name: string;
@@ -112,6 +113,26 @@ export function SubstanceTypePicker({
     if (!customDescription.trim()) return;
 
     setIsEnriching(true);
+
+    // Offline: skip the network call entirely and fall through to defaults.
+    if (isOffline()) {
+      setAiResult(null);
+      const otherType =
+        type === "caffeine"
+          ? substanceConfig.caffeine.types.find((t) => t.name === "Other")
+          : substanceConfig.alcohol.types.find((t) => t.name === "Other");
+
+      if (type === "caffeine" && otherType && "defaultMg" in otherType) {
+        setOverrideAmount(String(otherType.defaultMg));
+        setOverrideVolume(String(otherType.defaultVolumeMl));
+      } else if (type === "alcohol" && otherType && "defaultDrinks" in otherType) {
+        setOverrideAmount(String(otherType.defaultDrinks));
+        setOverrideVolume(String(otherType.defaultVolumeMl));
+      }
+      setIsEnriching(false);
+      setStep("other-result");
+      return;
+    }
 
     try {
       const authHeaders = await getAuthHeader();

--- a/src/components/substance/substance-type-picker.tsx
+++ b/src/components/substance/substance-type-picker.tsx
@@ -174,8 +174,11 @@ export function SubstanceTypePicker({
         populateOtherDefaults("error");
       }
     } catch {
-      // Network error -- fallback to defaults
-      populateOtherDefaults("error");
+      // Network error -- fallback to defaults. If the device dropped
+      // connection mid-request, surface that to the user instead of a
+      // generic "AI estimation unavailable" so the banner copy matches
+      // the pre-flight offline path.
+      populateOtherDefaults(isOffline() ? "offline" : "error");
     } finally {
       setIsEnriching(false);
     }

--- a/src/hooks/use-interaction-check.ts
+++ b/src/hooks/use-interaction-check.ts
@@ -2,6 +2,7 @@ import { useState, useCallback, useRef } from "react";
 import { getCached, setCache } from "@/lib/interaction-cache";
 import { useUpdatePrescription } from "@/hooks/use-medication-queries";
 import { useAuth } from "@/components/auth-guard";
+import { isOffline } from "@/lib/ai-client";
 
 // --- Types ---
 
@@ -64,6 +65,13 @@ export function useInteractionCheck() {
         setIsLoading(false);
         return cached;
       }
+    }
+
+    // Offline: skip the network call. Cached lookups (above) still work.
+    if (isOffline()) {
+      setError("Offline — interaction check unavailable.");
+      setIsLoading(false);
+      return null;
     }
 
     // Abort any in-flight request
@@ -140,6 +148,7 @@ export function useRefreshInteractions() {
       genericName: string,
       activePrescriptions: ActivePrescription[]
     ) => {
+      if (isOffline()) return null;
       setIsRefreshing(true);
 
       try {

--- a/src/hooks/use-interaction-check.ts
+++ b/src/hooks/use-interaction-check.ts
@@ -68,7 +68,10 @@ export function useInteractionCheck() {
     }
 
     // Offline: skip the network call. Cached lookups (above) still work.
+    // Clear any previous result so consumers don't render stale `data`
+    // alongside the offline error.
     if (isOffline()) {
+      setData(null);
       setError("Offline — interaction check unavailable.");
       setIsLoading(false);
       return null;

--- a/src/hooks/use-interaction-check.ts
+++ b/src/hooks/use-interaction-check.ts
@@ -150,8 +150,11 @@ export function useRefreshInteractions() {
       prescriptionId: string,
       genericName: string,
       activePrescriptions: ActivePrescription[]
-    ) => {
-      if (isOffline()) return null;
+    ): Promise<InteractionResult | { error: "offline" } | null> => {
+      // Return a distinct sentinel for offline so callers can show
+      // "Offline — try again when connected" instead of treating it as a
+      // generic "refresh failed".
+      if (isOffline()) return { error: "offline" };
       setIsRefreshing(true);
 
       try {

--- a/src/hooks/use-medicine-search.ts
+++ b/src/hooks/use-medicine-search.ts
@@ -3,6 +3,7 @@
 import { useMutation } from "@tanstack/react-query";
 import { useAuth } from "@/components/auth-guard";
 import { useSettingsStore } from "@/stores/settings-store";
+import { isOffline, OfflineError } from "@/lib/ai-client";
 
 export interface MedicineSearchResult {
   brandNames: string[];
@@ -27,6 +28,9 @@ export function useMedicineSearch() {
 
   return useMutation({
     mutationFn: async (query: string): Promise<MedicineSearchResult> => {
+      if (isOffline()) {
+        throw new OfflineError("Medication search requires an internet connection.");
+      }
       const state = useSettingsStore.getState();
       const primary = state.primaryRegion;
       const secondary = state.secondaryRegion;

--- a/src/hooks/use-online-status.ts
+++ b/src/hooks/use-online-status.ts
@@ -1,0 +1,31 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+/**
+ * Reactive `navigator.onLine` flag. Subscribes to "online" / "offline" events
+ * so consumers re-render when connectivity changes.
+ *
+ * Caveat: `navigator.onLine === true` only means the radio is up — it does
+ * NOT guarantee internet reachability (captive portals, dead Wi-Fi, etc).
+ * Use this to short-circuit obviously-impossible network calls and to drive
+ * UI affordances; do not use it as proof that a fetch will succeed.
+ */
+export function useOnlineStatus(): boolean {
+  const [online, setOnline] = useState(true);
+
+  useEffect(() => {
+    if (typeof navigator === "undefined") return;
+    setOnline(navigator.onLine !== false);
+    const handleOnline = () => setOnline(true);
+    const handleOffline = () => setOnline(false);
+    window.addEventListener("online", handleOnline);
+    window.addEventListener("offline", handleOffline);
+    return () => {
+      window.removeEventListener("online", handleOnline);
+      window.removeEventListener("offline", handleOffline);
+    };
+  }, []);
+
+  return online;
+}

--- a/src/hooks/use-service-worker.ts
+++ b/src/hooks/use-service-worker.ts
@@ -263,6 +263,7 @@ export function useServiceWorker() {
   // identity stays stable across unrelated state changes.
   const applyUpdate = useCallback(async (): Promise<{
     activated: boolean;
+    noRegistration?: boolean;
     error?: string;
   }> => {
     if (typeof navigator === "undefined" || !("serviceWorker" in navigator)) {
@@ -277,11 +278,19 @@ export function useServiceWorker() {
       return { activated: false, error: message };
     }
 
-    if (!registration?.waiting) {
+    // Distinguish "we don't even have a registration" from "registered but
+    // nothing waiting". Without this, calling registration?.update() on
+    // undefined silently does nothing and we'd lie that the check
+    // succeeded.
+    if (!registration) {
+      return { activated: false, noRegistration: true };
+    }
+
+    if (!registration.waiting) {
       // No waiting worker. Best-effort: check for one in case the consumer
       // wants to refresh state. Surface any thrown error to the caller.
       try {
-        await registration?.update();
+        await registration.update();
       } catch (error) {
         const message = error instanceof Error ? error.message : "Unknown error";
         console.error("Failed to check for updates:", error);

--- a/src/hooks/use-service-worker.ts
+++ b/src/hooks/use-service-worker.ts
@@ -264,6 +264,7 @@ export function useServiceWorker() {
   const applyUpdate = useCallback(async (): Promise<{
     activated: boolean;
     noRegistration?: boolean;
+    updateInProgress?: boolean;
     error?: string;
   }> => {
     if (typeof navigator === "undefined" || !("serviceWorker" in navigator)) {
@@ -295,6 +296,24 @@ export function useServiceWorker() {
         const message = error instanceof Error ? error.message : "Unknown error";
         console.error("Failed to check for updates:", error);
         return { activated: false, error: message };
+      }
+
+      // Re-read after update() so the caller can tell "nothing on the
+      // server" from "found something, install in progress".
+      if (registration.waiting) {
+        // The update finished installing while we waited; nudge the UI to
+        // surface the now-waiting worker.
+        setState((prev) => ({
+          ...prev,
+          isUpdateAvailable: true,
+          registration,
+        }));
+        return { activated: false, updateInProgress: true };
+      }
+      if (registration.installing) {
+        // Still installing — caller can show "update pending" instead of
+        // "already up to date".
+        return { activated: false, updateInProgress: true };
       }
       return { activated: false };
     }

--- a/src/hooks/use-service-worker.ts
+++ b/src/hooks/use-service-worker.ts
@@ -259,11 +259,23 @@ export function useServiceWorker() {
   // Function to apply the update. Returns a status object so callers can
   // distinguish "activated a waiting worker" from "nothing to apply" or
   // "underlying SW call threw" instead of swallowing the outcome silently.
+  // Reads the registration directly from the SW container so the callback
+  // identity stays stable across unrelated state changes.
   const applyUpdate = useCallback(async (): Promise<{
     activated: boolean;
     error?: string;
   }> => {
-    const { registration } = state;
+    if (typeof navigator === "undefined" || !("serviceWorker" in navigator)) {
+      return { activated: false, error: "Service Worker not supported" };
+    }
+
+    let registration: ServiceWorkerRegistration | undefined;
+    try {
+      registration = await navigator.serviceWorker.getRegistration();
+    } catch (error) {
+      const message = error instanceof Error ? error.message : "Unknown error";
+      return { activated: false, error: message };
+    }
 
     if (!registration?.waiting) {
       // No waiting worker. Best-effort: check for one in case the consumer
@@ -283,7 +295,7 @@ export function useServiceWorker() {
     // Tell the waiting service worker to skip waiting and take control
     registration.waiting.postMessage({ type: "SKIP_WAITING" });
     return { activated: true };
-  }, [state]);
+  }, []);
 
   // Function to manually check for updates
   const checkForUpdates = useCallback(async () => {

--- a/src/hooks/use-service-worker.ts
+++ b/src/hooks/use-service-worker.ts
@@ -256,24 +256,33 @@ export function useServiceWorker() {
     };
   }, [checkForWaitingWorker, setupRegistrationListeners, registerServiceWorker]);
 
-  // Function to apply the update
-  const applyUpdate = useCallback(async () => {
+  // Function to apply the update. Returns a status object so callers can
+  // distinguish "activated a waiting worker" from "nothing to apply" or
+  // "underlying SW call threw" instead of swallowing the outcome silently.
+  const applyUpdate = useCallback(async (): Promise<{
+    activated: boolean;
+    error?: string;
+  }> => {
     const { registration } = state;
-    
+
     if (!registration?.waiting) {
-      // No waiting worker, try to check for updates
+      // No waiting worker. Best-effort: check for one in case the consumer
+      // wants to refresh state. Surface any thrown error to the caller.
       try {
         await registration?.update();
       } catch (error) {
+        const message = error instanceof Error ? error.message : "Unknown error";
         console.error("Failed to check for updates:", error);
+        return { activated: false, error: message };
       }
-      return;
+      return { activated: false };
     }
 
     setState((prev) => ({ ...prev, isUpdating: true }));
 
     // Tell the waiting service worker to skip waiting and take control
     registration.waiting.postMessage({ type: "SKIP_WAITING" });
+    return { activated: true };
   }, [state]);
 
   // Function to manually check for updates

--- a/src/lib/ai-client.ts
+++ b/src/lib/ai-client.ts
@@ -16,6 +16,17 @@ export interface ParsedIntake {
  * - All requests are audit logged
  */
 
+export class OfflineError extends Error {
+  constructor(message = "AI features require an internet connection.") {
+    super(message);
+    this.name = "OfflineError";
+  }
+}
+
+export function isOffline(): boolean {
+  return typeof navigator !== "undefined" && navigator.onLine === false;
+}
+
 export async function parseIntakeWithAI(
   input: string,
   options?: {
@@ -24,6 +35,11 @@ export async function parseIntakeWithAI(
   }
 ): Promise<ParsedIntake> {
   logAudit("ai_parse_request");
+
+  if (isOffline()) {
+    logAudit("ai_parse_error", "offline");
+    throw new OfflineError();
+  }
 
   try {
     // Build headers with auth token

--- a/src/lib/auth-bypass.ts
+++ b/src/lib/auth-bypass.ts
@@ -1,0 +1,22 @@
+/**
+ * Shared constants and helpers for the offline auth-bypass mechanism.
+ *
+ * Centralised here so AuthGuard, ServiceWorkerBootstrap, and the debug
+ * panel all read the exact same localStorage keys and TTL — drift between
+ * them previously meant code that "activated" the bypass in one place
+ * could read inactive in another, defeating the offline grace window.
+ */
+
+export const BYPASS_KEY = "intake-tracker-bypass-auth";
+export const REMEMBERED_AUTH_KEY = "intake-tracker-last-auth";
+
+// 18-day window for both the bypass and the remembered-Privy-login grace.
+// Long enough for a typical offline trip; short enough that an unattended
+// device doesn't stay unlocked indefinitely.
+export const BYPASS_TTL_MS = 18 * 24 * 60 * 60 * 1000;
+
+export const DEFAULT_BYPASS_CODE = "meowmeowmeow";
+
+export function getBypassCode(): string {
+  return process.env.NEXT_PUBLIC_BYPASS_CODE || DEFAULT_BYPASS_CODE;
+}

--- a/src/lib/auth-bypass.ts
+++ b/src/lib/auth-bypass.ts
@@ -15,7 +15,10 @@ export const REMEMBERED_AUTH_KEY = "intake-tracker-last-auth";
 // expiring on its own if the device gets lost or sits idle. Anything under
 // ~2 weeks risks locking out a user who hasn't reopened the app between
 // trips; anything much longer effectively becomes "permanent unlock".
-export const BYPASS_TTL_MS = 18 * 24 * 60 * 60 * 1000;
+// Typed as `number` (not the literal `18`) so callers that branch on the
+// value for pluralization aren't flagged by TS as dead code.
+export const BYPASS_TTL_DAYS: number = 18;
+export const BYPASS_TTL_MS = BYPASS_TTL_DAYS * 24 * 60 * 60 * 1000;
 
 /**
  * Returns the configured bypass code, or `null` when no code is configured.
@@ -36,17 +39,32 @@ export function getBypassCode(): string | null {
  * Stamp the bypass localStorage key with the current time so subsequent
  * `isBypassActive()` checks (in AuthGuard) grant access for BYPASS_TTL_MS.
  * Safe to call from any client context — guarded for SSR.
+ *
+ * Swallows storage errors (Safari private mode, full quota, sandboxed
+ * iframes) so a broken localStorage doesn't bubble up and break the
+ * user-driven flow that called this. Worst case the bypass simply doesn't
+ * persist; the user can retry or use the URL escape hatch.
  */
 export function activateBypass(): void {
   if (typeof window === "undefined") return;
-  window.localStorage.setItem(BYPASS_KEY, String(Date.now()));
+  try {
+    window.localStorage.setItem(BYPASS_KEY, String(Date.now()));
+  } catch (err) {
+    console.warn("[auth-bypass] activateBypass failed:", err);
+  }
 }
 
 /**
  * Remove the bypass timestamp. The next AuthGuard render falls back to
  * Privy / remembered-auth, so this is the user-visible "lock again" action.
+ *
+ * Same try/catch guarantee as `activateBypass`.
  */
 export function clearBypass(): void {
   if (typeof window === "undefined") return;
-  window.localStorage.removeItem(BYPASS_KEY);
+  try {
+    window.localStorage.removeItem(BYPASS_KEY);
+  } catch (err) {
+    console.warn("[auth-bypass] clearBypass failed:", err);
+  }
 }

--- a/src/lib/auth-bypass.ts
+++ b/src/lib/auth-bypass.ts
@@ -10,13 +10,43 @@
 export const BYPASS_KEY = "intake-tracker-bypass-auth";
 export const REMEMBERED_AUTH_KEY = "intake-tracker-last-auth";
 
-// 18-day window for both the bypass and the remembered-Privy-login grace.
-// Long enough for a typical offline trip; short enough that an unattended
-// device doesn't stay unlocked indefinitely.
+// 18 days. Picked to comfortably cover a 2–3 week offline trip (a typical
+// camping/hiking/travel scenario for this single-user PWA) while still
+// expiring on its own if the device gets lost or sits idle. Anything under
+// ~2 weeks risks locking out a user who hasn't reopened the app between
+// trips; anything much longer effectively becomes "permanent unlock".
 export const BYPASS_TTL_MS = 18 * 24 * 60 * 60 * 1000;
 
-export const DEFAULT_BYPASS_CODE = "meowmeowmeow";
+/**
+ * Returns the configured bypass code, or `null` when no code is configured.
+ *
+ * Fail-closed: we deliberately do NOT ship a hardcoded default. If
+ * `NEXT_PUBLIC_BYPASS_CODE` is unset, the URL escape hatch and the
+ * emergency bypass form are inert (no string can match `null`). The
+ * navigator-onLine offline auto-activation path in ServiceWorkerBootstrap
+ * still works without a code, so users on a genuinely offline device are
+ * never locked out.
+ */
+export function getBypassCode(): string | null {
+  const code = process.env.NEXT_PUBLIC_BYPASS_CODE;
+  return code && code.length > 0 ? code : null;
+}
 
-export function getBypassCode(): string {
-  return process.env.NEXT_PUBLIC_BYPASS_CODE || DEFAULT_BYPASS_CODE;
+/**
+ * Stamp the bypass localStorage key with the current time so subsequent
+ * `isBypassActive()` checks (in AuthGuard) grant access for BYPASS_TTL_MS.
+ * Safe to call from any client context — guarded for SSR.
+ */
+export function activateBypass(): void {
+  if (typeof window === "undefined") return;
+  window.localStorage.setItem(BYPASS_KEY, String(Date.now()));
+}
+
+/**
+ * Remove the bypass timestamp. The next AuthGuard render falls back to
+ * Privy / remembered-auth, so this is the user-visible "lock again" action.
+ */
+export function clearBypass(): void {
+  if (typeof window === "undefined") return;
+  window.localStorage.removeItem(BYPASS_KEY);
 }


### PR DESCRIPTION
Make every record-taking flow work fully offline by short-circuiting AI
calls when navigator.onLine === false, falling back to manual entry, and
visibly disabling AI affordances. Adds a Service Worker section to the
Debug Panel so the user can inspect/register/unregister/update the SW,
clear caches, and manage the offline auth bypass directly.

- New useOnlineStatus hook + reactive OfflineIndicator banner
- AI sites (parse, medicine-search, substance-lookup, substance-enrich,
  titration-warnings, interaction-check) skip network when offline
- AuthGuard short-circuits the 5s Privy timeout when explicitly offline

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Persistent offline status banner
  * Service worker debug panel with controls, cache listing, and bypass tools
  * App-wide online/offline hook for reactive UI

* **Improvements**
  * AI-powered buttons and workflows disable when offline with contextual tooltips/toasts
  * Offline-aware auth/bypass handling and clearer messaging; local logging continues and AI resumes on reconnect
  * Interaction/refresh flows surface offline feedback instead of silent failures
<!-- end of auto-generated comment: release notes by coderabbit.ai -->