### PR TITLE
feat(auth): make landing offline-first; gate AI & push behind a sign-in modal

### DIFF
--- a/src/app/analytics/page.tsx
+++ b/src/app/analytics/page.tsx
@@ -12,7 +12,6 @@ import { CorrelationsTab } from "@/components/analytics/correlations-tab";
 import { TitrationTab } from "@/components/analytics/titration-tab";
 import { ExportControls } from "@/components/analytics/export-controls";
 import { AppHeader } from "@/components/app-header";
-import { AuthGuard } from "@/components/auth-guard";
 import { useTimeScopeRange } from "@/hooks/use-analytics-queries";
 import { useScrollHide } from "@/hooks/use-scroll-hide";
 import { useSettings } from "@/hooks/use-settings";
@@ -106,10 +105,8 @@ function AnalyticsContent() {
 
 export default function AnalyticsPage() {
   return (
-    <AuthGuard>
-      <Suspense>
-        <AnalyticsContent />
-      </Suspense>
-    </AuthGuard>
+    <Suspense>
+      <AnalyticsContent />
+    </Suspense>
   );
 }

--- a/src/app/medications/page.tsx
+++ b/src/app/medications/page.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useState, useCallback } from "react";
-import { AuthGuard } from "@/components/auth-guard";
 import { AppHeader } from "@/components/app-header";
 import { WeekDaySelector } from "@/components/medications/week-day-selector";
 import { MedTabBar, type MedTab } from "@/components/medications/med-footer";
@@ -94,9 +93,5 @@ function MedicationsContent() {
 }
 
 export default function MedicationsPage() {
-  return (
-    <AuthGuard>
-      <MedicationsContent />
-    </AuthGuard>
-  );
+  return <MedicationsContent />;
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import { AuthGuard } from "@/components/auth-guard";
 import { WeightCard } from "@/components/weight-card";
 import { BloodPressureCard } from "@/components/blood-pressure-card";
 import { AppHeader } from "@/components/app-header";
@@ -106,9 +105,5 @@ function HomeContent() {
 }
 
 export default function Home() {
-  return (
-    <AuthGuard>
-      <HomeContent />
-    </AuthGuard>
-  );
+  return <HomeContent />;
 }

--- a/src/app/providers.tsx
+++ b/src/app/providers.tsx
@@ -5,6 +5,7 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { PrivyProvider } from "@privy-io/react-auth";
 import { ThemeProvider, useTheme } from "next-themes";
 import { PinGateProvider } from "@/hooks/use-pin-gate";
+import { AuthRequiredProvider } from "@/components/auth-required-dialog";
 import { ErrorBoundary } from "@/components/error-boundary";
 import { initStockRecalculation } from "@/lib/inventory-service";
 import { useTimezoneDetection } from "@/hooks/use-timezone-detection";
@@ -68,7 +69,9 @@ function PrivyProviderWithTheme({
         },
       }}
     >
-      <PinGateProvider><TimezoneGuard>{children}</TimezoneGuard></PinGateProvider>
+      <AuthRequiredProvider>
+        <PinGateProvider><TimezoneGuard>{children}</TimezoneGuard></PinGateProvider>
+      </AuthRequiredProvider>
     </PrivyProvider>
   );
 }
@@ -120,7 +123,9 @@ export function Providers({ children }: { children: React.ReactNode }) {
       <ErrorBoundary>
         <QueryClientProvider client={queryClient}>
           <ThemeProvider attribute="class" defaultTheme="system" enableSystem>
-            <PinGateProvider><TimezoneGuard>{children}</TimezoneGuard></PinGateProvider>
+            <AuthRequiredProvider>
+              <PinGateProvider><TimezoneGuard>{children}</TimezoneGuard></PinGateProvider>
+            </AuthRequiredProvider>
           </ThemeProvider>
         </QueryClientProvider>
       </ErrorBoundary>

--- a/src/app/providers.tsx
+++ b/src/app/providers.tsx
@@ -69,9 +69,11 @@ function PrivyProviderWithTheme({
         },
       }}
     >
-      <AuthRequiredProvider>
-        <PinGateProvider><TimezoneGuard>{children}</TimezoneGuard></PinGateProvider>
-      </AuthRequiredProvider>
+      <PinGateProvider>
+        <AuthRequiredProvider>
+          <TimezoneGuard>{children}</TimezoneGuard>
+        </AuthRequiredProvider>
+      </PinGateProvider>
     </PrivyProvider>
   );
 }
@@ -123,9 +125,11 @@ export function Providers({ children }: { children: React.ReactNode }) {
       <ErrorBoundary>
         <QueryClientProvider client={queryClient}>
           <ThemeProvider attribute="class" defaultTheme="system" enableSystem>
-            <AuthRequiredProvider>
-              <PinGateProvider><TimezoneGuard>{children}</TimezoneGuard></PinGateProvider>
-            </AuthRequiredProvider>
+            <PinGateProvider>
+              <AuthRequiredProvider>
+                <TimezoneGuard>{children}</TimezoneGuard>
+              </AuthRequiredProvider>
+            </PinGateProvider>
           </ThemeProvider>
         </QueryClientProvider>
       </ErrorBoundary>

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -6,7 +6,6 @@ import { useSettings } from "@/hooks/use-settings";
 import { useToast } from "@/hooks/use-toast";
 import { useScrollHide } from "@/hooks/use-scroll-hide";
 import { AppHeader } from "@/components/app-header";
-import { AuthGuard } from "@/components/auth-guard";
 import { DebugPanel } from "@/components/debug-panel";
 import { CustomizationPanel } from "@/components/customization-panel";
 import { AboutDialog } from "@/components/about-dialog";
@@ -87,9 +86,5 @@ function SettingsContent() {
 }
 
 export default function SettingsPage() {
-  return (
-    <AuthGuard>
-      <SettingsContent />
-    </AuthGuard>
-  );
+  return <SettingsContent />;
 }

--- a/src/components/app-header.tsx
+++ b/src/components/app-header.tsx
@@ -5,6 +5,7 @@ import { motion } from "motion/react";
 import { Button } from "@/components/ui/button";
 import { Droplets, Pill, BarChart3, Settings } from "lucide-react";
 import { cn } from "@/lib/utils";
+import { HeaderAuthIndicator } from "@/components/header-auth-indicator";
 
 const NAV_ITEMS = [
   { path: "/", icon: Droplets, label: "Intake", title: "Intake Tracker", subtitle: "Daily budget tracking" },
@@ -58,6 +59,7 @@ export function AppHeader({
             </Button>
           );
         })}
+        <HeaderAuthIndicator />
       </div>
     </motion.header>
   );

--- a/src/components/auth-guard.tsx
+++ b/src/components/auth-guard.tsx
@@ -1,82 +1,6 @@
 "use client";
 
 import { usePrivy } from "@privy-io/react-auth";
-import { Button } from "@/components/ui/button";
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
-import { LogIn, Shield, Loader2 } from "lucide-react";
-
-interface AuthGuardProps {
-  children: React.ReactNode;
-  fallback?: React.ReactNode;
-}
-
-/**
- * Protects content behind Privy authentication.
- * Shows login prompt if user is not authenticated.
- */
-export function AuthGuard({ children, fallback }: AuthGuardProps) {
-  // Skip auth entirely when Privy is not configured (dev / CI e2e)
-  if (!process.env.NEXT_PUBLIC_PRIVY_APP_ID) {
-    return <>{children}</>;
-  }
-
-  return <PrivyAuthGuard fallback={fallback}>{children}</PrivyAuthGuard>;
-}
-
-function PrivyAuthGuard({ children, fallback }: AuthGuardProps) {
-  const { ready, authenticated, login } = usePrivy();
-
-  if (!ready) {
-    return (
-      <div className="flex items-center justify-center min-h-[50vh]">
-        <div className="flex items-center gap-3 text-muted-foreground">
-          <Loader2 className="w-6 h-6 animate-spin" />
-          <span>Loading...</span>
-        </div>
-      </div>
-    );
-  }
-
-  // User is authenticated - show protected content
-  if (authenticated) {
-    return <>{children}</>;
-  }
-
-  // User is not authenticated - show login prompt or fallback
-  if (fallback) {
-    return <>{fallback}</>;
-  }
-
-  return (
-    <div className="flex items-center justify-center min-h-[60vh] p-4">
-      <Card className="w-full max-w-md">
-        <CardHeader className="text-center">
-          <div className="mx-auto mb-4 p-3 rounded-full bg-primary/10 w-fit">
-            <Shield className="w-8 h-8 text-primary" />
-          </div>
-          <CardTitle>Sign in Required</CardTitle>
-          <CardDescription>
-            This app requires authentication to protect your health data and API access.
-          </CardDescription>
-        </CardHeader>
-        <CardContent className="space-y-4">
-          <Button
-            onClick={login}
-            className="w-full gap-2"
-            size="lg"
-          >
-            <LogIn className="w-5 h-5" />
-            Sign In
-          </Button>
-          <p className="text-xs text-center text-muted-foreground">
-            Only authorized accounts can access this app.
-            Contact the administrator if you need access.
-          </p>
-        </CardContent>
-      </Card>
-    </div>
-  );
-}
 
 const noopAuth = {
   ready: true as const,
@@ -87,8 +11,9 @@ const noopAuth = {
 };
 
 /**
- * Hook to check if user is authorized (authenticated + on whitelist)
- * The whitelist check happens server-side when making API calls.
+ * Hook exposing Privy auth state and a header helper for authenticated fetches.
+ * When Privy is not configured, returns an unauthenticated noop so the app
+ * stays fully usable in local-only mode (dev / CI / offline).
  */
 export const useAuth = process.env.NEXT_PUBLIC_PRIVY_APP_ID
   ? function useAuth() {

--- a/src/components/auth-required-dialog.tsx
+++ b/src/components/auth-required-dialog.tsx
@@ -1,0 +1,265 @@
+"use client";
+
+import { createContext, useCallback, useContext, useEffect, useMemo, useRef, useState } from "react";
+import { usePrivy } from "@privy-io/react-auth";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import {
+  AlertCircle,
+  Bell,
+  Cloud,
+  Loader2,
+  LogIn,
+  Pill,
+  Sparkles,
+  TestTube,
+  User,
+  type LucideIcon,
+} from "lucide-react";
+import { cn } from "@/lib/utils";
+
+export type AuthDialogVariant = "ai" | "push" | "expired" | "general";
+
+interface RequireAuthContextValue {
+  requireAuth: (variant?: AuthDialogVariant) => Promise<boolean>;
+  notifyExpired: () => Promise<boolean>;
+}
+
+const RequireAuthContext = createContext<RequireAuthContextValue | null>(null);
+
+interface DialogState {
+  open: boolean;
+  variant: AuthDialogVariant;
+}
+
+const noopContext: RequireAuthContextValue = {
+  requireAuth: async () => true,
+  notifyExpired: async () => true,
+};
+
+export function AuthRequiredProvider({ children }: { children: React.ReactNode }) {
+  if (!process.env.NEXT_PUBLIC_PRIVY_APP_ID) {
+    return (
+      <RequireAuthContext.Provider value={noopContext}>
+        {children}
+      </RequireAuthContext.Provider>
+    );
+  }
+  return <PrivyAuthRequiredProvider>{children}</PrivyAuthRequiredProvider>;
+}
+
+function PrivyAuthRequiredProvider({ children }: { children: React.ReactNode }) {
+  const { authenticated, login, logout } = usePrivy();
+  const [state, setState] = useState<DialogState>({ open: false, variant: "general" });
+  const resolverRef = useRef<((success: boolean) => void) | null>(null);
+
+  const closeWith = useCallback((success: boolean) => {
+    const resolve = resolverRef.current;
+    resolverRef.current = null;
+    setState((prev) => ({ ...prev, open: false }));
+    resolve?.(success);
+  }, []);
+
+  // Auto-resolve any pending request once Privy reports authenticated.
+  useEffect(() => {
+    if (authenticated && resolverRef.current) {
+      closeWith(true);
+    }
+  }, [authenticated, closeWith]);
+
+  const requireAuth = useCallback(
+    (variant: AuthDialogVariant = "general") => {
+      if (authenticated) return Promise.resolve(true);
+      return new Promise<boolean>((resolve) => {
+        resolverRef.current?.(false);
+        resolverRef.current = resolve;
+        setState({ open: true, variant });
+      });
+    },
+    [authenticated]
+  );
+
+  const notifyExpired = useCallback(async () => {
+    try {
+      await logout();
+    } catch {
+      // best-effort — Privy may already be in a bad state
+    }
+    return new Promise<boolean>((resolve) => {
+      resolverRef.current?.(false);
+      resolverRef.current = resolve;
+      setState({ open: true, variant: "expired" });
+    });
+  }, [logout]);
+
+  const value = useMemo<RequireAuthContextValue>(
+    () => ({ requireAuth, notifyExpired }),
+    [requireAuth, notifyExpired]
+  );
+
+  const handleOpenChange = (open: boolean) => {
+    if (!open) closeWith(false);
+  };
+
+  return (
+    <RequireAuthContext.Provider value={value}>
+      {children}
+      <AuthRequiredDialog
+        open={state.open}
+        variant={state.variant}
+        onOpenChange={handleOpenChange}
+        onSignIn={login}
+      />
+    </RequireAuthContext.Provider>
+  );
+}
+
+export function useRequireAuth(): RequireAuthContextValue {
+  const ctx = useContext(RequireAuthContext);
+  return ctx ?? noopContext;
+}
+
+interface VariantContent {
+  icon: LucideIcon;
+  iconClass: string;
+  title: string;
+  description: string;
+  features?: { icon: LucideIcon; label: string; comingSoon?: boolean }[];
+}
+
+const VARIANT_CONTENT: Record<AuthDialogVariant, VariantContent> = {
+  ai: {
+    icon: Sparkles,
+    iconClass: "text-orange-500",
+    title: "Sign in to use AI features",
+    description: "AI-powered parsing and lookups need a verified account.",
+    features: [
+      { icon: Sparkles, label: "Food & drink AI parsing" },
+      { icon: TestTube, label: "Substance lookup" },
+      { icon: Pill, label: "Medicine search & interactions" },
+    ],
+  },
+  push: {
+    icon: Bell,
+    iconClass: "text-teal-500",
+    title: "Sign in to enable reminders",
+    description: "Push notifications need a verified account so we can deliver them across your devices.",
+  },
+  expired: {
+    icon: AlertCircle,
+    iconClass: "text-amber-500",
+    title: "Your session expired",
+    description: "Sign in again to keep using AI features and reminders.",
+  },
+  general: {
+    icon: User,
+    iconClass: "text-primary",
+    title: "Sign in",
+    description: "Sign in to unlock cloud features. Your local data stays on this device.",
+    features: [
+      { icon: Sparkles, label: "AI food, drink & medicine parsing" },
+      { icon: Bell, label: "Medication reminders" },
+      { icon: Cloud, label: "Cloud sync", comingSoon: true },
+    ],
+  },
+};
+
+interface AuthRequiredDialogProps {
+  open: boolean;
+  variant: AuthDialogVariant;
+  onOpenChange: (open: boolean) => void;
+  onSignIn: () => void;
+}
+
+function AuthRequiredDialog({ open, variant, onOpenChange, onSignIn }: AuthRequiredDialogProps) {
+  const [submitting, setSubmitting] = useState(false);
+  const content = VARIANT_CONTENT[variant];
+  const Icon = content.icon;
+
+  useEffect(() => {
+    if (!open) setSubmitting(false);
+  }, [open]);
+
+  const handleSignIn = () => {
+    setSubmitting(true);
+    try {
+      onSignIn();
+    } catch {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-md">
+        <DialogHeader className="items-center text-center">
+          <div
+            className={cn(
+              "mx-auto mb-2 p-3 rounded-full bg-primary/10 w-fit",
+              variant === "expired" && "bg-amber-500/10"
+            )}
+          >
+            <Icon className={cn("w-6 h-6", content.iconClass)} />
+          </div>
+          <DialogTitle>{content.title}</DialogTitle>
+          <DialogDescription>{content.description}</DialogDescription>
+        </DialogHeader>
+
+        {content.features && content.features.length > 0 && (
+          <ul className="space-y-2 my-2">
+            {content.features.map((feature) => {
+              const FeatureIcon = feature.icon;
+              return (
+                <li
+                  key={feature.label}
+                  className="flex items-center gap-3 rounded-md border bg-muted/30 px-3 py-2 text-sm"
+                >
+                  <FeatureIcon className="w-4 h-4 text-muted-foreground shrink-0" />
+                  <span className="flex-1">{feature.label}</span>
+                  {feature.comingSoon && (
+                    <span className="text-[10px] uppercase tracking-wide font-medium text-muted-foreground bg-background border rounded px-1.5 py-0.5">
+                      Soon
+                    </span>
+                  )}
+                </li>
+              );
+            })}
+          </ul>
+        )}
+
+        <p className="text-xs text-center text-muted-foreground">
+          Local data stays on this device. Signing in only enables online features.
+        </p>
+
+        <div className="space-y-2 mt-2">
+          <Button
+            onClick={handleSignIn}
+            disabled={submitting}
+            className="w-full gap-2"
+            size="lg"
+          >
+            {submitting ? (
+              <Loader2 className="w-4 h-4 animate-spin" />
+            ) : (
+              <LogIn className="w-4 h-4" />
+            )}
+            Sign In
+          </Button>
+          <Button
+            variant="ghost"
+            onClick={() => onOpenChange(false)}
+            className="w-full"
+          >
+            Not now
+          </Button>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/auth-required-dialog.tsx
+++ b/src/components/auth-required-dialog.tsx
@@ -58,17 +58,27 @@ function PrivyAuthRequiredProvider({ children }: { children: React.ReactNode }) 
   const { authenticated, login, logout } = usePrivy();
   const [state, setState] = useState<DialogState>({ open: false, variant: "general" });
   const resolverRef = useRef<((success: boolean) => void) | null>(null);
+  // Tracks whether we've observed `authenticated === false` since the resolver
+  // was attached. Without this, the auto-resolve effect can fire on a stale
+  // `authenticated === true` render right after notifyExpired() opens the
+  // dialog (Privy's logout() does not synchronously flip the hook state).
+  const seenUnauthenticatedRef = useRef(false);
 
   const closeWith = useCallback((success: boolean) => {
     const resolve = resolverRef.current;
     resolverRef.current = null;
+    seenUnauthenticatedRef.current = false;
     setState((prev) => ({ ...prev, open: false }));
     resolve?.(success);
   }, []);
 
-  // Auto-resolve any pending request once Privy reports authenticated.
   useEffect(() => {
-    if (authenticated && resolverRef.current) {
+    if (!resolverRef.current) return;
+    if (!authenticated) {
+      seenUnauthenticatedRef.current = true;
+      return;
+    }
+    if (seenUnauthenticatedRef.current) {
       closeWith(true);
     }
   }, [authenticated, closeWith]);
@@ -78,6 +88,8 @@ function PrivyAuthRequiredProvider({ children }: { children: React.ReactNode }) 
       if (authenticated) return Promise.resolve(true);
       return new Promise<boolean>((resolve) => {
         resolverRef.current?.(false);
+        // We've already verified authenticated is false; the gate is open.
+        seenUnauthenticatedRef.current = true;
         resolverRef.current = resolve;
         setState({ open: true, variant });
       });
@@ -93,6 +105,8 @@ function PrivyAuthRequiredProvider({ children }: { children: React.ReactNode }) 
     }
     return new Promise<boolean>((resolve) => {
       resolverRef.current?.(false);
+      // Wait for an actual flip to unauthenticated before allowing auto-resolve.
+      seenUnauthenticatedRef.current = false;
       resolverRef.current = resolve;
       setState({ open: true, variant: "expired" });
     });

--- a/src/components/food-salt/food-section.tsx
+++ b/src/components/food-salt/food-section.tsx
@@ -16,6 +16,7 @@ import { cn } from "@/lib/utils";
 import { CARD_THEMES } from "@/lib/card-themes";
 import { RecentEntriesList, InlineEditFormShell } from "@/components/recent-entries-list";
 import { parseIntakeWithAI } from "@/lib/ai-client";
+import { useAiFetch } from "@/hooks/use-ai-fetch";
 import {
   useAddComposableEntry,
   type ComposableEntryInput,
@@ -30,7 +31,6 @@ import { useDeleteWithToast } from "@/hooks/use-delete-with-toast";
 import { useSaltTotalsByGroupIds, useDeleteIntake, useUpdateIntake } from "@/hooks/use-intake-queries";
 import { useEditRecord } from "@/hooks/use-edit-record";
 import { useToast } from "@/hooks/use-toast";
-import { useAuth } from "@/components/auth-guard";
 import { type EatingRecord } from "@/lib/db";
 import {
   getCurrentDateTimeLocal,
@@ -52,7 +52,7 @@ const SODIUM_MULTIPLIERS: Record<SodiumSource, number> = {
 
 export function FoodSection() {
   const { toast } = useToast();
-  const { getAuthHeader } = useAuth();
+  const aiFetch = useAiFetch();
   const addComposableEntry = useAddComposableEntry();
 
   // ─── Mutations ────────────────────────────────────────────────────
@@ -132,8 +132,10 @@ export function FoodSection() {
 
     setIsParsing(true);
     try {
-      const authHeaders = await getAuthHeader();
-      const result = await parseIntakeWithAI(trimmed, { authHeaders });
+      const result = await parseIntakeWithAI(trimmed, aiFetch);
+
+      // User dismissed the sign-in prompt
+      if (!result) return;
 
       // Populate form fields from AI result
       if (result.salt && result.salt > 0) {
@@ -163,7 +165,7 @@ export function FoodSection() {
     } finally {
       setIsParsing(false);
     }
-  }, [foodText, isParsing, toast, getAuthHeader]);
+  }, [foodText, isParsing, toast, aiFetch]);
 
   const handleDetailSubmit = useCallback(async () => {
     if (isSubmitting) return;

--- a/src/components/header-auth-indicator.tsx
+++ b/src/components/header-auth-indicator.tsx
@@ -1,0 +1,85 @@
+"use client";
+
+import { usePrivy } from "@privy-io/react-auth";
+import { Button } from "@/components/ui/button";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
+import { LogIn, LogOut, User } from "lucide-react";
+import { useRequireAuth } from "@/components/auth-required-dialog";
+
+export function HeaderAuthIndicator() {
+  if (!process.env.NEXT_PUBLIC_PRIVY_APP_ID) return null;
+  return <PrivyHeaderAuthIndicator />;
+}
+
+function PrivyHeaderAuthIndicator() {
+  const { ready, authenticated, user, logout } = usePrivy();
+  const { requireAuth } = useRequireAuth();
+
+  if (!ready) {
+    return (
+      <Button
+        variant="ghost"
+        size="icon"
+        disabled
+        className="shrink-0"
+        aria-label="Loading account"
+      >
+        <User className="w-5 h-5 text-muted-foreground/40" />
+      </Button>
+    );
+  }
+
+  if (!authenticated) {
+    return (
+      <Button
+        variant="ghost"
+        size="icon"
+        onClick={() => requireAuth("general")}
+        className="shrink-0"
+        aria-label="Sign in"
+        title="Sign in"
+      >
+        <LogIn className="w-5 h-5" />
+      </Button>
+    );
+  }
+
+  const email = user?.email?.address;
+  const initial = (email?.[0] ?? user?.wallet?.address?.[2] ?? "U").toUpperCase();
+
+  return (
+    <Popover>
+      <PopoverTrigger asChild>
+        <Button
+          variant="ghost"
+          size="icon"
+          className="shrink-0"
+          aria-label="Account menu"
+        >
+          <span className="flex items-center justify-center w-7 h-7 rounded-full bg-primary/10 text-primary text-sm font-semibold">
+            {initial}
+          </span>
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent align="end" className="w-56 p-2">
+        <div className="px-2 py-1.5 text-sm">
+          <p className="font-medium truncate">{email ?? "Signed in"}</p>
+          <p className="text-xs text-muted-foreground">AI & reminders enabled</p>
+        </div>
+        <Button
+          variant="ghost"
+          size="sm"
+          className="w-full justify-start gap-2 text-red-600 hover:text-red-700 hover:bg-red-50 dark:hover:bg-red-950/30"
+          onClick={() => logout()}
+        >
+          <LogOut className="w-4 h-4" />
+          Sign out
+        </Button>
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/src/components/liquids/preset-tab.tsx
+++ b/src/components/liquids/preset-tab.tsx
@@ -13,7 +13,7 @@ import { useSettings } from "@/hooks/use-settings";
 import { useIntake } from "@/hooks/use-intake-queries";
 import { useAddComposableEntry, type ComposableEntryInput } from "@/hooks/use-composable-entry";
 import { useToast } from "@/hooks/use-toast";
-import { useAuth } from "@/components/auth-guard";
+import { useAiFetch } from "@/hooks/use-ai-fetch";
 import {
   AlertDialog,
   AlertDialogAction,
@@ -52,7 +52,7 @@ export function PresetTab({ tab }: PresetTabProps) {
   const deletePreset = useSettingsStore((s) => s.deleteLiquidPreset);
   const addEntry = useAddComposableEntry();
   const { toast } = useToast();
-  const { getAuthHeader } = useAuth();
+  const aiFetch = useAiFetch();
 
   // Water progress data
   const settings = useSettings();
@@ -183,12 +183,15 @@ export function PresetTab({ tab }: PresetTabProps) {
     setIsLookingUp(true);
     setSelectedPresetId(null);
     try {
-      const authHeaders = await getAuthHeader();
-      const res = await fetch("/api/ai/substance-lookup", {
+      const res = await aiFetch("/api/ai/substance-lookup", {
         method: "POST",
-        headers: { "Content-Type": "application/json", ...authHeaders },
+        headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ query: searchText.trim(), type: aiLookupType }),
       });
+      if (!res) {
+        // User dismissed sign-in
+        return;
+      }
       if (!res.ok) throw new Error("Lookup failed");
       const data = await res.json();
       // Map AI response substancePer100ml to correct per-100ml field based on tab

--- a/src/components/medications/add-medication-wizard.tsx
+++ b/src/components/medications/add-medication-wizard.tsx
@@ -11,7 +11,7 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
 import { PillIcon } from "./pill-icon";
-import { useMedicineSearch, type MedicineSearchResult } from "@/hooks/use-medicine-search";
+import { useMedicineSearch, MedicineSearchCancelledError, type MedicineSearchResult } from "@/hooks/use-medicine-search";
 import { useAddPrescription, usePrescriptions, useAddMedicationToPrescription, usePhasesForPrescription } from "@/hooks/use-medication-queries";
 import { useToast } from "@/hooks/use-toast";
 import { Switch } from "@/components/ui/switch";
@@ -539,7 +539,9 @@ export function AddMedicationWizard({ open, onOpenChange }: AddMedicationWizardP
                 onSearch={handleSearch}
                 isSearching={searchMutation.isPending}
                 result={searchResult}
-                {...(searchMutation.error?.message && { error: searchMutation.error.message })}
+                {...(searchMutation.error &&
+                  !(searchMutation.error instanceof MedicineSearchCancelledError) &&
+                  searchMutation.error.message && { error: searchMutation.error.message })}
                 brandName={brandName}
                 onBrandNameChange={(v) => setBrandName(capitalizeWords(v))}
                 genericName={genericName}

--- a/src/components/medications/medication-settings-view.tsx
+++ b/src/components/medications/medication-settings-view.tsx
@@ -3,6 +3,7 @@
 import { useState } from "react";
 import { useSettingsStore } from "@/stores/settings-store";
 import { useDoseReminderToggle } from "@/hooks/use-push-schedule-sync";
+import { useAuth } from "@/components/auth-guard";
 import { Label } from "@/components/ui/label";
 import { Button } from "@/components/ui/button";
 import { Switch } from "@/components/ui/switch";
@@ -305,6 +306,7 @@ export function MedicationSettingsView() {
   const setReminderFollowUpInterval = useSettingsStore((s) => s.setReminderFollowUpInterval);
 
   const { handleToggle: handleToggleReminders, toggling: togglingReminders, supported: notificationsSupported } = useDoseReminderToggle();
+  const { authenticated: isSignedIn } = useAuth();
 
   return (
     <div className="space-y-6 pb-24">
@@ -326,9 +328,11 @@ export function MedicationSettingsView() {
           <div className="space-y-0.5">
             <Label htmlFor="dose-reminders-toggle">Enable Reminders</Label>
             <p className="text-[13px] text-muted-foreground">
-              {notificationsSupported
-                ? "Get push notifications when medications are due"
-                : "Notifications not supported in this browser"}
+              {!notificationsSupported
+                ? "Notifications not supported in this browser"
+                : !isSignedIn && !doseRemindersEnabled
+                  ? "Sign in to enable push reminders across devices"
+                  : "Get push notifications when medications are due"}
             </p>
           </div>
           <Switch

--- a/src/components/medications/titrations-view.tsx
+++ b/src/components/medications/titrations-view.tsx
@@ -49,7 +49,7 @@ import {
   useDeleteTitrationPlan,
 } from "@/hooks/use-medication-queries";
 import type { TitrationPlan, MedicationPhase, Prescription } from "@/lib/db";
-import { useAuth } from "@/components/auth-guard";
+import { useAiFetch } from "@/hooks/use-ai-fetch";
 import {
   Plus,
   Play,
@@ -493,7 +493,7 @@ function TitrationDrawer({
 }) {
   const createMutation = useCreateTitrationPlan();
   const updateMutation = useUpdateTitrationPlan();
-  const { getAuthHeader } = useAuth();
+  const aiFetch = useAiFetch();
   const isEditing = editingPlan !== null;
 
   // Load existing phases for editing
@@ -645,10 +645,9 @@ function TitrationDrawer({
 
     setAiLoading(true);
     try {
-      const authHeaders = await getAuthHeader();
-      const res = await fetch("/api/ai/titration-warnings", {
+      const res = await aiFetch("/api/ai/titration-warnings", {
         method: "POST",
-        headers: { "Content-Type": "application/json", ...authHeaders },
+        headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
           prescriptions: changingRx,
           otherMedications: otherRx.length > 0 ? otherRx : undefined,
@@ -656,7 +655,7 @@ function TitrationDrawer({
         }),
       });
 
-      if (res.ok) {
+      if (res && res.ok) {
         const data = await res.json();
         if (data.warnings && Array.isArray(data.warnings)) {
           const existing = warnings.trim();

--- a/src/components/settings/account-section.tsx
+++ b/src/components/settings/account-section.tsx
@@ -2,7 +2,8 @@
 
 import { usePrivy } from "@privy-io/react-auth";
 import { Button } from "@/components/ui/button";
-import { User, LogOut } from "lucide-react";
+import { Bell, Cloud, LogOut, Pill, Sparkles, TestTube, User, type LucideIcon } from "lucide-react";
+import { useRequireAuth } from "@/components/auth-required-dialog";
 
 export function AccountSection() {
   if (!process.env.NEXT_PUBLIC_PRIVY_APP_ID) return null;
@@ -10,10 +11,17 @@ export function AccountSection() {
   return <PrivyAccountSection />;
 }
 
-function PrivyAccountSection() {
-  const { authenticated, user, logout } = usePrivy();
+const FEATURES: { icon: LucideIcon; label: string; comingSoon?: boolean }[] = [
+  { icon: Sparkles, label: "AI food & drink parsing" },
+  { icon: TestTube, label: "Substance lookup" },
+  { icon: Pill, label: "Medicine search & interactions" },
+  { icon: Bell, label: "Medication reminders" },
+  { icon: Cloud, label: "Cloud sync", comingSoon: true },
+];
 
-  if (!authenticated) return null;
+function PrivyAccountSection() {
+  const { ready, authenticated, user, logout } = usePrivy();
+  const { requireAuth } = useRequireAuth();
 
   return (
     <div className="space-y-4">
@@ -21,20 +29,60 @@ function PrivyAccountSection() {
         <User className="w-4 h-4" />
         <h3 className="font-semibold">Account</h3>
       </div>
-      <div className="space-y-3">
-        <div className="p-3 rounded-lg bg-slate-50 dark:bg-slate-900 border">
-          <p className="text-sm font-medium">{user?.email?.address || "Authenticated user"}</p>
-          <p className="text-xs text-muted-foreground">Signed in</p>
+
+      {!ready ? (
+        <div className="p-3 rounded-lg border bg-muted/30 text-sm text-muted-foreground">
+          Loading…
         </div>
-        <Button
-          variant="outline"
-          className="w-full justify-start gap-2 text-red-600 hover:text-red-700 hover:bg-red-50 dark:hover:bg-red-950/30"
-          onClick={logout}
-        >
-          <LogOut className="w-4 h-4" />
-          Sign Out
-        </Button>
-      </div>
+      ) : authenticated ? (
+        <div className="space-y-3">
+          <div className="p-3 rounded-lg bg-slate-50 dark:bg-slate-900 border">
+            <p className="text-sm font-medium truncate">
+              {user?.email?.address ?? "Authenticated user"}
+            </p>
+            <p className="text-xs text-emerald-600 dark:text-emerald-400">
+              Signed in — AI & reminders enabled
+            </p>
+          </div>
+          <Button
+            variant="outline"
+            className="w-full justify-start gap-2 text-red-600 hover:text-red-700 hover:bg-red-50 dark:hover:bg-red-950/30"
+            onClick={() => logout()}
+          >
+            <LogOut className="w-4 h-4" />
+            Sign Out
+          </Button>
+        </div>
+      ) : (
+        <div className="space-y-3">
+          <div className="p-3 rounded-lg border bg-muted/30">
+            <p className="text-sm font-medium">Not signed in</p>
+            <p className="text-xs text-muted-foreground">
+              Local-only mode. Sign in to unlock cloud features.
+            </p>
+          </div>
+          <ul className="space-y-1.5">
+            {FEATURES.map(({ icon: Icon, label, comingSoon }) => (
+              <li
+                key={label}
+                className="flex items-center gap-3 text-sm text-muted-foreground"
+              >
+                <Icon className="w-4 h-4 shrink-0" />
+                <span className="flex-1">{label}</span>
+                {comingSoon && (
+                  <span className="text-[10px] uppercase tracking-wide font-medium bg-background border rounded px-1.5 py-0.5">
+                    Soon
+                  </span>
+                )}
+              </li>
+            ))}
+          </ul>
+          <Button className="w-full gap-2" onClick={() => requireAuth("general")}>
+            <User className="w-4 h-4" />
+            Sign In
+          </Button>
+        </div>
+      )}
     </div>
   );
 }

--- a/src/components/substance/substance-type-picker.tsx
+++ b/src/components/substance/substance-type-picker.tsx
@@ -124,7 +124,7 @@ export function SubstanceTypePicker({
       });
 
       if (!response) {
-        // User dismissed sign-in
+        // User dismissed sign-in — stay on the input step.
         setIsEnriching(false);
         return;
       }
@@ -141,6 +141,7 @@ export function SubstanceTypePicker({
           setOverrideAmount(String(data.standardDrinks ?? ""));
           setOverrideVolume(String(data.volumeMl ?? ""));
         }
+        setStep("other-result");
       } else {
         // Fallback to defaults on error
         setAiResult(null);
@@ -156,6 +157,7 @@ export function SubstanceTypePicker({
           setOverrideAmount(String(otherType.defaultDrinks));
           setOverrideVolume(String(otherType.defaultVolumeMl));
         }
+        setStep("other-result");
       }
     } catch {
       // Offline or network error -- fallback to defaults
@@ -172,9 +174,9 @@ export function SubstanceTypePicker({
         setOverrideAmount(String(otherType.defaultDrinks));
         setOverrideVolume(String(otherType.defaultVolumeMl));
       }
+      setStep("other-result");
     } finally {
       setIsEnriching(false);
-      setStep("other-result");
     }
   };
 

--- a/src/components/substance/substance-type-picker.tsx
+++ b/src/components/substance/substance-type-picker.tsx
@@ -13,7 +13,7 @@ import {
 } from "@/components/ui/drawer";
 import { Loader2, Sparkles, Edit3 } from "lucide-react";
 import { useSettingsStore } from "@/stores/settings-store";
-import { useAuth } from "@/components/auth-guard";
+import { useAiFetch } from "@/hooks/use-ai-fetch";
 
 export interface SubstanceTypeSelection {
   name: string;
@@ -46,7 +46,7 @@ export function SubstanceTypePicker({
   onSelect,
 }: SubstanceTypePickerProps) {
   const substanceConfig = useSettingsStore((s) => s.substanceConfig);
-  const { getAuthHeader } = useAuth();
+  const aiFetch = useAiFetch();
 
   const [step, setStep] = useState<PickerStep>("select");
   const [customDescription, setCustomDescription] = useState("");
@@ -114,15 +114,20 @@ export function SubstanceTypePicker({
     setIsEnriching(true);
 
     try {
-      const authHeaders = await getAuthHeader();
-      const response = await fetch("/api/ai/substance-enrich", {
+      const response = await aiFetch("/api/ai/substance-enrich", {
         method: "POST",
-        headers: { "Content-Type": "application/json", ...authHeaders },
+        headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
           description: customDescription.trim(),
           type,
         }),
       });
+
+      if (!response) {
+        // User dismissed sign-in
+        setIsEnriching(false);
+        return;
+      }
 
       if (response.ok) {
         const data = await response.json();

--- a/src/hooks/use-ai-fetch.ts
+++ b/src/hooks/use-ai-fetch.ts
@@ -1,0 +1,54 @@
+"use client";
+
+import { useCallback } from "react";
+import { useAuth } from "@/components/auth-guard";
+import {
+  useRequireAuth,
+  type AuthDialogVariant,
+} from "@/components/auth-required-dialog";
+
+/**
+ * Fetch wrapper for authenticated /api/ai/* endpoints.
+ *
+ * - Prompts the sign-in modal if the user is not authenticated and waits
+ *   for them to log in. Resolves with `null` if the user dismisses.
+ * - Attaches the Privy bearer token automatically.
+ * - On a 401 with `{ requiresAuth: true }` response body, treats the session
+ *   as expired: signs the user out, reopens the modal, and retries once on
+ *   successful re-login.
+ */
+export function useAiFetch() {
+  const { getAuthHeader } = useAuth();
+  const { requireAuth, notifyExpired } = useRequireAuth();
+
+  return useCallback(
+    async (
+      input: RequestInfo | URL,
+      init: RequestInit = {},
+      variant: AuthDialogVariant = "ai"
+    ): Promise<Response | null> => {
+      const ok = await requireAuth(variant);
+      if (!ok) return null;
+
+      const authHeaders = await getAuthHeader();
+      const baseHeaders = { ...(init.headers ?? {}), ...authHeaders };
+      let res = await fetch(input, { ...init, headers: baseHeaders });
+
+      if (res.status === 401) {
+        const body = await res.clone().json().catch(() => ({}));
+        if (body?.requiresAuth) {
+          const reauthOk = await notifyExpired();
+          if (!reauthOk) return res;
+          const retryHeaders = {
+            ...(init.headers ?? {}),
+            ...(await getAuthHeader()),
+          };
+          res = await fetch(input, { ...init, headers: retryHeaders });
+        }
+      }
+
+      return res;
+    },
+    [getAuthHeader, requireAuth, notifyExpired]
+  );
+}

--- a/src/hooks/use-interaction-check.ts
+++ b/src/hooks/use-interaction-check.ts
@@ -74,8 +74,9 @@ export function useInteractionCheck() {
     const controller = new AbortController();
     abortRef.current = controller;
 
-    // 15-second timeout
-    const timeoutId = setTimeout(() => controller.abort(), 15000);
+    // The 15s abort timer must not start while the sign-in modal is open;
+    // arm it only once aiFetch resolves with an actual Response.
+    let timeoutId: ReturnType<typeof setTimeout> | null = null;
 
     setIsLoading(true);
     setError(null);
@@ -89,13 +90,13 @@ export function useInteractionCheck() {
         signal: controller.signal,
       });
 
-      clearTimeout(timeoutId);
-
       if (!response) {
         // User dismissed sign-in
         setIsLoading(false);
         return null;
       }
+
+      timeoutId = setTimeout(() => controller.abort(), 15000);
 
       if (!response.ok) {
         const body = await response.json().catch(() => ({}));
@@ -116,8 +117,6 @@ export function useInteractionCheck() {
 
       return result;
     } catch (err) {
-      clearTimeout(timeoutId);
-
       if (err instanceof DOMException && err.name === "AbortError") {
         setError("Interaction check timed out");
       } else {
@@ -126,6 +125,8 @@ export function useInteractionCheck() {
 
       setIsLoading(false);
       return null;
+    } finally {
+      if (timeoutId !== null) clearTimeout(timeoutId);
     }
   }, [aiFetch]);
 

--- a/src/hooks/use-interaction-check.ts
+++ b/src/hooks/use-interaction-check.ts
@@ -1,7 +1,7 @@
 import { useState, useCallback, useRef } from "react";
 import { getCached, setCache } from "@/lib/interaction-cache";
 import { useUpdatePrescription } from "@/hooks/use-medication-queries";
-import { useAuth } from "@/components/auth-guard";
+import { useAiFetch } from "@/hooks/use-ai-fetch";
 
 // --- Types ---
 
@@ -42,7 +42,7 @@ export function useInteractionCheck() {
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const abortRef = useRef<AbortController | null>(null);
-  const { getAuthHeader } = useAuth();
+  const aiFetch = useAiFetch();
 
   const reset = useCallback(() => {
     setData(null);
@@ -82,15 +82,20 @@ export function useInteractionCheck() {
     setData(null);
 
     try {
-      const authHeaders = await getAuthHeader();
-      const response = await fetch("/api/ai/interaction-check", {
+      const response = await aiFetch("/api/ai/interaction-check", {
         method: "POST",
-        headers: { "Content-Type": "application/json", ...authHeaders },
+        headers: { "Content-Type": "application/json" },
         body: JSON.stringify(params),
         signal: controller.signal,
       });
 
       clearTimeout(timeoutId);
+
+      if (!response) {
+        // User dismissed sign-in
+        setIsLoading(false);
+        return null;
+      }
 
       if (!response.ok) {
         const body = await response.json().catch(() => ({}));
@@ -122,7 +127,7 @@ export function useInteractionCheck() {
       setIsLoading(false);
       return null;
     }
-  }, [getAuthHeader]);
+  }, [aiFetch]);
 
   return { check, data, isLoading, error, reset };
 }
@@ -132,7 +137,7 @@ export function useInteractionCheck() {
 export function useRefreshInteractions() {
   const [isRefreshing, setIsRefreshing] = useState(false);
   const updatePrescription = useUpdatePrescription();
-  const { getAuthHeader } = useAuth();
+  const aiFetch = useAiFetch();
 
   const refresh = useCallback(
     async (
@@ -143,10 +148,9 @@ export function useRefreshInteractions() {
       setIsRefreshing(true);
 
       try {
-        const authHeaders = await getAuthHeader();
-        const response = await fetch("/api/ai/interaction-check", {
+        const response = await aiFetch("/api/ai/interaction-check", {
           method: "POST",
-          headers: { "Content-Type": "application/json", ...authHeaders },
+          headers: { "Content-Type": "application/json" },
           body: JSON.stringify({
             mode: "conflict" as const,
             newMedication: genericName,
@@ -154,7 +158,7 @@ export function useRefreshInteractions() {
           }),
         });
 
-        if (!response.ok) {
+        if (!response || !response.ok) {
           setIsRefreshing(false);
           return null;
         }
@@ -191,7 +195,7 @@ export function useRefreshInteractions() {
         return null;
       }
     },
-    [updatePrescription, getAuthHeader]
+    [updatePrescription, aiFetch]
   );
 
   return { refresh, isRefreshing };

--- a/src/hooks/use-medicine-search.ts
+++ b/src/hooks/use-medicine-search.ts
@@ -1,7 +1,7 @@
 "use client";
 
 import { useMutation } from "@tanstack/react-query";
-import { useAuth } from "@/components/auth-guard";
+import { useAiFetch } from "@/hooks/use-ai-fetch";
 import { useSettingsStore } from "@/stores/settings-store";
 
 export interface MedicineSearchResult {
@@ -22,15 +22,22 @@ export interface MedicineSearchResult {
   isGenericFallback: boolean;
 }
 
+export class MedicineSearchCancelledError extends Error {
+  constructor() {
+    super("Medicine search cancelled");
+    this.name = "MedicineSearchCancelledError";
+  }
+}
+
 export function useMedicineSearch() {
-  const { getAuthHeader } = useAuth();
+  const aiFetch = useAiFetch();
 
   return useMutation({
     mutationFn: async (query: string): Promise<MedicineSearchResult> => {
       const state = useSettingsStore.getState();
       const primary = state.primaryRegion;
       const secondary = state.secondaryRegion;
-      
+
       let countryContext: string | undefined = undefined;
       if (primary && primary !== "none") {
         countryContext = primary;
@@ -39,23 +46,18 @@ export function useMedicineSearch() {
         }
       }
 
-      const headers: Record<string, string> = {
-        "Content-Type": "application/json",
-      };
-
-      const authHeader = await getAuthHeader();
-      if (authHeader.Authorization) {
-        headers.Authorization = authHeader.Authorization;
-      }
-
-      const response = await fetch("/api/ai/medicine-search", {
+      const response = await aiFetch("/api/ai/medicine-search", {
         method: "POST",
-        headers,
+        headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
           query,
           country: countryContext,
         }),
       });
+
+      if (!response) {
+        throw new MedicineSearchCancelledError();
+      }
 
       if (!response.ok) {
         const data = await response.json().catch(() => ({}));

--- a/src/hooks/use-push-schedule-sync.ts
+++ b/src/hooks/use-push-schedule-sync.ts
@@ -3,6 +3,8 @@
 import { useState, useEffect, useRef, useCallback } from "react";
 import { useSettingsStore } from "@/stores/settings-store";
 import { useDailyDoseSchedule } from "@/hooks/use-medication-queries";
+import { useAuth } from "@/components/auth-guard";
+import { useRequireAuth } from "@/components/auth-required-dialog";
 import {
   subscribeToPush,
   unsubscribeFromPush,
@@ -75,50 +77,37 @@ function buildScheduleEntries(
 /**
  * Hook that syncs dose schedule to server when push reminders are enabled.
  * Runs on mount and when schedule data changes. Debounced via schedule hash.
- *
- * @param getAuthToken - Optional function to get auth token (e.g., from usePrivy)
+ * No-ops when the user is not signed in (push subscriptions require auth).
  */
-export function usePushScheduleSync(getAuthToken?: () => Promise<string | null>): void {
+export function usePushScheduleSync(): void {
   const doseRemindersEnabled = useSettingsStore((s) => s.doseRemindersEnabled);
   const followUpCount = useSettingsStore((s) => s.reminderFollowUpCount);
   const followUpInterval = useSettingsStore((s) => s.reminderFollowUpInterval);
+  const { authenticated, getAuthHeader } = useAuth();
 
   const todayStr = getTodayDateStr();
   const slots = useDailyDoseSchedule(todayStr);
 
   const lastHashRef = useRef<string>("");
-  const getAuthTokenRef = useRef(getAuthToken);
-  getAuthTokenRef.current = getAuthToken;
 
   const syncSchedule = useCallback(async (entries: ScheduleEntry[]) => {
     try {
-      const headers: Record<string, string> = {
-        "Content-Type": "application/json",
-      };
-
-      // Add auth token if available
-      if (getAuthTokenRef.current) {
-        try {
-          const token = await getAuthTokenRef.current();
-          if (token) {
-            headers["Authorization"] = `Bearer ${token}`;
-          }
-        } catch {
-          // Auth not available -- continue without token (server falls back to dev user if Privy not configured)
-        }
-      }
-
+      const authHeaders = await getAuthHeader();
       await fetch("/api/push/sync-schedule", {
         method: "POST",
-        headers,
+        headers: {
+          "Content-Type": "application/json",
+          ...authHeaders,
+        },
         body: JSON.stringify({ schedules: entries }),
       });
     } catch (error) {
       console.warn("[push-schedule-sync] Failed to sync schedule:", error);
     }
-  }, []);
+  }, [getAuthHeader]);
 
   useEffect(() => {
+    if (!authenticated) return;
     if (!doseRemindersEnabled) return;
     if (!slots || slots.length === 0) return;
 
@@ -130,7 +119,7 @@ export function usePushScheduleSync(getAuthToken?: () => Promise<string | null>)
     lastHashRef.current = hash;
 
     syncSchedule(entries);
-  }, [slots, doseRemindersEnabled, followUpCount, followUpInterval, syncSchedule]);
+  }, [authenticated, slots, doseRemindersEnabled, followUpCount, followUpInterval, syncSchedule]);
 }
 
 /**
@@ -142,23 +131,31 @@ export function useDoseReminderToggle() {
   const setDoseRemindersEnabled = useSettingsStore((s) => s.setDoseRemindersEnabled);
   const [toggling, setToggling] = useState(false);
   const supported = typeof window !== "undefined" && isNotificationSupported();
+  const { getAccessToken } = useAuth();
+  const { requireAuth } = useRequireAuth();
 
   const handleToggle = useCallback(async (enabled: boolean) => {
     setToggling(true);
     try {
       if (enabled) {
+        // Push subscriptions are stored server-side keyed by Privy user ID.
+        const ok = await requireAuth("push");
+        if (!ok) return;
+
         const permResult = await requestNotificationPermission();
         if (!permResult.success || permResult.data !== "granted") {
           return;
         }
-        const subscription = await subscribeToPush("");
+        const token = (await getAccessToken()) ?? "";
+        const subscription = await subscribeToPush(token);
         if (!subscription) {
           console.warn("[dose-reminders] Push subscription failed");
           return;
         }
         setDoseRemindersEnabled(true);
       } else {
-        await unsubscribeFromPush("");
+        const token = (await getAccessToken()) ?? "";
+        await unsubscribeFromPush(token);
         setDoseRemindersEnabled(false);
       }
     } catch (error) {
@@ -166,7 +163,7 @@ export function useDoseReminderToggle() {
     } finally {
       setToggling(false);
     }
-  }, [setDoseRemindersEnabled]);
+  }, [setDoseRemindersEnabled, requireAuth, getAccessToken]);
 
   return { handleToggle, toggling, supported };
 }

--- a/src/hooks/use-push-schedule-sync.ts
+++ b/src/hooks/use-push-schedule-sync.ts
@@ -154,9 +154,27 @@ export function useDoseReminderToggle() {
         }
         setDoseRemindersEnabled(true);
       } else {
-        const token = (await getAccessToken()) ?? "";
-        await unsubscribeFromPush(token);
-        setDoseRemindersEnabled(false);
+        // Disable: always perform the browser-side unsubscribe so reminders
+        // actually stop on this device. If we have a token, also tell the
+        // server; otherwise skip the server call (a stale row will be cleaned
+        // up by /api/push/send when the dead endpoint 410s).
+        const token = await getAccessToken();
+        let unsubscribed = false;
+        if (token) {
+          unsubscribed = await unsubscribeFromPush(token);
+        } else if (typeof navigator !== "undefined" && "serviceWorker" in navigator) {
+          try {
+            const reg = await navigator.serviceWorker.ready;
+            const sub = await reg.pushManager.getSubscription();
+            if (sub) await sub.unsubscribe();
+            unsubscribed = true;
+          } catch {
+            unsubscribed = false;
+          }
+        }
+        if (unsubscribed) {
+          setDoseRemindersEnabled(false);
+        }
       }
     } catch (error) {
       console.error("[dose-reminders] Toggle failed:", error);

--- a/src/lib/ai-client.ts
+++ b/src/lib/ai-client.ts
@@ -7,43 +7,36 @@ export interface ParsedIntake {
   reasoning?: string;
 }
 
+type AiFetcher = (
+  input: RequestInfo | URL,
+  init?: RequestInit
+) => Promise<Response | null>;
+
 /**
  * PRIVACY & SECURITY:
- * - Uses Privy authentication to verify user identity
  * - Server verifies user is on whitelist before processing
  * - API key stored in server environment only
  * - PII patterns are stripped before AI processing
  * - All requests are audit logged
+ *
+ * Returns null if the user dismisses the auth prompt.
  */
-
 export async function parseIntakeWithAI(
   input: string,
-  options?: {
-    authToken?: string; // Privy access token (legacy)
-    authHeaders?: Record<string, string>; // Auth headers from useAuth().getAuthHeader()
-  }
-): Promise<ParsedIntake> {
+  fetcher: AiFetcher
+): Promise<ParsedIntake | null> {
   logAudit("ai_parse_request");
 
   try {
-    // Build headers with auth token
-    const headers: Record<string, string> = {
-      "Content-Type": "application/json",
-    };
-
-    // Add auth headers (prefer authHeaders over legacy authToken)
-    if (options?.authHeaders) {
-      Object.assign(headers, options.authHeaders);
-    } else if (options?.authToken) {
-      headers["Authorization"] = `Bearer ${options.authToken}`;
-    }
-
-    // Use server-side route (API key in env only)
-    const response = await fetch("/api/ai/parse", {
+    const response = await fetcher("/api/ai/parse", {
       method: "POST",
-      headers,
+      headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ input }),
     });
+
+    if (!response) {
+      return null;
+    }
 
     if (!response.ok) {
       const errorData = await response.json().catch(() => ({}));
@@ -51,9 +44,9 @@ export async function parseIntakeWithAI(
     }
 
     const result = await response.json();
-    
+
     logAudit("ai_parse_success");
-    
+
     return {
       water: result.water,
       salt: result.salt,


### PR DESCRIPTION
Remove the AuthGuard page-level gate so users can access /, /medications,
/analytics, and /settings fully offline. Replace it with a contextual
AuthRequiredDialog triggered only when the user invokes a feature that
needs Privy: AI parsing/lookup/search/interaction-check/titration warnings,
and dose-reminder push subscriptions.

- Add AuthRequiredProvider + useRequireAuth() with variants (ai/push/expired)
- Add useAiFetch() helper that prompts sign-in, attaches the bearer token,
  and on 401 { requiresAuth: true } signs the user out and reopens the
  modal for re-login + retry
- Add HeaderAuthIndicator (sign-in icon / avatar + popover with sign-out)
- Rewrite AccountSection with explicit logged-out feature list and CTA
- Gate dose-reminder toggle on auth and pass real Privy access tokens to
  push subscribe/unsubscribe (was previously sending empty Authorization)
- Refactor parseIntakeWithAI signature to accept the auth-aware fetcher

Local IndexedDB data is device-scoped only (no userId field anywhere), so
there is no migration impact when transitioning anonymous -> logged in.

https://claude.ai/code/session_01P96Ebr7bJwJ1MiocdtBSQZ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added authentication indicator in header displaying account status with menu options
  * AI-powered features and push reminders now prompt for sign-in when needed
  * Updated account settings to display available features based on sign-in status ("Local-only mode" vs full-feature access)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->