### PR TITLE
fix(ai): use Opus + web search + metric units for food/drink lookups

### DIFF
--- a/src/app/api/ai/_shared/claude-client.ts
+++ b/src/app/api/ai/_shared/claude-client.ts
@@ -17,4 +17,16 @@ export function getClaudeClient(): Anthropic {
 export const CLAUDE_MODELS = {
   fast: "claude-haiku-4-5-20251001" as const,
   quality: "claude-sonnet-4-6" as const,
+  premium: "claude-opus-4-7" as const,
 } as const;
+
+export const WEB_SEARCH_TOOL = {
+  type: "web_search_20250305" as const,
+  name: "web_search" as const,
+  max_uses: 5,
+};
+
+export {
+  GRAMS_PER_STANDARD_DRINK,
+  ETHANOL_DENSITY_G_PER_ML,
+} from "@/lib/alcohol-units";

--- a/src/app/api/ai/parse/route.ts
+++ b/src/app/api/ai/parse/route.ts
@@ -1,21 +1,16 @@
 import { NextResponse } from "next/server";
 import { z } from "zod";
+import type Anthropic from "@anthropic-ai/sdk";
 import { withAuth } from "@/lib/auth-middleware";
 import { sanitizeForAI } from "@/lib/security";
-import { getClaudeClient, CLAUDE_MODELS } from "../_shared/claude-client";
+import { getClaudeClient, CLAUDE_MODELS, WEB_SEARCH_TOOL } from "../_shared/claude-client";
 
 /**
- * Server-side API route for AI parsing via Anthropic Claude.
+ * Server-side AI parsing for food / drink descriptions.
  *
- * SECURITY:
- * - Centralized auth middleware (withAuth) handles Privy verification + whitelist
- * - API key stored in server environment only (never sent to client)
- * - Rate limiting applied per IP
- * - Input validation and PII stripping via sanitizeForAI
- * - Audit logging
+ * Always returns sodium in mg (no salt/sodium ambiguity). Uses Opus + web_search
+ * for high-quality lookups, with temperature 0 for deterministic numeric answers.
  */
-
-// --- Zod Schemas (co-located per user decision) ---
 
 const ParseRequestSchema = z.object({
   input: z.string().min(1, "Input is required").max(500, "Input too long"),
@@ -23,89 +18,98 @@ const ParseRequestSchema = z.object({
 
 const AIParseResponseSchema = z.object({
   water: z.number().min(0).max(10000).nullable(),
-  salt: z.number().min(0).max(50000).nullable(),
-  measurement_type: z.enum(["sodium", "salt"]).default("sodium"),
-  reasoning: z.string().max(500).optional(),
+  sodiumMg: z.number().min(0).max(20000).nullable(),
+  reasoning: z.string().max(1000).optional(),
 });
 
-// --- System Prompt ---
+const SYSTEM_PROMPT = `You are a nutrition lookup assistant. Given a food or drink description, return:
+- water_ml: water content in millilitres (ml)
+- sodium_mg: sodium content in milligrams (mg) -- NOT salt (NaCl). If a label or source reports salt in grams, convert: sodium_mg = salt_g * 1000 / 2.5.
+- reasoning: 1-3 sentence explanation citing the values used.
 
-const SYSTEM_PROMPT = `You are a nutrition parsing assistant. Your job is to analyze food and drink descriptions and estimate their water and sodium (salt) content.
+Units (metric only, no US units):
+- All volumes in millilitres (ml).
+- All masses in milligrams (mg) for sodium, grams (g) for portion weight.
+- Sodium, never salt. A "pinch of salt" is ~0.4 g of NaCl, which is ~155 mg sodium.
 
-When given a description of food or drink, respond with a JSON object containing:
-- water: estimated water content in milliliters (ml)
-- salt: estimated sodium content in milligrams (mg)
-- reasoning: brief explanation of your estimation
+Process:
+1. If the item is a branded product, regional dish, restaurant menu item, or anything where you are not highly confident of the typical nutritional values, USE THE web_search TOOL to look up authoritative data (manufacturer site, supermarket listing, USDA / EFSA / national food database). Prefer per-100g or per-100ml figures and scale to the described portion.
+2. If the item is a basic generic item with well-known values (plain water, milk, espresso, etc.), you may answer from your own knowledge.
+3. After research, call the parse_food_result tool with the final numbers. The tool MUST be called -- do not return free text only.
 
-Guidelines for estimation:
-- Plain water, tea, coffee (without additions): 100% of stated volume is water
-- Milk: ~87% water content
-- Juice: ~85-90% water content
-- Soft drinks: ~90% water content
-- Fresh fruits/vegetables: refer to their typical water content (e.g., watermelon 92%, cucumber 96%, apple 86%)
-- Cooked foods: estimate based on typical recipes
-- For salt/sodium, use typical nutritional data:
-  - Fresh fruits/vegetables: very low sodium (1-10mg per 100g)
-  - Processed foods: check typical sodium content
-  - A "pinch of salt": ~300-400mg
-  - Restaurant meals: typically 1000-2000mg sodium
-  - Chips/snacks: ~150-200mg per serving
+Reference values for water content:
+- Water, tea, black coffee: ~100% water
+- Milk: ~87%, juice: ~85-90%, soft drinks: ~90%, beer: ~93%, wine: ~87%, spirits: ~60%
+- Fresh produce varies (watermelon 92%, cucumber 96%, apple 86%)
 
-IMPORTANT: You must indicate whether you are reporting sodium content or salt (NaCl) content. Most nutritional databases report sodium. Table salt, soy sauce labels in some countries, and UK food labels typically report salt. US labels report sodium. Always specify which one you are returning.
+Reference values for sodium (per typical serving):
+- Plain fresh produce: 1-10 mg / 100 g
+- A "pinch of salt" (~0.4 g NaCl): ~155 mg sodium
+- Bread slice: ~150-250 mg
+- Restaurant entrée: 800-2000 mg
+- Salty snack (chips): ~150-250 mg per ~30 g serving
 
-Always respond with valid JSON only, no additional text.
-
-Example response:
-{"water": 250, "salt": 5, "measurement_type": "sodium", "reasoning": "A glass of water (250ml) contains 250ml water and negligible sodium"}`;
-
-// --- Tool Definition ---
+If you cannot estimate a value, return null for that field.`;
 
 const PARSE_RESULT_TOOL = {
-  name: "parse_result" as const,
-  description: "Return parsed water and salt content from a food/drink description",
+  name: "parse_food_result" as const,
+  description: "Return parsed water (ml) and sodium (mg) for a food or drink description.",
   input_schema: {
     type: "object" as const,
     properties: {
-      water: { type: ["number", "null"], description: "Water content in ml, null if cannot estimate" },
-      salt: { type: ["number", "null"], description: "Sodium content in mg, null if cannot estimate" },
-      measurement_type: { type: "string", enum: ["sodium", "salt"], description: "Whether the 'salt' value represents sodium (Na) or salt (NaCl). sodium x 2.5 = salt." },
-      reasoning: { type: "string", description: "Brief explanation of the estimate" },
+      water_ml: {
+        type: ["number", "null"],
+        description: "Water content in millilitres. Null if it cannot be estimated.",
+      },
+      sodium_mg: {
+        type: ["number", "null"],
+        description:
+          "Sodium content in milligrams (NOT NaCl). If the source reports salt, divide by 2.5 before returning. Null if it cannot be estimated.",
+      },
+      reasoning: {
+        type: "string",
+        description: "Brief explanation of the estimate, including any sources consulted.",
+      },
     },
-    required: ["water", "salt", "measurement_type", "reasoning"],
+    required: ["water_ml", "sodium_mg", "reasoning"],
     additionalProperties: false,
   },
 };
 
-// Simple in-memory rate limiting (per IP, resets on server restart)
 const rateLimitMap = new Map<string, { count: number; resetTime: number }>();
-const RATE_LIMIT = 20; // requests per window
-const RATE_WINDOW = 60 * 1000; // 1 minute
+const RATE_LIMIT = 20;
+const RATE_WINDOW = 60 * 1000;
 
 function checkRateLimit(ip: string): boolean {
   const now = Date.now();
   const record = rateLimitMap.get(ip);
-
   if (!record || now > record.resetTime) {
     rateLimitMap.set(ip, { count: 1, resetTime: now + RATE_WINDOW });
     return true;
   }
-
-  if (record.count >= RATE_LIMIT) {
-    return false;
-  }
-
+  if (record.count >= RATE_LIMIT) return false;
   record.count++;
   return true;
 }
 
+type ToolUseBlock = Extract<Anthropic.Messages.ContentBlock, { type: "tool_use" }>;
+
+function findToolUse(
+  content: Anthropic.Messages.ContentBlock[],
+  toolName: string
+): ToolUseBlock | undefined {
+  return content.find(
+    (b): b is ToolUseBlock => b.type === "tool_use" && b.name === toolName
+  );
+}
+
 export const POST = withAuth(async ({ request, auth }) => {
   try {
-    // Get client IP for rate limiting
-    const ip = request.headers.get("x-forwarded-for")?.split(",")[0] ||
-               request.headers.get("x-real-ip") ||
-               "unknown";
+    const ip =
+      request.headers.get("x-forwarded-for")?.split(",")[0] ||
+      request.headers.get("x-real-ip") ||
+      "unknown";
 
-    // Check rate limit
     if (!checkRateLimit(ip)) {
       return NextResponse.json(
         { error: "Rate limit exceeded. Please try again later." },
@@ -114,11 +118,9 @@ export const POST = withAuth(async ({ request, auth }) => {
     }
 
     const body = await request.json();
-
-    // Validate request body with Zod
     const parsed = ParseRequestSchema.safeParse(body);
     if (!parsed.success) {
-      console.error("[VALIDATION] Parse request validation failed:", JSON.stringify(parsed.error.flatten()));
+      console.error("[VALIDATION] Parse request failed:", JSON.stringify(parsed.error.flatten()));
       return NextResponse.json(
         { error: "Invalid request", details: parsed.error.flatten() },
         { status: 400 }
@@ -126,9 +128,7 @@ export const POST = withAuth(async ({ request, auth }) => {
     }
 
     const { input } = parsed.data;
-
-    // User is authenticated and on whitelist (handled by withAuth)
-    console.log(`[AUDIT] AI request from user: ${auth.userId} (${auth.email || auth.wallet})`);
+    console.log(`[AUDIT] AI parse from user: ${auth.userId} (${auth.email || auth.wallet})`);
 
     let client;
     try {
@@ -141,7 +141,6 @@ export const POST = withAuth(async ({ request, auth }) => {
     }
 
     const sanitizedInput = sanitizeForAI(input);
-
     if (!sanitizedInput) {
       return NextResponse.json(
         { error: "Invalid input after sanitization" },
@@ -149,27 +148,53 @@ export const POST = withAuth(async ({ request, auth }) => {
       );
     }
 
-    // Log for audit (in production, send to proper logging service)
-    console.log(`[AUDIT] AI parse request at ${new Date().toISOString()}`);
+    const userMessage = `Estimate water (ml) and sodium (mg) for: "${sanitizedInput}". Use web_search for branded or regional items, then call parse_food_result.`;
 
     const response = await client.messages.create({
-      model: CLAUDE_MODELS.fast,
-      max_tokens: 512,
+      model: CLAUDE_MODELS.premium,
+      max_tokens: 4096,
+      temperature: 0,
       system: SYSTEM_PROMPT,
-      tools: [PARSE_RESULT_TOOL],
-      tool_choice: { type: "tool", name: "parse_result" },
-      messages: [{ role: "user", content: `Parse the following food/drink description and estimate water and salt content:\n\n"${sanitizedInput}"` }],
+      tools: [WEB_SEARCH_TOOL, PARSE_RESULT_TOOL],
+      messages: [{ role: "user", content: userMessage }],
     });
 
-    const toolBlock = response.content.find(b => b.type === "tool_use");
-    if (!toolBlock || toolBlock.type !== "tool_use") {
+    let toolBlock = findToolUse(response.content, PARSE_RESULT_TOOL.name);
+
+    // If the model finished with text instead of calling the structured tool,
+    // run a second turn that forces the tool with the prior context.
+    if (!toolBlock) {
+      const followup = await client.messages.create({
+        model: CLAUDE_MODELS.premium,
+        max_tokens: 1024,
+        temperature: 0,
+        system: SYSTEM_PROMPT,
+        tools: [PARSE_RESULT_TOOL],
+        tool_choice: { type: "tool", name: PARSE_RESULT_TOOL.name },
+        messages: [
+          { role: "user", content: userMessage },
+          { role: "assistant", content: response.content },
+          {
+            role: "user",
+            content: "Now return the final estimate via the parse_food_result tool.",
+          },
+        ],
+      });
+      toolBlock = findToolUse(followup.content, PARSE_RESULT_TOOL.name);
+    }
+
+    if (!toolBlock) {
       return NextResponse.json(
         { error: "AI response format invalid", fallbackToManual: true },
         { status: 422 }
       );
     }
 
-    const validated = AIParseResponseSchema.safeParse(toolBlock.input);
+    const validated = AIParseResponseSchema.safeParse({
+      water: (toolBlock.input as Record<string, unknown>).water_ml,
+      sodiumMg: (toolBlock.input as Record<string, unknown>).sodium_mg,
+      reasoning: (toolBlock.input as Record<string, unknown>).reasoning,
+    });
     if (!validated.success) {
       console.error("[VALIDATION] AI response validation failed:", JSON.stringify(validated.error.flatten()));
       return NextResponse.json(
@@ -180,8 +205,9 @@ export const POST = withAuth(async ({ request, auth }) => {
 
     return NextResponse.json({
       water: validated.data.water,
-      salt: validated.data.salt,
-      measurement_type: validated.data.measurement_type,
+      // Backwards-compatible field name; value is always sodium in mg.
+      salt: validated.data.sodiumMg,
+      measurement_type: "sodium" as const,
       ...(validated.data.reasoning !== undefined && { reasoning: validated.data.reasoning }),
     });
   } catch (error) {

--- a/src/app/api/ai/parse/route.ts
+++ b/src/app/api/ai/parse/route.ts
@@ -128,7 +128,7 @@ export const POST = withAuth(async ({ request, auth }) => {
     }
 
     const { input } = parsed.data;
-    console.log(`[AUDIT] AI parse from user: ${auth.userId} (${auth.email || auth.wallet})`);
+    console.log(`[AUDIT] AI parse from user: ${auth.userId}`);
 
     let client;
     try {
@@ -169,7 +169,10 @@ export const POST = withAuth(async ({ request, auth }) => {
         max_tokens: 1024,
         temperature: 0,
         system: SYSTEM_PROMPT,
-        tools: [PARSE_RESULT_TOOL],
+        // WEB_SEARCH_TOOL must stay declared because the prior assistant turn
+        // may contain server_tool_use blocks; tool_choice still forces the
+        // structured tool.
+        tools: [WEB_SEARCH_TOOL, PARSE_RESULT_TOOL],
         tool_choice: { type: "tool", name: PARSE_RESULT_TOOL.name },
         messages: [
           { role: "user", content: userMessage },
@@ -190,10 +193,11 @@ export const POST = withAuth(async ({ request, auth }) => {
       );
     }
 
+    const toolInput = toolBlock.input as Record<string, unknown>;
     const validated = AIParseResponseSchema.safeParse({
-      water: (toolBlock.input as Record<string, unknown>).water_ml,
-      sodiumMg: (toolBlock.input as Record<string, unknown>).sodium_mg,
-      reasoning: (toolBlock.input as Record<string, unknown>).reasoning,
+      water: toolInput.water_ml,
+      sodiumMg: toolInput.sodium_mg,
+      reasoning: toolInput.reasoning,
     });
     if (!validated.success) {
       console.error("[VALIDATION] AI response validation failed:", JSON.stringify(validated.error.flatten()));

--- a/src/app/api/ai/substance-enrich/route.ts
+++ b/src/app/api/ai/substance-enrich/route.ts
@@ -3,13 +3,8 @@ import { z } from "zod";
 import type Anthropic from "@anthropic-ai/sdk";
 import { withAuth } from "@/lib/auth-middleware";
 import { sanitizeForAI } from "@/lib/security";
-import {
-  getClaudeClient,
-  CLAUDE_MODELS,
-  WEB_SEARCH_TOOL,
-  GRAMS_PER_STANDARD_DRINK,
-  ETHANOL_DENSITY_G_PER_ML,
-} from "../_shared/claude-client";
+import { getClaudeClient, CLAUDE_MODELS, WEB_SEARCH_TOOL } from "../_shared/claude-client";
+import { ethanolGrams, standardDrinksFromAbv } from "@/lib/alcohol-units";
 
 /**
  * AI enrichment for caffeine / alcohol "Other" entries. Uses Opus + web_search
@@ -205,7 +200,10 @@ export const POST = withAuth(async ({ request, auth }) => {
         max_tokens: 1024,
         temperature: 0,
         system: systemPrompt,
-        tools: [tool],
+        // WEB_SEARCH_TOOL must stay declared because the prior assistant turn
+        // may contain server_tool_use blocks; tool_choice still forces the
+        // structured tool.
+        tools: [WEB_SEARCH_TOOL, tool],
         tool_choice: { type: "tool", name: tool.name },
         messages: [
           { role: "user", content: userPrompt },
@@ -253,17 +251,15 @@ export const POST = withAuth(async ({ request, auth }) => {
       );
     }
 
-    // Compute grams of ethanol and convert to metric standard drinks (10 g).
-    const ethanolGrams =
-      validated.data.volumeMl * (validated.data.abvPercent / 100) * ETHANOL_DENSITY_G_PER_ML;
+    const grams = ethanolGrams(validated.data.abvPercent, validated.data.volumeMl);
     const standardDrinks =
-      Math.round((ethanolGrams / GRAMS_PER_STANDARD_DRINK) * 10) / 10;
+      Math.round(standardDrinksFromAbv(validated.data.abvPercent, validated.data.volumeMl) * 10) / 10;
 
     return NextResponse.json({
       standardDrinks,
       volumeMl: validated.data.volumeMl,
       abvPercent: validated.data.abvPercent,
-      ethanolGrams: Math.round(ethanolGrams * 10) / 10,
+      ethanolGrams: Math.round(grams * 10) / 10,
       ...(validated.data.reasoning !== undefined && { reasoning: validated.data.reasoning }),
     });
   } catch (error) {

--- a/src/app/api/ai/substance-enrich/route.ts
+++ b/src/app/api/ai/substance-enrich/route.ts
@@ -1,49 +1,52 @@
 import { NextResponse } from "next/server";
 import { z } from "zod";
+import type Anthropic from "@anthropic-ai/sdk";
 import { withAuth } from "@/lib/auth-middleware";
 import { sanitizeForAI } from "@/lib/security";
-import { getClaudeClient, CLAUDE_MODELS } from "../_shared/claude-client";
+import {
+  getClaudeClient,
+  CLAUDE_MODELS,
+  WEB_SEARCH_TOOL,
+  GRAMS_PER_STANDARD_DRINK,
+  ETHANOL_DENSITY_G_PER_ML,
+} from "../_shared/claude-client";
 
 /**
- * Server-side API route for substance (caffeine/alcohol) AI enrichment via Anthropic Claude.
- *
- * SECURITY:
- * - Centralized auth middleware (withAuth) handles Privy verification + whitelist
- * - API key stored in server environment only
- * - Rate limiting applied per IP
- * - Input validation and PII stripping via sanitizeForAI
+ * AI enrichment for caffeine / alcohol "Other" entries. Uses Opus + web_search
+ * with temperature 0. Alcohol is reasoned in metric (ABV %, ml, grams of pure
+ * ethanol) and converted to standard drinks at the route boundary using the
+ * WHO / metric definition of 10 g ethanol per standard drink.
  */
-
-// --- Zod Schemas ---
 
 const SubstanceEnrichRequestSchema = z.object({
   description: z.string().min(1, "Description is required").max(500, "Description too long"),
   type: z.enum(["caffeine", "alcohol"]),
 });
 
-const CaffeineResponseSchema = z.object({
+// --- Tool inputs (raw, from the model) ---
+
+const CaffeineToolInputSchema = z.object({
   caffeineMg: z.number().min(0).max(2000),
   volumeMl: z.number().min(0).max(5000),
-  reasoning: z.string().max(500).optional(),
+  reasoning: z.string().max(1000).optional(),
 });
 
-const AlcoholResponseSchema = z.object({
-  standardDrinks: z.number().min(0).max(20),
+const AlcoholToolInputSchema = z.object({
+  abvPercent: z.number().min(0).max(95),
   volumeMl: z.number().min(0).max(5000),
-  reasoning: z.string().max(500).optional(),
+  ethanolGrams: z.number().min(0).max(500).optional(),
+  reasoning: z.string().max(1000).optional(),
 });
-
-// --- Tool Definitions ---
 
 const CAFFEINE_ENRICH_TOOL = {
   name: "caffeine_enrichment" as const,
-  description: "Return caffeine content estimate for a beverage",
+  description: "Return caffeine content estimate for a beverage.",
   input_schema: {
     type: "object" as const,
     properties: {
-      caffeineMg: { type: "number", description: "Estimated caffeine in mg" },
-      volumeMl: { type: "number", description: "Estimated volume in ml" },
-      reasoning: { type: "string", description: "Brief explanation" },
+      caffeineMg: { type: "number", description: "Estimated caffeine in milligrams." },
+      volumeMl: { type: "number", description: "Estimated volume in millilitres." },
+      reasoning: { type: "string", description: "Brief explanation citing any sources used." },
     },
     required: ["caffeineMg", "volumeMl", "reasoning"],
     additionalProperties: false,
@@ -52,57 +55,90 @@ const CAFFEINE_ENRICH_TOOL = {
 
 const ALCOHOL_ENRICH_TOOL = {
   name: "alcohol_enrichment" as const,
-  description: "Return alcohol content estimate for a beverage",
+  description:
+    "Return alcohol content for a beverage in metric units. Reason from ABV % and volume in ml.",
   input_schema: {
     type: "object" as const,
     properties: {
-      standardDrinks: { type: "number", description: "Estimated standard drinks" },
-      volumeMl: { type: "number", description: "Estimated volume in ml" },
-      reasoning: { type: "string", description: "Brief explanation" },
+      abvPercent: {
+        type: "number",
+        description:
+          "Alcohol by volume as a percentage -- the same number printed on the bottle label (e.g. 5 for typical lager, 13 for wine, 40 for vodka). NOT grams.",
+      },
+      volumeMl: {
+        type: "number",
+        description: "Volume of the drink consumed, in millilitres.",
+      },
+      ethanolGrams: {
+        type: "number",
+        description:
+          "Optional. Grams of pure ethanol = volumeMl * (abvPercent / 100) * 0.789. Provide it as a sanity check.",
+      },
+      reasoning: {
+        type: "string",
+        description: "Brief explanation citing any sources used.",
+      },
     },
-    required: ["standardDrinks", "volumeMl", "reasoning"],
+    required: ["abvPercent", "volumeMl", "reasoning"],
     additionalProperties: false,
   },
 };
 
-// --- System Prompts ---
+const CAFFEINE_SYSTEM_PROMPT = `You are a caffeine lookup assistant. Given a description of a caffeinated drink or food, return total caffeine in milligrams and total volume in millilitres.
 
-const CAFFEINE_SYSTEM_PROMPT = `You are a nutritional analysis assistant specializing in caffeine content estimation.
-Given a description of a caffeinated beverage or food, estimate the caffeine content.
-Respond using the caffeine_enrichment tool with caffeineMg, volumeMl, and reasoning.`;
+Units: metric only (mg, ml). Never ounces, never cups.
 
-const ALCOHOL_SYSTEM_PROMPT = `You are a nutritional analysis assistant specializing in alcohol content estimation.
-Given a description of an alcoholic beverage, estimate the number of standard drinks and volume.
-A standard drink contains approximately 14g (0.6 oz) of pure alcohol.
-Respond using the alcohol_enrichment tool with standardDrinks, volumeMl, and reasoning.`;
+Process:
+1. For branded items (Starbucks drinks, Red Bull variants, energy shots, named teas) USE THE web_search TOOL to find the manufacturer's published value or a reputable source.
+2. For generic items (drip coffee, espresso, black tea) you may answer from your own knowledge.
+3. Always finish by calling the caffeine_enrichment tool with the structured output.`;
 
-// Simple in-memory rate limiting (per IP, resets on server restart)
+const ALCOHOL_SYSTEM_PROMPT = `You are an alcohol lookup assistant. Given a description of an alcoholic drink, return its ABV (% alcohol by volume) and the volume in millilitres consumed.
+
+CRITICAL UNIT RULES:
+- abvPercent is a PERCENTAGE BY VOLUME -- the number printed on the bottle label. Examples: lager 5, IPA 6-7, red wine 13, vodka 40, cask whisky 60.
+- volumeMl is the volume of the drink in millilitres. Pint = 568, half pint = 284, wine glass = 125-175, single spirit measure = 25 (UK) / 30 (most of EU), double = 50.
+- Do NOT convert to "standard drinks" or "units" -- the server does that conversion. Return ABV % and volume only.
+- Never use ounces, never use US fluid ounces, never use US "standard drinks".
+
+Process:
+1. For branded products, craft beers, named cocktails, or anything you are not 100% sure of, USE THE web_search TOOL to confirm ABV.
+2. For generic items (lager, red wine, vodka) you may answer from your own knowledge using typical ABV.
+3. Always finish by calling the alcohol_enrichment tool with the structured output.`;
+
 const rateLimitMap = new Map<string, { count: number; resetTime: number }>();
-const RATE_LIMIT = 30; // requests per window
-const RATE_WINDOW = 60 * 1000; // 1 minute
+const RATE_LIMIT = 30;
+const RATE_WINDOW = 60 * 1000;
 
 function checkRateLimit(ip: string): boolean {
   const now = Date.now();
   const record = rateLimitMap.get(ip);
-
   if (!record || now > record.resetTime) {
     rateLimitMap.set(ip, { count: 1, resetTime: now + RATE_WINDOW });
     return true;
   }
-
-  if (record.count >= RATE_LIMIT) {
-    return false;
-  }
-
+  if (record.count >= RATE_LIMIT) return false;
   record.count++;
   return true;
 }
 
+type ToolUseBlock = Extract<Anthropic.Messages.ContentBlock, { type: "tool_use" }>;
+
+function findToolUse(
+  content: Anthropic.Messages.ContentBlock[],
+  toolName: string
+): ToolUseBlock | undefined {
+  return content.find(
+    (b): b is ToolUseBlock => b.type === "tool_use" && b.name === toolName
+  );
+}
+
 export const POST = withAuth(async ({ request, auth }) => {
   try {
-    const ip = request.headers.get("x-forwarded-for")?.split(",")[0] ||
-               request.headers.get("x-real-ip") ||
-               "unknown";
+    const ip =
+      request.headers.get("x-forwarded-for")?.split(",")[0] ||
+      request.headers.get("x-real-ip") ||
+      "unknown";
 
     if (!checkRateLimit(ip)) {
       return NextResponse.json(
@@ -112,10 +148,12 @@ export const POST = withAuth(async ({ request, auth }) => {
     }
 
     const body = await request.json();
-
     const parsed = SubstanceEnrichRequestSchema.safeParse(body);
     if (!parsed.success) {
-      console.error("[VALIDATION] Substance enrich request validation failed:", JSON.stringify(parsed.error.flatten()));
+      console.error(
+        "[VALIDATION] Substance enrich request failed:",
+        JSON.stringify(parsed.error.flatten())
+      );
       return NextResponse.json(
         { error: "Invalid request", details: parsed.error.flatten() },
         { status: 400 }
@@ -123,8 +161,7 @@ export const POST = withAuth(async ({ request, auth }) => {
     }
 
     const { description, type } = parsed.data;
-
-    console.log(`[AUDIT] Substance enrich request from user: ${auth.userId}`);
+    console.log(`[AUDIT] Substance enrich from user: ${auth.userId}, type: ${type}`);
 
     let client;
     try {
@@ -144,43 +181,91 @@ export const POST = withAuth(async ({ request, auth }) => {
       );
     }
 
-    console.log(`[AUDIT] Substance enrich request at ${new Date().toISOString()}`);
-
     const systemPrompt = type === "caffeine" ? CAFFEINE_SYSTEM_PROMPT : ALCOHOL_SYSTEM_PROMPT;
     const tool = type === "caffeine" ? CAFFEINE_ENRICH_TOOL : ALCOHOL_ENRICH_TOOL;
-    const schema = type === "caffeine" ? CaffeineResponseSchema : AlcoholResponseSchema;
-
-    const userPrompt = type === "caffeine"
-      ? `Estimate caffeine content in mg for: "${sanitized}". Return caffeineMg, volumeMl, and reasoning.`
-      : `Estimate standard drinks and volume for: "${sanitized}". Return standardDrinks, volumeMl, and reasoning.`;
+    const userPrompt =
+      type === "caffeine"
+        ? `Estimate caffeine (mg) and volume (ml) for: "${sanitized}". Use web_search for branded items, then call caffeine_enrichment.`
+        : `Estimate ABV (%) and volume (ml) for: "${sanitized}". Use web_search if branded or unfamiliar, then call alcohol_enrichment. Return ABV as a percentage, NOT grams.`;
 
     const response = await client.messages.create({
-      model: CLAUDE_MODELS.fast,
-      max_tokens: 512,
+      model: CLAUDE_MODELS.premium,
+      max_tokens: 4096,
+      temperature: 0,
       system: systemPrompt,
-      tools: [tool],
-      tool_choice: { type: "tool", name: tool.name },
+      tools: [WEB_SEARCH_TOOL, tool],
       messages: [{ role: "user", content: userPrompt }],
     });
 
-    const toolBlock = response.content.find(b => b.type === "tool_use");
-    if (!toolBlock || toolBlock.type !== "tool_use") {
+    let toolBlock = findToolUse(response.content, tool.name);
+
+    if (!toolBlock) {
+      const followup = await client.messages.create({
+        model: CLAUDE_MODELS.premium,
+        max_tokens: 1024,
+        temperature: 0,
+        system: systemPrompt,
+        tools: [tool],
+        tool_choice: { type: "tool", name: tool.name },
+        messages: [
+          { role: "user", content: userPrompt },
+          { role: "assistant", content: response.content },
+          {
+            role: "user",
+            content: `Now return the final answer via the ${tool.name} tool.`,
+          },
+        ],
+      });
+      toolBlock = findToolUse(followup.content, tool.name);
+    }
+
+    if (!toolBlock) {
       return NextResponse.json(
         { error: "AI response format invalid", fallbackToManual: true },
         { status: 422 }
       );
     }
 
-    const validated = schema.safeParse(toolBlock.input);
+    if (type === "caffeine") {
+      const validated = CaffeineToolInputSchema.safeParse(toolBlock.input);
+      if (!validated.success) {
+        console.error(
+          "[VALIDATION] Caffeine enrichment validation failed:",
+          JSON.stringify(validated.error.flatten())
+        );
+        return NextResponse.json(
+          { error: "AI response format invalid", fallbackToManual: true },
+          { status: 422 }
+        );
+      }
+      return NextResponse.json(validated.data);
+    }
+
+    const validated = AlcoholToolInputSchema.safeParse(toolBlock.input);
     if (!validated.success) {
-      console.error("[VALIDATION] AI enrichment response validation failed:", JSON.stringify(validated.error.flatten()));
+      console.error(
+        "[VALIDATION] Alcohol enrichment validation failed:",
+        JSON.stringify(validated.error.flatten())
+      );
       return NextResponse.json(
         { error: "AI response format invalid", fallbackToManual: true },
         { status: 422 }
       );
     }
 
-    return NextResponse.json(validated.data);
+    // Compute grams of ethanol and convert to metric standard drinks (10 g).
+    const ethanolGrams =
+      validated.data.volumeMl * (validated.data.abvPercent / 100) * ETHANOL_DENSITY_G_PER_ML;
+    const standardDrinks =
+      Math.round((ethanolGrams / GRAMS_PER_STANDARD_DRINK) * 10) / 10;
+
+    return NextResponse.json({
+      standardDrinks,
+      volumeMl: validated.data.volumeMl,
+      abvPercent: validated.data.abvPercent,
+      ethanolGrams: Math.round(ethanolGrams * 10) / 10,
+      ...(validated.data.reasoning !== undefined && { reasoning: validated.data.reasoning }),
+    });
   } catch (error) {
     console.error("Substance enrich error:", error);
     return NextResponse.json(

--- a/src/app/api/ai/substance-lookup/route.ts
+++ b/src/app/api/ai/substance-lookup/route.ts
@@ -147,7 +147,10 @@ export const POST = withAuth(async ({ request, auth }) => {
         max_tokens: 1024,
         temperature: 0,
         system: systemPrompt,
-        tools: [SUBSTANCE_LOOKUP_TOOL],
+        // WEB_SEARCH_TOOL must stay declared because the prior assistant turn
+        // may contain server_tool_use blocks; tool_choice still forces the
+        // structured tool.
+        tools: [WEB_SEARCH_TOOL, SUBSTANCE_LOOKUP_TOOL],
         tool_choice: { type: "tool", name: SUBSTANCE_LOOKUP_TOOL.name },
         messages: [
           { role: "user", content: userPrompt },

--- a/src/app/api/ai/substance-lookup/route.ts
+++ b/src/app/api/ai/substance-lookup/route.ts
@@ -1,8 +1,9 @@
 import { NextResponse } from "next/server";
 import { z } from "zod";
+import type Anthropic from "@anthropic-ai/sdk";
 import { withAuth } from "@/lib/auth-middleware";
 import { sanitizeForAI } from "@/lib/security";
-import { getClaudeClient, CLAUDE_MODELS } from "../_shared/claude-client";
+import { getClaudeClient, CLAUDE_MODELS, WEB_SEARCH_TOOL } from "../_shared/claude-client";
 import { SubstanceLookupResponseSchema, SUBSTANCE_LOOKUP_TOOL } from "./schema";
 
 const RequestSchema = z.object({
@@ -10,7 +11,6 @@ const RequestSchema = z.object({
   type: z.enum(["caffeine", "alcohol"]),
 });
 
-// Rate limiting: 15 requests/min (same as other AI routes)
 const rateLimitMap = new Map<string, { count: number; resetTime: number }>();
 const RATE_LIMIT = 15;
 const RATE_WINDOW = 60 * 1000;
@@ -27,10 +27,65 @@ function checkRateLimit(ip: string): boolean {
   return true;
 }
 
+type ToolUseBlock = Extract<Anthropic.Messages.ContentBlock, { type: "tool_use" }>;
+
+function findToolUse(
+  content: Anthropic.Messages.ContentBlock[],
+  toolName: string
+): ToolUseBlock | undefined {
+  return content.find(
+    (b): b is ToolUseBlock => b.type === "tool_use" && b.name === toolName
+  );
+}
+
+function buildSystemPrompt(type: "caffeine" | "alcohol"): string {
+  if (type === "caffeine") {
+    return `You are a beverage research assistant. Given a beverage name, return its caffeine content per 100 ml, a typical serving size, and water content percentage.
+
+Units (metric only):
+- substancePer100ml = milligrams of caffeine per 100 ml of beverage
+- defaultVolumeMl = typical single serve in millilitres
+- waterContentPercent = 0-100
+
+Reference points:
+- Filter / drip coffee: ~40 mg / 100 ml
+- Espresso: ~200 mg / 100 ml
+- Black tea: ~20 mg / 100 ml
+- Green tea: ~12 mg / 100 ml
+- Cola: ~10 mg / 100 ml
+- Energy drinks (Red Bull, Monster): ~32 mg / 100 ml
+- Matcha: highly variable, ~60-100 mg / 100 ml prepared
+
+Process:
+1. For branded products (Starbucks, Red Bull variants, energy shots, regional sodas) USE THE web_search TOOL to look up the manufacturer's published value or a reputable third-party measurement (Caffeine Informer, USDA, manufacturer site). Prefer per-100-ml values; if only per-serving is available, divide by the stated serving volume.
+2. For generic items (filter coffee, black tea) you may answer from your own knowledge.
+3. Always finish by calling the substance_lookup_result tool with the structured output.`;
+  }
+
+  return `You are a beverage research assistant. Given an alcoholic drink name, return its ABV (alcohol by volume), a typical serving size, and water content percentage.
+
+CRITICAL UNIT RULE:
+- substancePer100ml MUST be ABV as a percentage by volume -- the same number printed on the bottle label.
+- It is NOT grams of ethanol per 100 ml.
+- It is NOT millilitres of ethanol per 100 ml (numerically the same as ABV %, but think of it as the label %).
+- Examples: typical lager = 5, IPA = 6-7, red wine = 13, vodka = 40, cask-strength whisky = 60.
+
+Other fields:
+- defaultVolumeMl = typical single serving in millilitres (e.g. pint = 568, half pint = 284, wine glass = 175, single spirit = 25 (UK) / 30 (most of EU))
+- waterContentPercent = 0-100 (beer ~93, wine ~87, spirits ~60)
+
+Process:
+1. For branded products, regional drinks, craft beers, named cocktails, or anything you are not 100% sure of, USE THE web_search TOOL to look up the producer's stated ABV or a reputable retailer listing.
+2. For generic items (lager, red wine, vodka) you may answer from your own knowledge but stay within typical ranges.
+3. Always finish by calling the substance_lookup_result tool with the structured output. Do NOT convert ABV to grams or mg.`;
+}
+
 export const POST = withAuth(async ({ request, auth }) => {
   try {
-    const ip = request.headers.get("x-forwarded-for")?.split(",")[0] ||
-               request.headers.get("x-real-ip") || "unknown";
+    const ip =
+      request.headers.get("x-forwarded-for")?.split(",")[0] ||
+      request.headers.get("x-real-ip") ||
+      "unknown";
 
     if (!checkRateLimit(ip)) {
       return NextResponse.json(
@@ -51,7 +106,10 @@ export const POST = withAuth(async ({ request, auth }) => {
     const { query, type } = parsed.data;
     const sanitized = sanitizeForAI(query);
     if (!sanitized) {
-      return NextResponse.json({ error: "Invalid input after sanitization" }, { status: 400 });
+      return NextResponse.json(
+        { error: "Invalid input after sanitization" },
+        { status: 400 }
+      );
     }
 
     console.log(`[AUDIT] Substance lookup from user: ${auth.userId}, type: ${type}`);
@@ -60,29 +118,59 @@ export const POST = withAuth(async ({ request, auth }) => {
     try {
       client = getClaudeClient();
     } catch {
-      return NextResponse.json({ error: "AI service not configured on server" }, { status: 503 });
+      return NextResponse.json(
+        { error: "AI service not configured on server" },
+        { status: 503 }
+      );
     }
 
-    const systemPrompt = type === "caffeine"
-      ? "You are a beverage nutrition expert. Given a beverage name, estimate its caffeine content per 100ml and typical serving size. Be as accurate as possible based on known beverage data. Also estimate the beverage's water content as a percentage (0-100). Reference points: black coffee ~99%, beer ~93%, wine ~87%, spirits ~60%."
-      : "You are a beverage nutrition expert. Given a beverage name, estimate its ABV (alcohol by volume) percentage and typical serving size. Return the ABV as a percentage (e.g. 5 for beer, 12 for wine, 40 for spirits). Also estimate the beverage's water content as a percentage (0-100). Reference points: black coffee ~99%, beer ~93%, wine ~87%, spirits ~60%.";
+    const systemPrompt = buildSystemPrompt(type);
+    const userPrompt =
+      type === "caffeine"
+        ? `Look up caffeine content per 100 ml for: "${sanitized}". Use web_search if it is a branded product, then call substance_lookup_result.`
+        : `Look up the ABV (% alcohol by volume) for: "${sanitized}". Use web_search if it is a branded product, then call substance_lookup_result. Return the ABV as a percentage (e.g. 5, 13, 40), NOT grams of ethanol.`;
 
     const response = await client.messages.create({
-      model: CLAUDE_MODELS.fast,
-      max_tokens: 512,
+      model: CLAUDE_MODELS.premium,
+      max_tokens: 4096,
+      temperature: 0,
       system: systemPrompt,
-      tools: [SUBSTANCE_LOOKUP_TOOL],
-      tool_choice: { type: "tool", name: SUBSTANCE_LOOKUP_TOOL.name },
-      messages: [{ role: "user", content: `Estimate ${type} content per 100ml for: "${sanitized}"` }],
+      tools: [WEB_SEARCH_TOOL, SUBSTANCE_LOOKUP_TOOL],
+      messages: [{ role: "user", content: userPrompt }],
     });
 
-    const toolBlock = response.content.find(b => b.type === "tool_use");
-    if (!toolBlock || toolBlock.type !== "tool_use") {
+    let toolBlock = findToolUse(response.content, SUBSTANCE_LOOKUP_TOOL.name);
+
+    if (!toolBlock) {
+      const followup = await client.messages.create({
+        model: CLAUDE_MODELS.premium,
+        max_tokens: 1024,
+        temperature: 0,
+        system: systemPrompt,
+        tools: [SUBSTANCE_LOOKUP_TOOL],
+        tool_choice: { type: "tool", name: SUBSTANCE_LOOKUP_TOOL.name },
+        messages: [
+          { role: "user", content: userPrompt },
+          { role: "assistant", content: response.content },
+          {
+            role: "user",
+            content: "Now return the final answer via the substance_lookup_result tool.",
+          },
+        ],
+      });
+      toolBlock = findToolUse(followup.content, SUBSTANCE_LOOKUP_TOOL.name);
+    }
+
+    if (!toolBlock) {
       return NextResponse.json({ error: "AI response format invalid" }, { status: 422 });
     }
 
     const validated = SubstanceLookupResponseSchema.safeParse(toolBlock.input);
     if (!validated.success) {
+      console.error(
+        "[VALIDATION] Substance lookup response failed:",
+        JSON.stringify(validated.error.flatten())
+      );
       return NextResponse.json({ error: "AI response validation failed" }, { status: 422 });
     }
 

--- a/src/app/api/ai/substance-lookup/schema.ts
+++ b/src/app/api/ai/substance-lookup/schema.ts
@@ -10,32 +10,42 @@ export const SubstanceLookupResponseSchema = z.object({
 
 export const SUBSTANCE_LOOKUP_TOOL = {
   name: "substance_lookup_result" as const,
-  description: "Return the substance content per 100ml and typical serving size for a beverage",
+  description:
+    "Return beverage data. For caffeine queries: caffeine in mg per 100 ml. For alcohol queries: ABV as a percentage (vol/vol).",
   input_schema: {
     type: "object" as const,
     properties: {
       substancePer100ml: {
         type: "number",
-        description: "For caffeine: mg per 100ml. For alcohol: ABV percentage (e.g. 5 for beer, 12 for wine, 40 for spirits).",
+        description:
+          "FOR CAFFEINE QUERIES: caffeine in milligrams per 100 ml of beverage (e.g. ~40 for filter coffee, ~200 for espresso). FOR ALCOHOL QUERIES: ABV as a percentage by volume -- the same number that appears on the bottle label (e.g. 5 for typical lager, 12 for wine, 40 for vodka). NEVER grams of ethanol. NEVER mg of ethanol.",
       },
       defaultVolumeMl: {
         type: "number",
-        description: "Typical single serving volume in ml",
+        description: "Typical single serving volume in millilitres.",
       },
       beverageName: {
         type: "string",
-        description: "Normalized name of the beverage",
+        description: "Normalised name of the beverage.",
       },
       reasoning: {
         type: "string",
-        description: "Brief explanation of the estimate and data source",
+        description:
+          "Brief explanation of the estimate, citing the source (web search result, manufacturer label, etc.) and the unit interpretation used.",
       },
       waterContentPercent: {
         type: "number",
-        description: "Estimated water content as a percentage (0-100). Reference: black coffee ~99, beer ~93, wine ~87, spirits ~60.",
+        description:
+          "Estimated water content as a percentage (0-100). Reference: black coffee ~99, beer ~93, wine ~87, spirits ~60.",
       },
     },
-    required: ["substancePer100ml", "defaultVolumeMl", "beverageName", "reasoning", "waterContentPercent"],
+    required: [
+      "substancePer100ml",
+      "defaultVolumeMl",
+      "beverageName",
+      "reasoning",
+      "waterContentPercent",
+    ],
     additionalProperties: false,
   },
 };

--- a/src/components/food-salt/food-section.tsx
+++ b/src/components/food-salt/food-section.tsx
@@ -135,11 +135,11 @@ export function FoodSection() {
       const authHeaders = await getAuthHeader();
       const result = await parseIntakeWithAI(trimmed, { authHeaders });
 
-      // Populate form fields from AI result
+      // Populate form fields from AI result. The /api/ai/parse route now always
+      // returns sodium in mg, so the source is always "sodium".
       if (result.salt && result.salt > 0) {
         setSodiumMg(result.salt.toString());
-        // Auto-select sodium source based on what the AI reported
-        setSodiumSource(result.measurementType === "salt" ? "salt" : "sodium");
+        setSodiumSource("sodium");
       }
       if (result.water && result.water > 0) {
         setWaterMl(result.water.toString());

--- a/src/components/liquids/preset-tab.tsx
+++ b/src/components/liquids/preset-tab.tsx
@@ -25,6 +25,7 @@ import {
   AlertDialogTitle,
 } from "@/components/ui/alert-dialog";
 import type { LiquidPreset } from "@/lib/constants";
+import { standardDrinksFromAbv } from "@/lib/alcohol-units";
 
 interface PresetTabProps {
   tab: "coffee" | "alcohol" | "beverage";
@@ -90,7 +91,7 @@ export function PresetTab({ tab }: PresetTabProps) {
       );
     }
     if (alcoholPer100ml > 0) {
-      const stdDrinks = volumeMl * (alcoholPer100ml / 100) * 0.789 / 14;
+      const stdDrinks = standardDrinksFromAbv(alcoholPer100ml, volumeMl);
       parts.push(
         `${alcoholPer100ml}% ABV (${parseFloat(stdDrinks.toFixed(1))} std drinks)`
       );
@@ -269,7 +270,7 @@ export function PresetTab({ tab }: PresetTabProps) {
       });
     }
     if (alcoholPer100ml > 0) {
-      const stdDrinks = volumeMl * (alcoholPer100ml / 100) * 0.789 / 14;
+      const stdDrinks = standardDrinksFromAbv(alcoholPer100ml, volumeMl);
       substances.push({
         type: "alcohol",
         amountStandardDrinks: parseFloat(stdDrinks.toFixed(1)),

--- a/src/lib/alcohol-units.ts
+++ b/src/lib/alcohol-units.ts
@@ -1,0 +1,20 @@
+/**
+ * Metric alcohol unit constants. Shared by server AI routes and client UI so
+ * "standard drinks" means the same thing everywhere.
+ */
+
+// WHO / metric standard drink: 10 g of pure ethanol.
+export const GRAMS_PER_STANDARD_DRINK = 10;
+
+// Density of ethanol at 20 C, in g/ml.
+export const ETHANOL_DENSITY_G_PER_ML = 0.789;
+
+/** Convert ABV % and volume in ml to grams of pure ethanol. */
+export function ethanolGrams(abvPercent: number, volumeMl: number): number {
+  return volumeMl * (abvPercent / 100) * ETHANOL_DENSITY_G_PER_ML;
+}
+
+/** Convert ABV % and volume in ml to metric standard drinks (10 g ethanol). */
+export function standardDrinksFromAbv(abvPercent: number, volumeMl: number): number {
+  return ethanolGrams(abvPercent, volumeMl) / GRAMS_PER_STANDARD_DRINK;
+}


### PR DESCRIPTION
- Switch parse, substance-lookup, substance-enrich to Opus (CLAUDE_MODELS.premium)
  with temperature 0 and the Anthropic web_search server tool, so branded /
  regional items are looked up authoritatively instead of guessed.
- /api/ai/parse: drop salt vs sodium ambiguity; the route now always returns
  sodium in mg with a single, internally consistent prompt.
- /api/ai/substance-lookup: prompt now states explicitly that for alcohol the
  per-100ml field is ABV % (not g/100ml or mg/100ml), eliminating the unit
  conflation that was producing wrong alcohol values.
- /api/ai/substance-enrich: alcohol path reasons in metric (ABV %, ml, g of
  ethanol) and the route converts to standard drinks server-side using the
  WHO/metric 10 g definition. Drops the US 14 g standard-drink reference.
- Add shared src/lib/alcohol-units.ts (10 g per std drink, 0.789 g/ml ethanol
  density) used by both the server routes and preset-tab.tsx so the divisor
  matches everywhere.
- Each route falls back to a forced-tool call if the model returns text only.

https://claude.ai/code/session_01QsBbR9xU6VbfYEJhNrwBKP

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added web search capability to AI-powered food and substance lookups for improved accuracy on branded and regional items.
  * Introduced standardized alcohol unit calculations using metric standard-drink methodology.

* **Improvements**
  * Enhanced AI parsing to return sodium values in mg instead of salt measurements.
  * Upgraded to premium Claude model with improved deterministic tool-driven estimates.
  * Strengthened substance enrichment and lookup flows with more robust AI tool-calling and validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->