### PR TITLE
feat(voice): restyle launch bar and review action buttons

### DIFF
--- a/src/components/experimental/voice-launch-bar.tsx
+++ b/src/components/experimental/voice-launch-bar.tsx
@@ -34,7 +34,7 @@ export function VoiceLaunchBar({
   return (
     <>
       <motion.div
-        className="pointer-events-none fixed inset-x-0 z-30 px-3"
+        className="pointer-events-none fixed inset-x-0 z-30"
         style={{ bottom: bottomOffset }}
         animate={{ y: hidden ? "150%" : 0, opacity: hidden ? 0 : 1 }}
         transition={{ duration: transitionDuration, ease: "easeInOut" }}
@@ -44,15 +44,17 @@ export function VoiceLaunchBar({
           onClick={() => setOpen(true)}
           className={cn(
             "pointer-events-auto flex w-full items-center justify-center gap-2",
-            "rounded-full border border-primary/30 bg-primary/90 px-4 py-2.5",
-            "text-sm font-medium text-primary-foreground shadow-lg shadow-primary/20",
-            "backdrop-blur transition-all",
-            "hover:bg-primary active:scale-[0.98]",
-            "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+            "border-t bg-gradient-to-t from-slate-50 to-slate-50/95 dark:from-slate-950 dark:to-slate-950/95",
+            "backdrop-blur-sm px-4 py-2.5",
+            "text-sm font-medium text-muted-foreground transition-colors",
+            "hover:bg-muted/40 active:bg-muted/60",
+            "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-inset"
           )}
           aria-label="Open voice log"
         >
-          <Mic className="h-4 w-4" />
+          <span className="p-1.5 rounded-lg bg-sky-100 dark:bg-sky-900/50">
+            <Mic className="h-4 w-4 text-sky-600 dark:text-sky-400" />
+          </span>
           <span>Voice log</span>
         </button>
       </motion.div>

--- a/src/components/experimental/voice-panel.tsx
+++ b/src/components/experimental/voice-panel.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useCallback, useMemo, useState } from "react";
-import { Check, Mic, Sparkles, X } from "lucide-react";
+import { Check, Mic, X } from "lucide-react";
 import { useAuth } from "@/components/auth-guard";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
@@ -288,10 +288,6 @@ export function VoicePanel({ onCommitted }: VoicePanelProps) {
         <Mic className="h-5 w-5 text-primary" />
         <div className="flex-1">
           <h2 className="text-lg font-semibold leading-tight">Voice log</h2>
-          <p className="flex items-center gap-1 text-xs text-muted-foreground">
-            <Sparkles className="h-3 w-3" />
-            Experimental
-          </p>
         </div>
       </div>
 
@@ -383,11 +379,10 @@ export function VoicePanel({ onCommitted }: VoicePanelProps) {
         <div className="-mx-6 -mb-6 shrink-0 border-t bg-background/95 px-3 pt-3 backdrop-blur"
           style={{ paddingBottom: "calc(0.75rem + env(safe-area-inset-bottom, 0px))" }}
         >
-          <div className="flex gap-2">
+          <div className="flex">
             <Button
-              variant="outline"
               size="lg"
-              className="flex-1 gap-2"
+              className="flex-1 gap-2 rounded-r-none bg-red-600 text-white hover:bg-red-700 focus-visible:ring-red-600"
               disabled={stage === "saving"}
               onClick={rejectAll}
             >
@@ -395,25 +390,24 @@ export function VoicePanel({ onCommitted }: VoicePanelProps) {
               Reject all
             </Button>
             <Button
-              variant="outline"
               size="lg"
-              className="flex-1 gap-2"
+              className="flex-1 gap-2 rounded-l-none bg-emerald-600 text-white hover:bg-emerald-700 focus-visible:ring-emerald-600"
               disabled={stage === "saving" || pendingCount === 0}
               onClick={approveAll}
             >
               <Check className="h-5 w-5" />
               Approve all
             </Button>
-            <Button
-              size="lg"
-              className="flex-1 gap-2"
-              disabled={stage === "saving" || approvedCount === 0}
-              onClick={commit}
-            >
-              <Check className="h-5 w-5" />
-              Save {approvedCount > 0 ? approvedCount : ""}
-            </Button>
           </div>
+          <Button
+            size="lg"
+            className="mt-3 w-full gap-2"
+            disabled={stage === "saving" || approvedCount === 0}
+            onClick={commit}
+          >
+            <Check className="h-5 w-5" />
+            Save {approvedCount > 0 ? approvedCount : ""}
+          </Button>
         </div>
       )}
     </div>

--- a/src/components/experimental/voice-panel.tsx
+++ b/src/components/experimental/voice-panel.tsx
@@ -383,7 +383,7 @@ export function VoicePanel({ onCommitted }: VoicePanelProps) {
             <Button
               size="lg"
               className="flex-1 gap-2 rounded-r-none bg-red-600 text-white hover:bg-red-700 focus-visible:ring-red-600"
-              disabled={stage === "saving"}
+              disabled={stage === "saving" || pendingCount === 0}
               onClick={rejectAll}
             >
               <X className="h-5 w-5" />


### PR DESCRIPTION
Match the launch bar to the QuickNavFooter aesthetic — slate gradient,
square corners, mic icon in a colored chip beside horizontal "Voice
log" text. Drop the "Experimental" badge from the panel header.

Restructure the action bar: 50/50 Reject (red) / Approve (green) pair
as a single segmented control, with a full-width primary-blue Save
button below it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Refreshed voice launch bar button with new border styling, gradient effects, and backdrop blur
  * Updated microphone icon with enhanced visual styling
  * Redesigned voice panel header display
  * Restructured action buttons in voice panel with updated visual styling and arrangement

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/RyRy79261/intake-tracker/pull/64?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->