### PR TITLE
chore(license): switch from CC BY-NC-SA 4.0 to FSL-1.1-ALv2

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,41 +1,105 @@
-Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International
+# Functional Source License, Version 1.1, ALv2 Future License
 
-CC BY-NC-SA 4.0
+## Abbreviation
 
-Copyright (c) 2026 Ryan Noble
+FSL-1.1-ALv2
 
-This work is licensed under the Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International License.
+## Notice
 
-You are free to:
+Copyright 2026 Ryan Noble
 
-  Share - copy and redistribute the material in any medium or format
-  Adapt - remix, transform, and build upon the material
+## Terms and Conditions
 
-Under the following terms:
+### Licensor ("We")
 
-  Attribution - You must give appropriate credit, provide a link to the
-  license, and indicate if changes were made. You may do so in any reasonable
-  manner, but not in any way that suggests the licensor endorses you or your use.
+The party offering the Software under these Terms and Conditions.
 
-  NonCommercial - You may not use the material for commercial purposes.
+### The Software
 
-  ShareAlike - If you remix, transform, or build upon the material, you must
-  distribute your contributions under the same license as the original.
+The "Software" is each version of the software that we make available under
+these Terms and Conditions, as indicated by our inclusion of these Terms and
+Conditions with the Software.
 
-  No additional restrictions - You may not apply legal terms or technological
-  measures that legally restrict others from doing anything the license permits.
+### License Grant
 
-Notices:
+Subject to your compliance with this License Grant and the Patents,
+Redistribution and Trademark clauses below, we hereby grant you the right to
+use, copy, modify, create derivative works, publicly perform, publicly display
+and redistribute the Software for any Permitted Purpose identified below.
 
-  You do not have to comply with the license for elements of the material in
-  the public domain or where your use is permitted by an applicable exception
-  or limitation.
+### Permitted Purpose
 
-  No warranties are given. The license may not give you all of the permissions
-  necessary for your intended use. For example, other rights such as publicity,
-  privacy, or moral rights may limit how you use the material.
+A Permitted Purpose is any purpose other than a Competing Use. A Competing Use
+means making the Software available to others in a commercial product or
+service that:
 
-For the full license text, see:
-https://creativecommons.org/licenses/by-nc-sa/4.0/legalcode
+1. substitutes for the Software;
 
-For commercial use, please contact the author for permission.
+2. substitutes for any other product or service we offer using the Software
+   that exists as of the date we make the Software available; or
+
+3. offers the same or substantially similar functionality as the Software.
+
+Permitted Purposes specifically include using the Software:
+
+1. for your internal use and access;
+
+2. for non-commercial education;
+
+3. for non-commercial research; and
+
+4. in connection with professional services that you provide to a licensee
+   using the Software in accordance with these Terms and Conditions.
+
+### Patents
+
+To the extent your use for a Permitted Purpose would necessarily infringe our
+patents, the license grant above includes a license under our patents. If you
+make a claim against any party that the Software infringes or contributes to
+the infringement of any patent, then your patent license to the Software ends
+immediately.
+
+### Redistribution
+
+The Terms and Conditions apply to all copies, modifications and derivatives of
+the Software.
+
+If you redistribute any copies, modifications or derivatives of the Software,
+you must include a copy of or a link to these Terms and Conditions and not
+remove any copyright notices provided in or with the Software.
+
+### Disclaimer
+
+THE SOFTWARE IS PROVIDED "AS IS" AND WITHOUT WARRANTIES OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING WITHOUT LIMITATION WARRANTIES OF FITNESS FOR A PARTICULAR
+PURPOSE, MERCHANTABILITY, TITLE OR NON-INFRINGEMENT.
+
+IN NO EVENT WILL WE HAVE ANY LIABILITY TO YOU ARISING OUT OF OR RELATED TO THE
+SOFTWARE, INCLUDING INDIRECT, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES,
+EVEN IF WE HAVE BEEN INFORMED OF THEIR POSSIBILITY IN ADVANCE.
+
+### Trademarks
+
+Except for displaying the License Details and identifying us as the origin of
+the Software, you have no right under these Terms and Conditions to use our
+trademarks, trade names, service marks or product names.
+
+## Grant of Future License
+
+We hereby irrevocably grant you an additional license to use the Software under
+the Apache License, Version 2.0 that is effective on the second anniversary of
+the date we make the Software available. On or after that date, you may use the
+Software under the Apache License, Version 2.0, in which case the following
+will apply:
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+this file except in compliance with the License.
+
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed
+under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.

--- a/README.md
+++ b/README.md
@@ -247,7 +247,21 @@ AI features require Privy authentication and a server-side `ANTHROPIC_API_KEY`. 
 
 ## License
 
-This work is licensed under [CC BY-NC-SA 4.0](https://creativecommons.org/licenses/by-nc-sa/4.0/).
+This project is licensed under the [Functional Source License, Version 1.1, with Apache 2.0 Future License (FSL-1.1-ALv2)](https://fsl.software/). See [LICENSE](LICENSE) for the full text.
 
-You are free to share and adapt this work for non-commercial purposes with attribution.
-For commercial use, please contact the author for permission.
+**In plain language:**
+
+- You can use, copy, modify, fork, and redistribute the code for **any purpose** — personal use, self-hosting, internal use at your organization, education, research, or as part of professional services you provide — **except a Competing Use**.
+- A **Competing Use** is offering the Software (or something substantially similar) as a commercial product or service that competes with what we offer. In practice: don't take this code and launch a hosted/managed health-tracking SaaS that competes with our own offering.
+- **Every release auto-converts to Apache 2.0 on the second anniversary of its publication.** Each version carries its own clock, so older versions become fully open source on a rolling basis.
+
+**Examples:**
+
+- A patient self-hosting their own copy to track a chronic condition: allowed.
+- A clinician deploying it internally for their patients: allowed.
+- A developer forking it, wiring up their own AI provider, and sharing it with a community: allowed.
+- A company launching "HealthTrackerCloud" as a paid SaaS competing with the original: **not allowed** without a commercial license.
+
+### Commercial licensing
+
+If your intended use is a Competing Use, or you're unsure whether it qualifies, please get in touch before deploying: **meowzit.eth@gmail.com**.

--- a/README.md
+++ b/README.md
@@ -251,8 +251,8 @@ This project is licensed under the [Functional Source License, Version 1.1, with
 
 **In plain language:**
 
-- You can use, copy, modify, fork, and redistribute the code for **any purpose** — personal use, self-hosting, internal use at your organization, education, research, or as part of professional services you provide — **except a Competing Use**.
-- A **Competing Use** is offering the Software (or something substantially similar) as a commercial product or service that competes with what we offer. In practice: don't take this code and launch a hosted/managed health-tracking SaaS that competes with our own offering.
+- You can use, copy, modify, fork, and redistribute the code for **any purpose** — personal use, self-hosting, internal use at your organization, education, research, or as part of professional services you provide — **except a Competing Use**. The LICENSE defines a Competing Use as making the Software available to others in a commercial product or service that (1) substitutes for the Software, (2) substitutes for any other product or service the licensor offers using the Software, or (3) offers the same or substantially similar functionality as the Software.
+- Clause (3) stands on its own: a commercial product or service offering the same or substantially similar functionality is a Competing Use **even if the licensor does not currently offer a competing product or service**.
 - **Every release auto-converts to Apache 2.0 on the second anniversary of its publication.** Each version carries its own clock, so older versions become fully open source on a rolling basis.
 
 **Examples:**
@@ -260,7 +260,7 @@ This project is licensed under the [Functional Source License, Version 1.1, with
 - A patient self-hosting their own copy to track a chronic condition: allowed.
 - A clinician deploying it internally for their patients: allowed.
 - A developer forking it, wiring up their own AI provider, and sharing it with a community: allowed.
-- A company launching "HealthTrackerCloud" as a paid SaaS competing with the original: **not allowed** without a commercial license.
+- A company launching "HealthTrackerCloud" as a paid SaaS offering the same or substantially similar functionality as the Software: **not allowed** without a commercial license, whether or not the licensor currently offers a competing service.
 
 ### Commercial licensing
 


### PR DESCRIPTION
Replaces the Creative Commons license with the Functional Source
License 1.1 with Apache 2.0 Future License. FSL is purpose-built for
software, restricts only Competing Use (a commercial product/service
that substitutes for or substantially mirrors the original), and
auto-converts each release to Apache 2.0 on its second anniversary so
the project remains a long-term public good.

Updates README License section with a plain-language summary,
examples, and commercial licensing contact.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated project license to Functional Source License, Version 1.1, with future conversion to Apache 2.0 after two years. Commercial licensing inquiries are now available.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/RyRy79261/intake-tracker/pull/68?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->