### PR TITLE
Replace BP delta with pulse pressure calculation

### DIFF
--- a/src/components/blood-pressure-card.tsx
+++ b/src/components/blood-pressure-card.tsx
@@ -11,10 +11,10 @@ import { cn } from "@/lib/utils";
 import { CARD_THEMES } from "@/lib/card-themes";
 import { logAudit } from "@/lib/audit";
 
-function formatDelta(d: number) { return d > 0 ? `+${d}` : `${d}`; }
-function deltaColor(d: number) {
-  return d > 0 ? "text-red-500 dark:text-red-400"
-    : d < 0 ? "text-green-600 dark:text-green-400"
+function pulsePressureColor(pp: number) {
+  // Normal pulse pressure is roughly 40 mmHg; >60 elevated, <30 narrow.
+  return pp > 60 || pp < 30
+    ? "text-red-500 dark:text-red-400"
     : "text-muted-foreground";
 }
 
@@ -181,12 +181,9 @@ export function BloodPressureCard() {
     }
   };
 
-  // BP delta vs previous reading
-  const prevReading = recentRecords?.[1];
-  const bpDelta = latestReading && prevReading ? {
-    sys: latestReading.systolic - prevReading.systolic,
-    dia: latestReading.diastolic - prevReading.diastolic,
-  } : null;
+  const pulsePressure = latestReading
+    ? latestReading.systolic - latestReading.diastolic
+    : null;
 
   return (
     <>
@@ -218,11 +215,11 @@ export function BloodPressureCard() {
               {latestReading.heartRate && (
                 <p className="text-xs text-muted-foreground">{latestReading.heartRate} BPM</p>
               )}
-              {bpDelta && (
+              {pulsePressure !== null && (
                 <p className="text-xs">
-                  <span className={deltaColor(bpDelta.sys)}>{formatDelta(bpDelta.sys)}</span>
-                  <span className="text-muted-foreground"> / </span>
-                  <span className={deltaColor(bpDelta.dia)}>{formatDelta(bpDelta.dia)}</span>
+                  <span className="text-muted-foreground">Pulse pressure </span>
+                  <span className={pulsePressureColor(pulsePressure)}>{pulsePressure}</span>
+                  <span className="text-muted-foreground"> mmHg</span>
                 </p>
               )}
             </div>


### PR DESCRIPTION
## Summary
This PR replaces the blood pressure delta (change from previous reading) display with pulse pressure calculation on the blood pressure card component.

## Key Changes
- Removed `formatDelta()` and `deltaColor()` functions that were used to display systolic/diastolic changes
- Added new `pulsePressureColor()` function that evaluates pulse pressure health status:
  - Red (elevated/narrow) for values >60 mmHg or <30 mmHg
  - Muted for normal range (~40 mmHg)
- Changed calculation from comparing consecutive readings to computing pulse pressure (systolic - diastolic) from the latest reading
- Updated the UI to display "Pulse pressure X mmHg" instead of delta values with +/- formatting

## Implementation Details
- Pulse pressure is a clinically relevant metric indicating arterial stiffness and cardiovascular health
- Normal pulse pressure is approximately 40 mmHg; values >60 or <30 are considered abnormal
- The change simplifies the logic by removing the need to track previous readings for comparison

https://claude.ai/code/session_01KaiFj3Na2p7K7oBWwgmLbs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated blood pressure card to display pulse pressure instead of previous reading comparison, with color-coded indicators highlighting values outside the normal range.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->