### PR TITLE
Add inline editing for food sodium/water and liquid substances

### DIFF
--- a/src/components/food-salt/food-section.tsx
+++ b/src/components/food-salt/food-section.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useCallback, useMemo } from "react";
+import { useState, useCallback, useMemo, useRef } from "react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -101,6 +101,8 @@ export function FoodSection() {
   const [editSodiumMg, setEditSodiumMg] = useState("");
   const [editSodiumSource, setEditSodiumSource] = useState<SodiumSource>("sodium");
   const [editWaterMl, setEditWaterMl] = useState("");
+  // Token to discard stale fetchEntryGroup results when opening another record
+  const openTokenRef = useRef(0);
 
   const {
     editingRecord,
@@ -113,12 +115,14 @@ export function FoodSection() {
     handleEditSubmit,
   } = useEditRecord<EatingRecord>({
     onOpen: (record) => {
+      const token = ++openTokenRef.current;
       setEditGrams(record.grams?.toString() || "");
       setEditSodiumMg("");
       setEditSodiumSource("sodium");
       setEditWaterMl("");
       if (record.groupId) {
         void fetchEntryGroup(record.groupId).then((group) => {
+          if (token !== openTokenRef.current) return;
           if (!group) return;
           const salt = group.intakes.find((r) => r.type === "salt");
           const water = group.intakes.find(

--- a/src/components/food-salt/food-section.tsx
+++ b/src/components/food-salt/food-section.tsx
@@ -18,16 +18,18 @@ import { RecentEntriesList, InlineEditFormShell } from "@/components/recent-entr
 import { parseIntakeWithAI } from "@/lib/ai-client";
 import {
   useAddComposableEntry,
+  useSyncEatingGroup,
+  fetchEntryGroup,
+  sodiumKindFromSource,
   type ComposableEntryInput,
 } from "@/hooks/use-composable-entry";
 import {
   useEatingRecords,
   useAddEating,
   useDeleteEating,
-  useUpdateEating,
 } from "@/hooks/use-eating-queries";
 import { useDeleteWithToast } from "@/hooks/use-delete-with-toast";
-import { useSaltTotalsByGroupIds, useDeleteIntake, useUpdateIntake } from "@/hooks/use-intake-queries";
+import { useSaltTotalsByGroupIds } from "@/hooks/use-intake-queries";
 import { useEditRecord } from "@/hooks/use-edit-record";
 import { useToast } from "@/hooks/use-toast";
 import { useAuth } from "@/components/auth-guard";
@@ -88,14 +90,17 @@ export function FoodSection() {
   const groupSodiumMap = useSaltTotalsByGroupIds(groupIds);
 
   const deleteMutation = useDeleteEating();
-  const updateMutation = useUpdateEating();
+  const syncEatingGroupMutation = useSyncEatingGroup();
   const { deletingId, handleDelete } = useDeleteWithToast(
     deleteMutation,
     "Eating record removed"
   );
 
-  // Extra edit field for grams
+  // Extra edit fields
   const [editGrams, setEditGrams] = useState("");
+  const [editSodiumMg, setEditSodiumMg] = useState("");
+  const [editSodiumSource, setEditSodiumSource] = useState<SodiumSource>("sodium");
+  const [editWaterMl, setEditWaterMl] = useState("");
 
   const {
     editingRecord,
@@ -107,12 +112,55 @@ export function FoodSection() {
     closeEdit,
     handleEditSubmit,
   } = useEditRecord<EatingRecord>({
-    onOpen: (record) => setEditGrams(record.grams?.toString() || ""),
+    onOpen: (record) => {
+      setEditGrams(record.grams?.toString() || "");
+      setEditSodiumMg("");
+      setEditSodiumSource("sodium");
+      setEditWaterMl("");
+      if (record.groupId) {
+        void fetchEntryGroup(record.groupId).then((group) => {
+          if (!group) return;
+          const salt = group.intakes.find((r) => r.type === "salt");
+          const water = group.intakes.find(
+            (r) => r.type === "water" && r.source === "manual:food_water_content",
+          );
+          if (salt) {
+            const kind = sodiumKindFromSource(salt.source);
+            // back-convert stored sodium-mg to the user's input units
+            const multiplier = SODIUM_MULTIPLIERS[kind];
+            const inputValue = Math.round(salt.amount / multiplier);
+            setEditSodiumMg(inputValue.toString());
+            setEditSodiumSource(kind);
+          }
+          if (water) {
+            setEditWaterMl(water.amount.toString());
+          }
+        });
+      }
+    },
     buildUpdates: (timestamp, note) => {
       const g = editGrams ? parseInt(editGrams, 10) : undefined;
-      return { timestamp, note, grams: g && g > 0 ? g : undefined };
+      const sodiumInput = editSodiumMg ? parseFloat(editSodiumMg) : 0;
+      const calculatedSodiumMg =
+        sodiumInput > 0
+          ? Math.round(sodiumInput * SODIUM_MULTIPLIERS[editSodiumSource])
+          : 0;
+      const waterInput = editWaterMl ? parseFloat(editWaterMl) : 0;
+      return {
+        timestamp,
+        note,
+        grams: g && g > 0 ? g : undefined,
+        sodiumMg: calculatedSodiumMg,
+        sodiumKind: editSodiumSource,
+        waterMl: waterInput > 0 ? Math.round(waterInput) : 0,
+      };
     },
-    mutateAsync: updateMutation.mutateAsync,
+    mutateAsync: async ({ id, updates }) => {
+      await syncEatingGroupMutation(
+        id,
+        updates as Parameters<typeof syncEatingGroupMutation>[1],
+      );
+    },
   });
 
   // ─── Handlers ─────────────────────────────────────────────────────
@@ -403,7 +451,44 @@ export function FoodSection() {
         )}
         renderEditForm={() => (
           <InlineEditFormShell timestamp={editTimestamp} onTimestampChange={setEditTimestamp} note={editNote} onNoteChange={setEditNote} onSave={() => handleEditSubmit()} onCancel={closeEdit} buttonClassName={theme.buttonBg}>
-            <Input type="number" placeholder="Grams (optional)" value={editGrams} onChange={(e) => setEditGrams(e.target.value)} className="h-8 text-sm" />
+            <Input
+              type="number"
+              placeholder="Grams (optional)"
+              value={editGrams}
+              onChange={(e) => setEditGrams(e.target.value)}
+              className="h-8 text-sm"
+            />
+            <div className="flex gap-2">
+              <Input
+                type="number"
+                min="0"
+                placeholder="Sodium (optional)"
+                value={editSodiumMg}
+                onChange={(e) => setEditSodiumMg(e.target.value)}
+                className="h-8 text-sm flex-1"
+              />
+              <Select
+                value={editSodiumSource}
+                onValueChange={(v) => setEditSodiumSource(v as SodiumSource)}
+              >
+                <SelectTrigger className="h-8 text-sm w-[100px]">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="sodium">Sodium</SelectItem>
+                  <SelectItem value="salt">Salt</SelectItem>
+                  <SelectItem value="msg">MSG</SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+            <Input
+              type="number"
+              min="0"
+              placeholder="Water content (ml, optional)"
+              value={editWaterMl}
+              onChange={(e) => setEditWaterMl(e.target.value)}
+              className="h-8 text-sm"
+            />
           </InlineEditFormShell>
         )}
       />

--- a/src/components/liquids-card.tsx
+++ b/src/components/liquids-card.tsx
@@ -21,9 +21,10 @@ import { useSettings } from "@/hooks/use-settings";
 import { useToast } from "@/hooks/use-toast";
 import { useDeleteWithToast } from "@/hooks/use-delete-with-toast";
 import { useEditRecord } from "@/hooks/use-edit-record";
+import { useSyncLiquidGroup, fetchEntryGroup } from "@/hooks/use-composable-entry";
 import { cn, formatAmount, getLiquidTypeLabel } from "@/lib/utils";
 import { formatTimeOnly } from "@/lib/date-utils";
-import { type IntakeRecord } from "@/lib/db";
+import { type IntakeRecord, type SubstanceRecord } from "@/lib/db";
 
 const TAB_THEMES = {
   water: CARD_THEMES.water,
@@ -50,12 +51,20 @@ export function LiquidsCard() {
   const { toast } = useToast();
   const deleteMutation = useDeleteIntake();
   const updateMutation = useUpdateIntake();
+  const syncLiquidGroupMutation = useSyncLiquidGroup();
   const { deletingId, handleDelete } = useDeleteWithToast(
     deleteMutation,
     "Water entry removed"
   );
 
   const [editAmount, setEditAmount] = useState("");
+  const [editBeverageName, setEditBeverageName] = useState("");
+  const [showBeverageNameField, setShowBeverageNameField] = useState(false);
+  const [editSubstance, setEditSubstance] = useState<{
+    type: "caffeine" | "alcohol";
+    description: string;
+  } | null>(null);
+  const [editSubstanceAmount, setEditSubstanceAmount] = useState("");
 
   const {
     editingRecord,
@@ -67,16 +76,86 @@ export function LiquidsCard() {
     closeEdit,
     handleEditSubmit,
   } = useEditRecord<IntakeRecord>({
-    onOpen: (record) => setEditAmount(record.amount.toString()),
+    onOpen: (record) => {
+      setEditAmount(record.amount.toString());
+      setEditBeverageName("");
+      setShowBeverageNameField(false);
+      setEditSubstance(null);
+      setEditSubstanceAmount("");
+
+      const source = record.source ?? "";
+      if (source.startsWith("beverage:")) {
+        setShowBeverageNameField(true);
+        setEditBeverageName(source.slice("beverage:".length));
+      } else if (source === "beverage") {
+        setShowBeverageNameField(true);
+      }
+
+      if (record.groupId) {
+        void fetchEntryGroup(record.groupId).then((group) => {
+          if (!group) return;
+          const substance = group.substances.find(
+            (s): s is SubstanceRecord =>
+              s.type === "caffeine" || s.type === "alcohol",
+          );
+          if (!substance) return;
+          setEditSubstance({
+            type: substance.type,
+            description: substance.description,
+          });
+          setEditBeverageName(substance.description);
+          setShowBeverageNameField(true);
+          if (substance.type === "caffeine" && substance.amountMg !== undefined) {
+            setEditSubstanceAmount(substance.amountMg.toString());
+          } else if (
+            substance.type === "alcohol" &&
+            substance.amountStandardDrinks !== undefined
+          ) {
+            setEditSubstanceAmount(substance.amountStandardDrinks.toString());
+          }
+        });
+      }
+    },
     buildUpdates: (timestamp, note) => {
       const newAmount = parseInt(editAmount, 10);
       if (isNaN(newAmount) || newAmount <= 0) {
         toast({ title: "Invalid amount", variant: "destructive" });
         return null;
       }
-      return { amount: newAmount, timestamp, note };
+      const updates: { amount: number; timestamp: number; note: string | undefined; source?: string } = {
+        amount: newAmount,
+        timestamp,
+        note,
+      };
+      // Update source for beverage rename (only when no substance group is involved)
+      if (showBeverageNameField && !editSubstance) {
+        const trimmed = editBeverageName.trim();
+        updates.source = trimmed ? `beverage:${trimmed}` : "beverage";
+      }
+      return updates;
     },
-    mutateAsync: updateMutation.mutateAsync,
+    mutateAsync: async ({ id, updates }) => {
+      await updateMutation.mutateAsync({ id, updates });
+      // Sync linked substance records when editing a coffee/alcohol entry
+      if (editingRecord?.groupId && editSubstance) {
+        const u = updates as { amount: number; timestamp: number };
+        const substanceAmount = editSubstanceAmount
+          ? parseFloat(editSubstanceAmount)
+          : 0;
+        await syncLiquidGroupMutation(editingRecord.groupId, {
+          timestamp: u.timestamp,
+          description: editBeverageName.trim() || editSubstance.description,
+          volumeMl: u.amount,
+          ...(editSubstance.type === "caffeine" && {
+            amountMg: substanceAmount > 0 ? Math.round(substanceAmount) : 0,
+          }),
+          ...(editSubstance.type === "alcohol" && {
+            amountStandardDrinks:
+              substanceAmount > 0 ? parseFloat(substanceAmount.toFixed(2)) : 0,
+          }),
+        });
+      }
+    },
   });
 
   const theme = TAB_THEMES[activeTab as TabKey] ?? TAB_THEMES.water;
@@ -213,6 +292,30 @@ export function LiquidsCard() {
           renderEditForm={() => (
             <InlineEditFormShell timestamp={editTimestamp} onTimestampChange={setEditTimestamp} note={editNote} onNoteChange={setEditNote} onSave={() => handleEditSubmit()} onCancel={closeEdit} buttonClassName={CARD_THEMES.water.buttonBg}>
               <Input type="number" placeholder="Amount (ml)" value={editAmount} onChange={(e) => setEditAmount(e.target.value)} className="h-8 text-sm" />
+              {showBeverageNameField && (
+                <Input
+                  type="text"
+                  placeholder="Beverage name"
+                  value={editBeverageName}
+                  onChange={(e) => setEditBeverageName(e.target.value)}
+                  className="h-8 text-sm"
+                />
+              )}
+              {editSubstance && (
+                <Input
+                  type="number"
+                  min="0"
+                  step={editSubstance.type === "alcohol" ? "0.1" : "1"}
+                  placeholder={
+                    editSubstance.type === "caffeine"
+                      ? "Caffeine (mg)"
+                      : "Alcohol (std drinks)"
+                  }
+                  value={editSubstanceAmount}
+                  onChange={(e) => setEditSubstanceAmount(e.target.value)}
+                  className="h-8 text-sm"
+                />
+              )}
             </InlineEditFormShell>
           )}
         />

--- a/src/components/liquids-card.tsx
+++ b/src/components/liquids-card.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useRef, useState } from "react";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Card, CardContent } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
@@ -24,7 +24,7 @@ import { useEditRecord } from "@/hooks/use-edit-record";
 import { useSyncLiquidGroup, fetchEntryGroup } from "@/hooks/use-composable-entry";
 import { cn, formatAmount, getLiquidTypeLabel } from "@/lib/utils";
 import { formatTimeOnly } from "@/lib/date-utils";
-import { type IntakeRecord, type SubstanceRecord } from "@/lib/db";
+import { type IntakeRecord } from "@/lib/db";
 
 const TAB_THEMES = {
   water: CARD_THEMES.water,
@@ -65,6 +65,8 @@ export function LiquidsCard() {
     description: string;
   } | null>(null);
   const [editSubstanceAmount, setEditSubstanceAmount] = useState("");
+  // Token to discard stale fetchEntryGroup results when opening another record
+  const openTokenRef = useRef(0);
 
   const {
     editingRecord,
@@ -77,6 +79,7 @@ export function LiquidsCard() {
     handleEditSubmit,
   } = useEditRecord<IntakeRecord>({
     onOpen: (record) => {
+      const token = ++openTokenRef.current;
       setEditAmount(record.amount.toString());
       setEditBeverageName("");
       setShowBeverageNameField(false);
@@ -93,10 +96,10 @@ export function LiquidsCard() {
 
       if (record.groupId) {
         void fetchEntryGroup(record.groupId).then((group) => {
+          if (token !== openTokenRef.current) return;
           if (!group) return;
           const substance = group.substances.find(
-            (s): s is SubstanceRecord =>
-              s.type === "caffeine" || s.type === "alcohol",
+            (s) => s.type === "caffeine" || s.type === "alcohol",
           );
           if (!substance) return;
           setEditSubstance({
@@ -127,7 +130,10 @@ export function LiquidsCard() {
         timestamp,
         note,
       };
-      // Update source for beverage rename (only when no substance group is involved)
+      // Update IntakeRecord.source for plain beverage entries so the
+      // displayed name stays in sync. For coffee/alcohol entries the source
+      // is a `preset:<id>` / `substance:<id>` reference and the user-facing
+      // name lives on SubstanceRecord.description (synced separately below).
       if (showBeverageNameField && !editSubstance) {
         const trimmed = editBeverageName.trim();
         updates.source = trimmed ? `beverage:${trimmed}` : "beverage";
@@ -139,20 +145,28 @@ export function LiquidsCard() {
       // Sync linked substance records when editing a coffee/alcohol entry
       if (editingRecord?.groupId && editSubstance) {
         const u = updates as { amount: number; timestamp: number };
-        const substanceAmount = editSubstanceAmount
-          ? parseFloat(editSubstanceAmount)
-          : 0;
+        const rawSubstanceAmount = editSubstanceAmount.trim();
+        const parsedSubstanceAmount = rawSubstanceAmount
+          ? parseFloat(rawSubstanceAmount)
+          : NaN;
+        const hasSubstanceAmount =
+          rawSubstanceAmount !== "" &&
+          !isNaN(parsedSubstanceAmount) &&
+          parsedSubstanceAmount >= 0;
         await syncLiquidGroupMutation(editingRecord.groupId, {
           timestamp: u.timestamp,
           description: editBeverageName.trim() || editSubstance.description,
           volumeMl: u.amount,
-          ...(editSubstance.type === "caffeine" && {
-            amountMg: substanceAmount > 0 ? Math.round(substanceAmount) : 0,
-          }),
-          ...(editSubstance.type === "alcohol" && {
-            amountStandardDrinks:
-              substanceAmount > 0 ? parseFloat(substanceAmount.toFixed(2)) : 0,
-          }),
+          // Only include the typed amount when the user supplied a value;
+          // otherwise leave the existing linked-record value intact.
+          ...(hasSubstanceAmount &&
+            editSubstance.type === "caffeine" && {
+              amountMg: Math.round(parsedSubstanceAmount),
+            }),
+          ...(hasSubstanceAmount &&
+            editSubstance.type === "alcohol" && {
+              amountStandardDrinks: parseFloat(parsedSubstanceAmount.toFixed(2)),
+            }),
         });
       }
     },

--- a/src/hooks/use-composable-entry.ts
+++ b/src/hooks/use-composable-entry.ts
@@ -18,6 +18,8 @@ import {
   type RecordTable,
   type SodiumKind,
 } from "@/lib/composable-entry-service";
+import { unwrap } from "@/lib/service-result";
+import { showUndoToast } from "@/components/medications/undo-toast";
 
 export type { ComposableEntryInput, ComposableEntryResult, EntryGroup, RecordTable, SodiumKind };
 
@@ -27,8 +29,6 @@ export type { ComposableEntryInput, ComposableEntryResult, EntryGroup, RecordTab
  */
 export const fetchEntryGroup = getEntryGroup;
 export const sodiumKindFromSource = parseSodiumKindFromSource;
-import { unwrap } from "@/lib/service-result";
-import { showUndoToast } from "@/components/medications/undo-toast";
 
 /**
  * Reactive hook for reading all records in a composable entry group.

--- a/src/hooks/use-composable-entry.ts
+++ b/src/hooks/use-composable-entry.ts
@@ -9,13 +9,24 @@ import {
   getEntryGroup,
   deleteSingleGroupRecord,
   undoDeleteSingleRecord,
+  syncEatingGroup,
+  syncLiquidGroup,
+  parseSodiumKindFromSource,
   type ComposableEntryInput,
   type ComposableEntryResult,
   type EntryGroup,
   type RecordTable,
+  type SodiumKind,
 } from "@/lib/composable-entry-service";
 
-export type { ComposableEntryInput, ComposableEntryResult, EntryGroup, RecordTable };
+export type { ComposableEntryInput, ComposableEntryResult, EntryGroup, RecordTable, SodiumKind };
+
+/**
+ * Re-exports for component-side use (services may not be imported directly
+ * from components per the no-restricted-imports rule).
+ */
+export const fetchEntryGroup = getEntryGroup;
+export const sodiumKindFromSource = parseSodiumKindFromSource;
 import { unwrap } from "@/lib/service-result";
 import { showUndoToast } from "@/components/medications/undo-toast";
 
@@ -42,6 +53,39 @@ export function useAddComposableEntry() {
   return useCallback(
     async (input: ComposableEntryInput, timestamp?: number): Promise<ComposableEntryResult> => {
       return unwrap(await addComposableEntry(input, timestamp));
+    },
+    [],
+  );
+}
+
+/**
+ * Mutation hook for syncing an eating record's linked sodium / water-content
+ * intake records (used by the inline edit form on the Food card).
+ */
+export function useSyncEatingGroup() {
+  return useCallback(
+    async (
+      eatingId: string,
+      patch: Parameters<typeof syncEatingGroup>[1],
+    ): Promise<void> => {
+      unwrap(await syncEatingGroup(eatingId, patch));
+    },
+    [],
+  );
+}
+
+/**
+ * Mutation hook for syncing a liquid entry's linked substance records
+ * (used by the inline edit form on the Liquids card for coffee/alcohol/preset
+ * entries).
+ */
+export function useSyncLiquidGroup() {
+  return useCallback(
+    async (
+      groupId: string,
+      patch: Parameters<typeof syncLiquidGroup>[1],
+    ): Promise<void> => {
+      unwrap(await syncLiquidGroup(groupId, patch));
     },
     [],
   );

--- a/src/hooks/use-intake-queries.ts
+++ b/src/hooks/use-intake-queries.ts
@@ -120,7 +120,7 @@ export function useUpdateIntake() {
       updates,
     }: {
       id: string;
-      updates: { amount?: number; timestamp?: number; note?: string };
+      updates: { amount?: number; timestamp?: number; note?: string; source?: string };
     }) => unwrap(await updateIntakeRecord(id, updates)),
   });
 }

--- a/src/lib/composable-entry-service.ts
+++ b/src/lib/composable-entry-service.ts
@@ -347,12 +347,17 @@ export async function syncEatingGroup(
         .equals(groupId)
         .toArray();
 
-      const existingSalt = groupIntakes.find(
+      // Some legacy data may have multiple linked salt/water rows in one
+      // group. Reconcile the first match with the new value, soft-delete
+      // the rest so duplicates don't keep contributing to totals.
+      const existingSalts = groupIntakes.filter(
         (r) => r.type === "salt" && r.deletedAt === null && isSodiumKindSource(r.source),
       );
-      const existingWater = groupIntakes.find(
+      const existingWaters = groupIntakes.filter(
         (r) => r.type === "water" && r.deletedAt === null && r.source === FOOD_WATER_SOURCE,
       );
+      const [existingSalt, ...extraSalts] = existingSalts;
+      const [existingWater, ...extraWaters] = existingWaters;
 
       const sodiumSource = `manual:${patch.sodiumKind}`;
       const groupSource = eating.groupSource ?? "manual_food_entry";
@@ -385,16 +390,23 @@ export async function syncEatingGroup(
           updatedAt: now,
         });
       }
+      for (const dup of extraSalts) {
+        await db.intakeRecords.update(dup.id, {
+          deletedAt: now,
+          updatedAt: now,
+        });
+      }
 
       // ── Water content intake ──
       if (patch.waterMl > 0) {
         const waterNote = patch.note;
         if (existingWater) {
+          // Don't clear an existing note when the patch doesn't carry one.
           const waterUpdates: Record<string, unknown> = {
             amount: patch.waterMl,
             timestamp: patch.timestamp,
-            note: waterNote,
             updatedAt: now,
+            ...(waterNote !== undefined && { note: waterNote }),
           };
           await db.intakeRecords.update(existingWater.id, waterUpdates);
         } else {
@@ -413,6 +425,12 @@ export async function syncEatingGroup(
         }
       } else if (existingWater) {
         await db.intakeRecords.update(existingWater.id, {
+          deletedAt: now,
+          updatedAt: now,
+        });
+      }
+      for (const dup of extraWaters) {
+        await db.intakeRecords.update(dup.id, {
           deletedAt: now,
           updatedAt: now,
         });

--- a/src/lib/composable-entry-service.ts
+++ b/src/lib/composable-entry-service.ts
@@ -282,6 +282,210 @@ export async function undoDeleteSingleRecord(
   }
 }
 
+// ─── syncEatingGroup ──────────────────────────────────────────────────
+
+export type SodiumKind = "sodium" | "salt" | "msg";
+
+const FOOD_WATER_SOURCE = "manual:food_water_content";
+const SODIUM_KINDS: ReadonlyArray<SodiumKind> = ["sodium", "salt", "msg"];
+
+function isSodiumKindSource(source: string | undefined): boolean {
+  if (!source) return false;
+  return SODIUM_KINDS.some((k) => source === `manual:${k}`);
+}
+
+/**
+ * Apply edits to an eating record and its linked sodium / water-content
+ * intake records (linked by groupId). Creates/updates/soft-deletes the
+ * linked intake records to match the requested values.
+ *
+ * - If the eating record has no groupId, one is generated and assigned.
+ * - sodiumMg / waterMl of 0 (or undefined) soft-deletes any existing
+ *   linked record of that kind.
+ */
+export async function syncEatingGroup(
+  eatingId: string,
+  patch: {
+    timestamp: number;
+    note: string | undefined;
+    grams: number | undefined;
+    sodiumMg: number;
+    sodiumKind: SodiumKind;
+    waterMl: number;
+  },
+): Promise<ServiceResult<void>> {
+  try {
+    const fields = syncFields();
+    const now = fields.updatedAt;
+
+    await db.transaction("rw", [...COMPOSABLE_TABLES], async () => {
+      const eating = await db.eatingRecords.get(eatingId);
+      if (!eating) throw new Error("Eating record not found");
+
+      let groupId = eating.groupId;
+      if (!groupId && (patch.sodiumMg > 0 || patch.waterMl > 0)) {
+        groupId = crypto.randomUUID();
+      }
+
+      // ── Update the eating record itself ──
+      // Note: Dexie's update accepts undefined to clear optional fields,
+      // but exactOptionalPropertyTypes rejects that on Partial<EatingRecord>.
+      const eatingUpdates: Record<string, unknown> = {
+        timestamp: patch.timestamp,
+        note: patch.note,
+        grams: patch.grams,
+        updatedAt: now,
+      };
+      if (!eating.groupId && groupId) eatingUpdates.groupId = groupId;
+      await db.eatingRecords.update(eatingId, eatingUpdates);
+
+      if (!groupId) return; // Nothing else to sync
+
+      // ── Find existing linked records ──
+      const groupIntakes = await db.intakeRecords
+        .where("groupId")
+        .equals(groupId)
+        .toArray();
+
+      const existingSalt = groupIntakes.find(
+        (r) => r.type === "salt" && r.deletedAt === null && isSodiumKindSource(r.source),
+      );
+      const existingWater = groupIntakes.find(
+        (r) => r.type === "water" && r.deletedAt === null && r.source === FOOD_WATER_SOURCE,
+      );
+
+      const sodiumSource = `manual:${patch.sodiumKind}`;
+      const groupSource = eating.groupSource ?? "manual_food_entry";
+
+      // ── Sodium intake ──
+      if (patch.sodiumMg > 0) {
+        if (existingSalt) {
+          await db.intakeRecords.update(existingSalt.id, {
+            amount: patch.sodiumMg,
+            source: sodiumSource,
+            timestamp: patch.timestamp,
+            updatedAt: now,
+          });
+        } else {
+          const record: IntakeRecord = {
+            id: crypto.randomUUID(),
+            type: "salt",
+            amount: patch.sodiumMg,
+            timestamp: patch.timestamp,
+            source: sodiumSource,
+            groupId,
+            groupSource,
+            ...fields,
+          };
+          await db.intakeRecords.add(record);
+        }
+      } else if (existingSalt) {
+        await db.intakeRecords.update(existingSalt.id, {
+          deletedAt: now,
+          updatedAt: now,
+        });
+      }
+
+      // ── Water content intake ──
+      if (patch.waterMl > 0) {
+        const waterNote = patch.note;
+        if (existingWater) {
+          const waterUpdates: Record<string, unknown> = {
+            amount: patch.waterMl,
+            timestamp: patch.timestamp,
+            note: waterNote,
+            updatedAt: now,
+          };
+          await db.intakeRecords.update(existingWater.id, waterUpdates);
+        } else {
+          const record: IntakeRecord = {
+            id: crypto.randomUUID(),
+            type: "water",
+            amount: patch.waterMl,
+            timestamp: patch.timestamp,
+            source: FOOD_WATER_SOURCE,
+            groupId,
+            groupSource,
+            ...(waterNote !== undefined && { note: waterNote }),
+            ...fields,
+          };
+          await db.intakeRecords.add(record);
+        }
+      } else if (existingWater) {
+        await db.intakeRecords.update(existingWater.id, {
+          deletedAt: now,
+          updatedAt: now,
+        });
+      }
+    });
+
+    return ok(undefined);
+  } catch (e) {
+    return err("Failed to sync eating group", e);
+  }
+}
+
+/** Sodium kind embedded in the source tag of a linked salt intake record. */
+export function parseSodiumKindFromSource(source: string | undefined): SodiumKind {
+  if (source === "manual:salt") return "salt";
+  if (source === "manual:msg") return "msg";
+  return "sodium";
+}
+
+// ─── syncLiquidGroup ──────────────────────────────────────────────────
+
+/**
+ * Apply edits to the linked substance records of a liquid intake entry.
+ * Used when editing a coffee/alcohol/preset entry inline — keeps the
+ * substance amount (mg / std drinks) and description in sync with the
+ * water IntakeRecord.
+ *
+ * Pass `volumeMl` so any substance record that tracks liquid volume
+ * stays consistent with the edited IntakeRecord amount.
+ */
+export async function syncLiquidGroup(
+  groupId: string,
+  patch: {
+    timestamp: number;
+    description?: string;
+    volumeMl: number;
+    amountMg?: number;
+    amountStandardDrinks?: number;
+  },
+): Promise<ServiceResult<void>> {
+  try {
+    const now = Date.now();
+
+    await db.transaction("rw", [db.substanceRecords], async () => {
+      const substances = await db.substanceRecords
+        .where("groupId")
+        .equals(groupId)
+        .toArray();
+
+      for (const sub of substances) {
+        if (sub.deletedAt !== null) continue;
+        const updates: Partial<SubstanceRecord> = {
+          timestamp: patch.timestamp,
+          updatedAt: now,
+        };
+        if (patch.description !== undefined) updates.description = patch.description;
+        if (sub.volumeMl !== undefined) updates.volumeMl = patch.volumeMl;
+        if (sub.type === "caffeine" && patch.amountMg !== undefined) {
+          updates.amountMg = patch.amountMg;
+        }
+        if (sub.type === "alcohol" && patch.amountStandardDrinks !== undefined) {
+          updates.amountStandardDrinks = patch.amountStandardDrinks;
+        }
+        await db.substanceRecords.update(sub.id, updates);
+      }
+    });
+
+    return ok(undefined);
+  } catch (e) {
+    return err("Failed to sync liquid group", e);
+  }
+}
+
 // ─── recalculateFromCurrentValues (stub) ──────────────────────────────
 
 export async function recalculateFromCurrentValues(

--- a/src/lib/intake-service.ts
+++ b/src/lib/intake-service.ts
@@ -74,7 +74,7 @@ export async function undoDeleteIntakeRecord(id: string): Promise<ServiceResult<
 
 export async function updateIntakeRecord(
   id: string,
-  updates: { amount?: number; timestamp?: number; note?: string }
+  updates: { amount?: number; timestamp?: number; note?: string; source?: string }
 ): Promise<ServiceResult<void>> {
   try {
     const existing = await db.intakeRecords.get(id);


### PR DESCRIPTION
## Summary
This PR adds comprehensive inline editing capabilities for food entries (sodium and water content) and liquid entries (caffeine/alcohol substances), with automatic synchronization of linked intake and substance records.

## Key Changes

- **New service functions in `composable-entry-service.ts`:**
  - `syncEatingGroup()`: Syncs eating records with linked sodium/water intake records. Handles creation, updates, and soft-deletion of linked records based on input values. Automatically generates groupId when needed.
  - `syncLiquidGroup()`: Syncs liquid entries with linked substance records (caffeine/alcohol). Updates timestamp, description, volume, and substance-specific amounts across all linked records.
  - `parseSodiumKindFromSource()`: Extracts sodium kind ("sodium", "salt", or "msg") from intake record source tags.
  - Added `SodiumKind` type and helper constants (`SODIUM_KINDS`, `FOOD_WATER_SOURCE`).

- **Enhanced `FoodSection` component:**
  - Added inline edit fields for sodium amount, sodium kind (dropdown), and water content
  - Integrated `useSyncEatingGroup()` hook to persist changes to linked records
  - Fetches existing group data on edit open to populate fields with current values
  - Converts between user input units and stored mg values using `SODIUM_MULTIPLIERS`

- **Enhanced `LiquidsCard` component:**
  - Added inline edit fields for beverage name and substance amount (caffeine mg or alcohol standard drinks)
  - Integrated `useSyncLiquidGroup()` hook to sync substance records
  - Fetches linked substance data on edit open to show current values
  - Handles beverage source tagging (e.g., "beverage:Coffee")

- **Hook exports in `use-composable-entry.ts`:**
  - Exported `useSyncEatingGroup()` and `useSyncLiquidGroup()` mutation hooks
  - Re-exported service functions as `fetchEntryGroup` and `sodiumKindFromSource` for component use

- **Type updates:**
  - Updated `updateIntakeRecord()` signature to accept optional `source` field for beverage renaming

## Implementation Details

- Uses Dexie transactions for atomic updates across multiple record types
- Soft-deletes linked records (sets `deletedAt`) rather than hard-deleting
- Preserves `groupSource` when creating new linked records
- Handles undefined/zero values to trigger soft-deletion of linked records
- Maintains consistency between eating/intake records and substance records through coordinated updates

https://claude.ai/code/session_014hfBPAsYugfThkRCSgZq45

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced food entry editing to include sodium type/source and water content fields
  * Extended beverage entry editing to support beverage names and linked substance details (caffeine/alcohol amounts)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->