### PR TITLE
Add swipe navigation between main routes

### DIFF
--- a/src/app/analytics/page.tsx
+++ b/src/app/analytics/page.tsx
@@ -9,22 +9,13 @@ import { InsightsTab } from "@/components/analytics/insights-tab";
 import { CorrelationsTab } from "@/components/analytics/correlations-tab";
 import { TitrationTab } from "@/components/analytics/titration-tab";
 import { ExportControls } from "@/components/analytics/export-controls";
-import { AppHeader } from "@/components/app-header";
 import { useTimeScopeRange } from "@/hooks/use-analytics-queries";
-import { useScrollHide } from "@/hooks/use-scroll-hide";
-import { useSettings } from "@/hooks/use-settings";
 import type { TimeScope, TimeRange } from "@/lib/analytics-types";
 
 type AnalyticsTab = "records" | "insights" | "correlations" | "titration";
 
 function AnalyticsContent() {
-  const settings = useSettings();
   const searchParams = useSearchParams();
-  const barTransitionSec = settings.barTransitionDurationMs / 1000;
-  const { isHidden } = useScrollHide({
-    scrollDurationMs: settings.scrollDurationMs,
-    autoHideDelayMs: settings.autoHideDelayMs,
-  });
 
   const tabParam = searchParams.get("tab");
   const initialTab: AnalyticsTab =
@@ -47,10 +38,7 @@ function AnalyticsContent() {
   const effectiveRange = customRange ?? scopeRange;
 
   return (
-    <>
-      <AppHeader headerHidden={isHidden} transitionDuration={barTransitionSec} />
-
-      <div className="space-y-4">
+    <div className="space-y-4">
         <div className="flex items-center justify-between gap-2">
           <TimeRangeSelector
             scope={scope}
@@ -96,8 +84,7 @@ function AnalyticsContent() {
             <TitrationTab range={effectiveRange} />
           </TabsContent>
         </Tabs>
-      </div>
-    </>
+    </div>
   );
 }
 

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -8,6 +8,7 @@ import { OfflineChip } from "@/components/sync/offline-chip";
 import { SwipeNav } from "@/components/swipe-nav";
 import { AppHeader } from "@/components/app-header";
 import { HomeFloatingBars } from "@/components/home-floating-bars";
+import { MedicationsFloatingBars } from "@/components/medications-floating-bars";
 
 const outfit = Outfit({ 
   subsets: ["latin"],
@@ -57,6 +58,7 @@ export default function RootLayout({
             </div>
             <SwipeNav>{children}</SwipeNav>
             <HomeFloatingBars />
+            <MedicationsFloatingBars />
           </main>
         </Providers>
         <UpdateNotification />

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -7,6 +7,7 @@ import { UpdateNotification } from "@/components/update-notification";
 import { OfflineChip } from "@/components/sync/offline-chip";
 import { SwipeNav } from "@/components/swipe-nav";
 import { AppHeader } from "@/components/app-header";
+import { HomeFloatingBars } from "@/components/home-floating-bars";
 
 const outfit = Outfit({ 
   subsets: ["latin"],
@@ -55,6 +56,7 @@ export default function RootLayout({
               <AppHeader />
             </div>
             <SwipeNav>{children}</SwipeNav>
+            <HomeFloatingBars />
           </main>
         </Providers>
         <UpdateNotification />

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -5,6 +5,7 @@ import { Toaster } from "@/components/ui/toaster";
 import { Providers } from "./providers";
 import { UpdateNotification } from "@/components/update-notification";
 import { OfflineChip } from "@/components/sync/offline-chip";
+import { SwipeNav } from "@/components/swipe-nav";
 
 const outfit = Outfit({ 
   subsets: ["latin"],
@@ -47,11 +48,13 @@ export default function RootLayout({
       </head>
       <body className={`${outfit.variable} font-sans antialiased`}>
         <Providers>
-          <main className="min-h-screen bg-gradient-to-b from-slate-50 to-slate-100 dark:from-slate-950 dark:to-slate-900">
-            <div className="container mx-auto px-4 py-6 max-w-lg">
-              <OfflineChip />
-              {children}
-            </div>
+          <main className="min-h-screen overflow-x-hidden bg-gradient-to-b from-slate-50 to-slate-100 dark:from-slate-950 dark:to-slate-900">
+            <SwipeNav>
+              <div className="container mx-auto px-4 py-6 max-w-lg">
+                <OfflineChip />
+                {children}
+              </div>
+            </SwipeNav>
           </main>
         </Providers>
         <UpdateNotification />

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -6,6 +6,7 @@ import { Providers } from "./providers";
 import { UpdateNotification } from "@/components/update-notification";
 import { OfflineChip } from "@/components/sync/offline-chip";
 import { SwipeNav } from "@/components/swipe-nav";
+import { AppHeader } from "@/components/app-header";
 
 const outfit = Outfit({ 
   subsets: ["latin"],
@@ -49,12 +50,11 @@ export default function RootLayout({
       <body className={`${outfit.variable} font-sans antialiased`}>
         <Providers>
           <main className="min-h-screen overflow-x-hidden bg-gradient-to-b from-slate-50 to-slate-100 dark:from-slate-950 dark:to-slate-900">
-            <SwipeNav>
-              <div className="container mx-auto px-4 py-6 max-w-lg">
-                <OfflineChip />
-                {children}
-              </div>
-            </SwipeNav>
+            <div className="container mx-auto max-w-lg px-4 pt-6">
+              <OfflineChip />
+              <AppHeader />
+            </div>
+            <SwipeNav>{children}</SwipeNav>
           </main>
         </Providers>
         <UpdateNotification />

--- a/src/app/medications/page.tsx
+++ b/src/app/medications/page.tsx
@@ -2,21 +2,22 @@
 
 import { useState, useCallback } from "react";
 import { WeekDaySelector } from "@/components/medications/week-day-selector";
-import { MedTabBar, type MedTab } from "@/components/medications/med-footer";
+import { MedTabBar } from "@/components/medications/med-footer";
 import { ScheduleView } from "@/components/medications/schedule-view";
 import { MedicationSettingsView } from "@/components/medications/medication-settings-view";
 import { DoseDetailDialog } from "@/components/medications/dose-detail-dialog";
-import { AddMedicationWizard } from "@/components/medications/add-medication-wizard";
 import { CompoundList } from "@/components/medications/compound-list";
 import { PrescriptionsView } from "@/components/medications/prescriptions-view";
 import { TitrationsView } from "@/components/medications/titrations-view";
 import type { DoseSlot } from "@/hooks/use-medication-queries";
 import { useMedicationNotifications } from "@/hooks/use-medication-notifications";
+import { useMedicationUIStore } from "@/stores/medication-ui-store";
 
 function MedicationsContent() {
-  const [activeTab, setActiveTab] = useState<MedTab>("schedule");
+  const activeTab = useMedicationUIStore((s) => s.activeTab);
+  const setActiveTab = useMedicationUIStore((s) => s.setActiveTab);
+  const setWizardOpen = useMedicationUIStore((s) => s.setWizardOpen);
   const [selectedDate, setSelectedDate] = useState(() => new Date());
-  const [wizardOpen, setWizardOpen] = useState(false);
 
   const [doseDetailOpen, setDoseDetailOpen] = useState(false);
   const [selectedSlot, setSelectedSlot] = useState<DoseSlot | null>(null);
@@ -32,7 +33,7 @@ function MedicationsContent() {
 
   const handleAddMed = useCallback(() => {
     setWizardOpen(true);
-  }, []);
+  }, [setWizardOpen]);
 
   return (
     <>
@@ -67,11 +68,6 @@ function MedicationsContent() {
         onOpenChange={setDoseDetailOpen}
         slot={selectedSlot}
         isToday={isToday}
-      />
-
-      <AddMedicationWizard
-        open={wizardOpen}
-        onOpenChange={setWizardOpen}
       />
     </>
   );

--- a/src/app/medications/page.tsx
+++ b/src/app/medications/page.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useState, useCallback } from "react";
-import { AppHeader } from "@/components/app-header";
 import { WeekDaySelector } from "@/components/medications/week-day-selector";
 import { MedTabBar, type MedTab } from "@/components/medications/med-footer";
 import { ScheduleView } from "@/components/medications/schedule-view";
@@ -11,8 +10,6 @@ import { AddMedicationWizard } from "@/components/medications/add-medication-wiz
 import { CompoundList } from "@/components/medications/compound-list";
 import { PrescriptionsView } from "@/components/medications/prescriptions-view";
 import { TitrationsView } from "@/components/medications/titrations-view";
-import { useScrollHide } from "@/hooks/use-scroll-hide";
-import { useSettings } from "@/hooks/use-settings";
 import type { DoseSlot } from "@/hooks/use-medication-queries";
 import { useMedicationNotifications } from "@/hooks/use-medication-notifications";
 
@@ -25,13 +22,6 @@ function MedicationsContent() {
   const [selectedSlot, setSelectedSlot] = useState<DoseSlot | null>(null);
 
   useMedicationNotifications();
-
-  const settings = useSettings();
-  const barTransitionSec = settings.barTransitionDurationMs / 1000;
-  const { isHidden } = useScrollHide({
-    scrollDurationMs: settings.scrollDurationMs,
-    autoHideDelayMs: settings.autoHideDelayMs,
-  });
 
   const isToday = selectedDate.toDateString() === new Date().toDateString();
 
@@ -46,11 +36,6 @@ function MedicationsContent() {
 
   return (
     <>
-      <AppHeader
-        headerHidden={isHidden}
-        transitionDuration={barTransitionSec}
-      />
-
       <MedTabBar activeTab={activeTab} onTabChange={setActiveTab} />
 
       {activeTab === "schedule" && (

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -3,7 +3,6 @@
 import { useEffect, useState } from "react";
 import { WeightCard } from "@/components/weight-card";
 import { BloodPressureCard } from "@/components/blood-pressure-card";
-import { QuickNavFooter } from "@/components/quick-nav-footer";
 import { TextMetrics } from "@/components/text-metrics";
 import { UrinationCard } from "@/components/urination-card";
 import { DefecationCard } from "@/components/defecation-card";
@@ -11,20 +10,12 @@ import { useSettings } from "@/hooks/use-settings";
 import { LiquidsCard } from "@/components/liquids-card";
 import { FoodSaltCard } from "@/components/food-salt-card";
 import { InsightBadge } from "@/components/insight-badge";
-import { VoiceLaunchBar } from "@/components/voice/voice-launch-bar";
-import { useScrollHide } from "@/hooks/use-scroll-hide";
 import { cn } from "@/lib/utils";
 import { Droplets } from "lucide-react";
 
 function HomeContent() {
   const [mounted, setMounted] = useState(false);
   const settings = useSettings();
-
-  const barTransitionSec = settings.barTransitionDurationMs / 1000;
-  const { isHidden, handleQuickNav } = useScrollHide({
-    scrollDurationMs: settings.scrollDurationMs,
-    autoHideDelayMs: settings.autoHideDelayMs,
-  });
 
   useEffect(() => {
     setMounted(true);
@@ -85,23 +76,6 @@ function HomeContent() {
           Water: max 1L/day · Sodium: max 1500mg/day
         </p>
       </footer>
-
-      <VoiceLaunchBar
-        hidden={isHidden}
-        hasQuickNav={settings.showQuickNav}
-        transitionDuration={barTransitionSec}
-      />
-
-
-      {settings.showQuickNav && (
-        <QuickNavFooter
-          hidden={isHidden}
-          order={settings.quickNavOrder}
-          transitionDuration={barTransitionSec}
-          quickNavItems={settings.quickNavItems}
-          onScrollTo={handleQuickNav}
-        />
-      )}
     </>
   );
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -3,7 +3,6 @@
 import { useEffect, useState } from "react";
 import { WeightCard } from "@/components/weight-card";
 import { BloodPressureCard } from "@/components/blood-pressure-card";
-import { AppHeader } from "@/components/app-header";
 import { QuickNavFooter } from "@/components/quick-nav-footer";
 import { TextMetrics } from "@/components/text-metrics";
 import { UrinationCard } from "@/components/urination-card";
@@ -44,11 +43,6 @@ function HomeContent() {
 
   return (
     <>
-      <AppHeader
-        headerHidden={isHidden}
-        transitionDuration={barTransitionSec}
-      />
-
       <div className="mb-4">
         <InsightBadge />
       </div>

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -24,6 +24,7 @@ import { LiquidPresetsSection } from "@/components/settings/liquid-presets-secti
 import { UrinationDefecationDefaults } from "@/components/settings/urination-defecation-defaults";
 import { MedicationSettingsSection } from "@/components/settings/medication-settings-section";
 import { AnimationTimingSection } from "@/components/settings/animation-timing-section";
+import { SwipeNavSection } from "@/components/settings/swipe-nav-section";
 import { StorageInfoSection } from "@/components/settings/storage-info-section";
 
 
@@ -70,6 +71,7 @@ function SettingsContent() {
           <AppearanceSection />
           <QuickNavSection />
           <AnimationTimingSection />
+          <SwipeNavSection />
         </SettingsAccordionGroup>
 
         <SettingsAccordionGroup value="medication" icon={Pill} label="Medication" iconColorClass="text-teal-600 dark:text-teal-400">

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -5,8 +5,6 @@ import { Accordion } from "@/components/ui/accordion";
 import { RotateCcw, Activity, Palette, Pill, Database, Shield, Bug } from "lucide-react";
 import { useSettings } from "@/hooks/use-settings";
 import { useToast } from "@/hooks/use-toast";
-import { useScrollHide } from "@/hooks/use-scroll-hide";
-import { AppHeader } from "@/components/app-header";
 import { DebugPanel } from "@/components/debug-panel";
 import { AboutDialog } from "@/components/about-dialog";
 import { SettingsAccordionGroup } from "@/components/settings/settings-accordion-group";
@@ -32,12 +30,6 @@ function SettingsContent() {
   const settings = useSettings();
   const { toast } = useToast();
 
-  const barTransitionSec = settings.barTransitionDurationMs / 1000;
-  const { isHidden } = useScrollHide({
-    scrollDurationMs: settings.scrollDurationMs,
-    autoHideDelayMs: settings.autoHideDelayMs,
-  });
-
   const handleResetToDefaults = () => {
     settings.resetToDefaults();
     toast({
@@ -48,11 +40,6 @@ function SettingsContent() {
 
   return (
     <>
-      <AppHeader
-        headerHidden={isHidden}
-        transitionDuration={barTransitionSec}
-      />
-
       <div className="pb-6">
         <AccountSection />
       </div>

--- a/src/components/app-header.tsx
+++ b/src/components/app-header.tsx
@@ -7,27 +7,31 @@ import { cn } from "@/lib/utils";
 import { SyncStatusBadge } from "@/components/sync/sync-status-badge";
 import { AuthButton } from "@/components/auth-button";
 import { NAV_ROUTES } from "@/lib/nav-routes";
+import { useSettings } from "@/hooks/use-settings";
+import { useScrollHide } from "@/hooks/use-scroll-hide";
 
 const NAV_ITEMS = NAV_ROUTES;
 
-interface AppHeaderProps {
-  headerHidden: boolean;
-  transitionDuration?: number;
-}
-
-export function AppHeader({
-  headerHidden,
-  transitionDuration = 0.2,
-}: AppHeaderProps) {
+export function AppHeader() {
   const pathname = usePathname();
   const router = useRouter();
+  const settings = useSettings();
+  const { isHidden } = useScrollHide({
+    scrollDurationMs: settings.scrollDurationMs,
+    autoHideDelayMs: settings.autoHideDelayMs,
+  });
+  const transitionDuration = settings.barTransitionDurationMs / 1000;
 
   const current = NAV_ITEMS.find((item) => item.path === pathname) ?? NAV_ITEMS[0];
+
+  // Hide entirely on routes that aren't top-level (e.g. /auth/*, /history)
+  const isTopRoute = NAV_ITEMS.some((item) => item.path === pathname);
+  if (!isTopRoute) return null;
 
   return (
     <motion.header
       className="sticky top-0 z-40 -mx-4 px-4 py-4 mb-2 bg-gradient-to-b from-slate-50 to-slate-50/95 dark:from-slate-950 dark:to-slate-950/95 backdrop-blur-sm flex items-center justify-between"
-      animate={{ y: headerHidden ? "-100%" : 0 }}
+      animate={{ y: isHidden ? "-100%" : 0 }}
       transition={{ duration: transitionDuration, ease: "easeInOut" }}
     >
       <div>

--- a/src/components/app-header.tsx
+++ b/src/components/app-header.tsx
@@ -3,17 +3,12 @@
 import { usePathname, useRouter } from "next/navigation";
 import { motion } from "motion/react";
 import { Button } from "@/components/ui/button";
-import { Droplets, Pill, BarChart3, Settings } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { SyncStatusBadge } from "@/components/sync/sync-status-badge";
 import { AuthButton } from "@/components/auth-button";
+import { NAV_ROUTES } from "@/lib/nav-routes";
 
-const NAV_ITEMS = [
-  { path: "/", icon: Droplets, label: "Intake", title: "Intake Tracker", subtitle: "Daily budget tracking" },
-  { path: "/medications", icon: Pill, label: "Meds", title: "Medications", subtitle: "Medicine schedule & tracking" },
-  { path: "/analytics", icon: BarChart3, label: "Analytics", title: "Analytics", subtitle: "Insights & record browsing" },
-  { path: "/settings", icon: Settings, label: "Settings", title: "Settings", subtitle: "Configure preferences" },
-] as const;
+const NAV_ITEMS = NAV_ROUTES;
 
 interface AppHeaderProps {
   headerHidden: boolean;

--- a/src/components/home-floating-bars.tsx
+++ b/src/components/home-floating-bars.tsx
@@ -1,0 +1,44 @@
+"use client";
+
+import { usePathname } from "next/navigation";
+import { useSettings } from "@/hooks/use-settings";
+import { useScrollHide } from "@/hooks/use-scroll-hide";
+import { QuickNavFooter } from "@/components/quick-nav-footer";
+import { VoiceLaunchBar } from "@/components/voice/voice-launch-bar";
+
+/**
+ * Renders the home-page floating chrome (QuickNavFooter + VoiceLaunchBar)
+ * outside the SwipeNav's transformed layer. Lives in the layout so
+ * `position: fixed` is honored against the viewport, not the swipe transform.
+ */
+export function HomeFloatingBars() {
+  const pathname = usePathname();
+  const settings = useSettings();
+  const { isHidden, handleQuickNav } = useScrollHide({
+    scrollDurationMs: settings.scrollDurationMs,
+    autoHideDelayMs: settings.autoHideDelayMs,
+  });
+
+  if (pathname !== "/") return null;
+
+  const barTransitionSec = settings.barTransitionDurationMs / 1000;
+
+  return (
+    <>
+      <VoiceLaunchBar
+        hidden={isHidden}
+        hasQuickNav={settings.showQuickNav}
+        transitionDuration={barTransitionSec}
+      />
+      {settings.showQuickNav && (
+        <QuickNavFooter
+          hidden={isHidden}
+          order={settings.quickNavOrder}
+          transitionDuration={barTransitionSec}
+          quickNavItems={settings.quickNavItems}
+          onScrollTo={handleQuickNav}
+        />
+      )}
+    </>
+  );
+}

--- a/src/components/medications-floating-bars.tsx
+++ b/src/components/medications-floating-bars.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useEffect } from "react";
 import { usePathname } from "next/navigation";
 import { Plus } from "lucide-react";
 import { AddMedicationWizard } from "@/components/medications/add-medication-wizard";
@@ -16,6 +17,15 @@ export function MedicationsFloatingBars() {
   const activeTab = useMedicationUIStore((s) => s.activeTab);
   const wizardOpen = useMedicationUIStore((s) => s.wizardOpen);
   const setWizardOpen = useMedicationUIStore((s) => s.setWizardOpen);
+
+  // Close the wizard when the user navigates away from the medications page,
+  // so coming back doesn't reopen it mid-flow. Tab state is intentionally
+  // preserved.
+  useEffect(() => {
+    if (pathname !== "/medications") {
+      setWizardOpen(false);
+    }
+  }, [pathname, setWizardOpen]);
 
   if (pathname !== "/medications") return null;
 

--- a/src/components/medications-floating-bars.tsx
+++ b/src/components/medications-floating-bars.tsx
@@ -1,0 +1,37 @@
+"use client";
+
+import { usePathname } from "next/navigation";
+import { Plus } from "lucide-react";
+import { AddMedicationWizard } from "@/components/medications/add-medication-wizard";
+import { useMedicationUIStore } from "@/stores/medication-ui-store";
+
+/**
+ * Renders the medications-page floating chrome (the "+" FAB and the
+ * AddMedicationWizard dialog) outside the SwipeNav's transformed layer so
+ * position:fixed resolves against the viewport. The FAB is only shown on the
+ * schedule tab — the other tabs have inline "Add" controls.
+ */
+export function MedicationsFloatingBars() {
+  const pathname = usePathname();
+  const activeTab = useMedicationUIStore((s) => s.activeTab);
+  const wizardOpen = useMedicationUIStore((s) => s.wizardOpen);
+  const setWizardOpen = useMedicationUIStore((s) => s.setWizardOpen);
+
+  if (pathname !== "/medications") return null;
+
+  return (
+    <>
+      {activeTab === "schedule" && (
+        <button
+          type="button"
+          onClick={() => setWizardOpen(true)}
+          className="fixed bottom-20 right-4 z-30 w-14 h-14 rounded-full bg-teal-600 hover:bg-teal-700 text-white shadow-lg flex items-center justify-center transition-colors active:scale-95"
+          aria-label="Add medication"
+        >
+          <Plus className="w-6 h-6" />
+        </button>
+      )}
+      <AddMedicationWizard open={wizardOpen} onOpenChange={setWizardOpen} />
+    </>
+  );
+}

--- a/src/components/medications/schedule-view.tsx
+++ b/src/components/medications/schedule-view.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useMemo, useEffect, useState, useCallback } from "react";
-import { Plus } from "lucide-react";
 import { useDailyDoseSchedule, useTakeDose, useUntakeDose, useSkipDose, useTakeAllDoses } from "@/hooks/use-medication-queries";
 import type { DoseSlot } from "@/hooks/use-medication-queries";
 import { hapticTake, hapticSkip } from "@/lib/medication-ui-utils";
@@ -324,13 +323,6 @@ export function ScheduleView({ selectedDate, onDoseClick, onAddMed }: ScheduleVi
         compoundName="all doses"
         onConfirm={handleMarkAllTimeConfirm}
       />
-
-      <button
-        onClick={onAddMed}
-        className="fixed bottom-20 right-4 z-30 w-14 h-14 rounded-full bg-teal-600 hover:bg-teal-700 text-white shadow-lg flex items-center justify-center transition-colors active:scale-95"
-      >
-        <Plus className="w-6 h-6" />
-      </button>
     </div>
   );
 }

--- a/src/components/page-skeletons.tsx
+++ b/src/components/page-skeletons.tsx
@@ -5,154 +5,341 @@ import type { NavRoute } from "@/lib/nav-routes";
 /**
  * Per-route layout-mimicking skeletons rendered as drag-peek previews by the
  * SwipeNav. Each tries to match the destination page's structural fingerprint
- * (tab bar, week selector, accordion list, etc) so the user gets a usable
- * preview of what they're swiping to rather than a generic placeholder.
+ * — same card shapes, header pattern, control rows, button heights — so the
+ * preview is recognizable rather than a generic placeholder.
  *
- * All decorative — wrapped in aria-hidden by the SwipeNav.
+ * Decorative only; wrapped in aria-hidden by SwipeNav.
  */
 
-const BLOCK = "bg-muted/40 rounded";
-const BLOCK_SOFT = "bg-muted/30 rounded";
-const CARD = "rounded-xl border bg-card/50";
+// ── Primitives ──────────────────────────────────────────────
 
-function SkeletonHeader({ route }: { route: NavRoute }) {
+function Block({ className = "" }: { className?: string }) {
+  return <div className={`rounded bg-muted/40 ${className}`} />;
+}
+
+function BlockSoft({ className = "" }: { className?: string }) {
+  return <div className={`rounded bg-muted/25 ${className}`} />;
+}
+
+function Pill({ className = "" }: { className?: string }) {
+  return <div className={`rounded-full bg-muted/40 ${className}`} />;
+}
+
+function Card({ children }: { children: React.ReactNode }) {
   return (
-    <div className="-mx-4 px-4 py-4 mb-2">
-      <div className="flex items-center justify-between gap-3">
-        <div className="space-y-2">
-          <div className={`h-7 w-44 ${BLOCK}`} />
-          <div className={`h-4 w-32 ${BLOCK_SOFT}`} />
-        </div>
-        <div className="flex h-9 w-9 items-center justify-center rounded-md bg-primary/10">
-          <route.icon className="h-5 w-5 text-primary/70" />
-        </div>
+    <div className="rounded-xl border bg-card/40 p-6">{children}</div>
+  );
+}
+
+/**
+ * Mimics the standard intake-card header: icon-square + uppercase label on
+ * the left, stat numbers on the right.
+ */
+function CardHeader({ statLines = 2 }: { statLines?: number }) {
+  return (
+    <div className="flex items-center justify-between mb-4">
+      <div className="flex items-center gap-2">
+        <Block className="h-9 w-9 rounded-lg" />
+        <Block className="h-5 w-20" />
+      </div>
+      <div className="space-y-1.5 text-right">
+        <Block className="h-4 w-24 ml-auto" />
+        <BlockSoft className="h-3 w-14 ml-auto" />
+        {statLines > 2 && <BlockSoft className="h-3 w-20 ml-auto" />}
       </div>
     </div>
   );
 }
 
-function IntakeSkeletonBody() {
+// ── Intake card skeletons ──────────────────────────────────
+
+function LiquidsCardSkel() {
+  return (
+    <Card>
+      <CardHeader statLines={3} />
+      {/* 4-tab strip */}
+      <div className="grid grid-cols-4 gap-1 rounded-md bg-muted/30 p-1 mb-4">
+        <Block className="h-7" />
+        <BlockSoft className="h-7" />
+        <BlockSoft className="h-7" />
+        <BlockSoft className="h-7" />
+      </div>
+      {/* Progress bar */}
+      <Pill className="h-3 w-full mb-4" />
+      {/* Quick-pick size row */}
+      <div className="flex gap-2 mb-4">
+        <Block className="h-9 flex-1" />
+        <Block className="h-9 flex-1" />
+        <Block className="h-9 flex-1" />
+        <Block className="h-9 flex-1" />
+      </div>
+      {/* Big +/- row */}
+      <div className="flex items-center gap-3 mb-4">
+        <Pill className="h-12 w-12" />
+        <BlockSoft className="h-16 flex-1 rounded-xl" />
+        <Pill className="h-12 w-12" />
+      </div>
+      {/* Confirm */}
+      <Block className="h-12 w-full" />
+    </Card>
+  );
+}
+
+function FoodSaltCardSkel() {
+  return (
+    <Card>
+      <CardHeader />
+      {/* AI input bar */}
+      <Block className="h-10 mb-4" />
+      {/* Sodium input */}
+      <BlockSoft className="h-3 w-16 mb-1" />
+      <Block className="h-10 mb-3" />
+      {/* Submit */}
+      <Block className="h-10 w-full" />
+    </Card>
+  );
+}
+
+function BloodPressureCardSkel() {
+  return (
+    <Card>
+      <CardHeader />
+      <div className="grid grid-cols-2 gap-3 mb-3">
+        <div className="space-y-1.5">
+          <BlockSoft className="h-3 w-20" />
+          <Block className="h-12" />
+        </div>
+        <div className="space-y-1.5">
+          <BlockSoft className="h-3 w-20" />
+          <Block className="h-12" />
+        </div>
+      </div>
+      <BlockSoft className="h-3 w-24 mb-1" />
+      <div className="flex gap-2 mb-3">
+        <Block className="h-11 flex-1" />
+        <Block className="h-11 w-14" />
+      </div>
+      <BlockSoft className="h-8 w-full mb-3" />
+      <Block className="h-10 w-full" />
+    </Card>
+  );
+}
+
+function WeightCardSkel() {
+  return (
+    <Card>
+      <CardHeader />
+      <div className="flex items-center gap-3 mb-4">
+        <Pill className="h-12 w-12" />
+        <BlockSoft className="h-14 flex-1 rounded-xl" />
+        <Pill className="h-12 w-12" />
+      </div>
+      <Block className="h-10 w-full" />
+    </Card>
+  );
+}
+
+function QuickLogCardSkel() {
+  return (
+    <Card>
+      <CardHeader />
+      <div className="grid grid-cols-3 gap-2">
+        <BlockSoft className="h-16 rounded-lg" />
+        <Block className="h-16 rounded-lg" />
+        <BlockSoft className="h-16 rounded-lg" />
+      </div>
+    </Card>
+  );
+}
+
+function IntakeBody() {
   return (
     <>
-      <div className={`mb-4 h-8 w-3/4 mx-auto rounded-full ${BLOCK_SOFT}`} />
+      <Pill className="h-9 w-full mb-4" />
       <div className="mb-6 space-y-2">
-        <div className={`h-3.5 w-2/3 ${BLOCK_SOFT}`} />
-        <div className={`h-3.5 w-1/2 ${BLOCK_SOFT}`} />
+        <BlockSoft className="h-3 w-2/3" />
+        <BlockSoft className="h-3 w-1/2" />
       </div>
-      <div className={`${CARD} mb-4 p-4 space-y-3`}>
-        <div className="flex gap-1.5">
-          <div className={`h-7 flex-1 ${BLOCK}`} />
-          <div className={`h-7 flex-1 ${BLOCK_SOFT}`} />
-          <div className={`h-7 flex-1 ${BLOCK_SOFT}`} />
-        </div>
-        <div className={`h-20 ${BLOCK_SOFT}`} />
-      </div>
-      <div className={`${CARD} mb-6 h-28`} />
       <div className="space-y-4 mb-6">
-        <div className={`${CARD} h-32`} />
-        <div className={`${CARD} h-24`} />
+        <LiquidsCardSkel />
+        <FoodSaltCardSkel />
+      </div>
+      <div className="space-y-4 mb-6">
+        <BloodPressureCardSkel />
+        <WeightCardSkel />
       </div>
       <div className="space-y-4">
-        <div className={`${CARD} h-24`} />
-        <div className={`${CARD} h-24`} />
+        <QuickLogCardSkel />
+        <QuickLogCardSkel />
       </div>
     </>
   );
 }
 
-function MedicationsSkeletonBody() {
+// ── Medications ────────────────────────────────────────────
+
+function MedicationsBody() {
   return (
     <>
-      <div className={`${CARD} p-1 mb-4 flex justify-between`}>
-        {Array.from({ length: 5 }).map((_, i) => (
-          <div key={i} className={`h-9 flex-1 mx-0.5 ${BLOCK_SOFT}`} />
-        ))}
+      {/* MedTabBar: full-width row of 5 icon+label tabs, with a 0.5px bottom
+          indicator on the first one. The real bar uses -mx-4 to break out of
+          the container; we mimic that by using a negative margin. */}
+      <div className="-mx-4 mb-3 border-b">
+        <div className="flex">
+          {Array.from({ length: 5 }).map((_, i) => (
+            <div
+              key={i}
+              className="flex-1 flex items-center justify-center gap-1.5 py-2.5 relative"
+            >
+              <BlockSoft className="h-4 w-4" />
+              <BlockSoft className="h-3 w-12" />
+              {i === 0 && (
+                <span className="absolute bottom-0 left-0 right-0 h-0.5 bg-muted/60" />
+              )}
+            </div>
+          ))}
+        </div>
       </div>
-      <div className="flex justify-between mb-6 px-1">
-        {Array.from({ length: 7 }).map((_, i) => (
-          <div key={i} className="flex flex-col items-center gap-1.5">
-            <div className={`h-3 w-6 ${BLOCK_SOFT}`} />
-            <div className="h-10 w-10 rounded-full bg-muted/40" />
+      {/* WeekDaySelector: chevron + 7 day buttons + chevron */}
+      <div className="flex items-center gap-1 mb-4">
+        <Pill className="h-8 w-8" />
+        <div className="flex-1 grid grid-cols-7 gap-0.5">
+          {Array.from({ length: 7 }).map((_, i) => (
+            <div
+              key={i}
+              className={`flex flex-col items-center py-1.5 rounded-lg ${
+                i === 3 ? "bg-muted/50" : ""
+              }`}
+            >
+              <BlockSoft className="h-2.5 w-5" />
+              <Block className="h-3.5 w-5 mt-1" />
+            </div>
+          ))}
+        </div>
+        <Pill className="h-8 w-8" />
+      </div>
+      {/* Dose-progress summary */}
+      <div className="rounded-xl border bg-card/40 p-4 mb-4">
+        <div className="flex items-center justify-between mb-3">
+          <Block className="h-4 w-24" />
+          <Block className="h-4 w-12" />
+        </div>
+        <Pill className="h-2 w-full" />
+      </div>
+      {/* Time slot groups */}
+      {Array.from({ length: 3 }).map((_, i) => (
+        <div key={i} className="rounded-xl border bg-card/40 p-4 mb-3">
+          <div className="flex items-center justify-between mb-3">
+            <Block className="h-5 w-16" />
+            <BlockSoft className="h-7 w-16" />
+          </div>
+          <div className="space-y-2">
+            <BlockSoft className="h-12 rounded-lg" />
+            <BlockSoft className="h-12 rounded-lg" />
+          </div>
+        </div>
+      ))}
+    </>
+  );
+}
+
+// ── Analytics ──────────────────────────────────────────────
+
+function AnalyticsBody() {
+  return (
+    <>
+      {/* Time range + export row */}
+      <div className="flex items-center justify-between gap-2 mb-4">
+        <div className="flex gap-1.5">
+          <Block className="h-8 w-12" />
+          <BlockSoft className="h-8 w-12" />
+          <BlockSoft className="h-8 w-12" />
+          <BlockSoft className="h-8 w-16" />
+        </div>
+        <Pill className="h-8 w-8" />
+      </div>
+      {/* 4 tab triggers */}
+      <div className="grid grid-cols-4 gap-1 rounded-md bg-muted/30 p-1 mb-6">
+        <Block className="h-8" />
+        <BlockSoft className="h-8" />
+        <BlockSoft className="h-8" />
+        <BlockSoft className="h-8" />
+      </div>
+      {/* Chart-ish big block */}
+      <div className="rounded-xl border bg-card/40 p-4 mb-4">
+        <div className="flex items-center justify-between mb-3">
+          <Block className="h-4 w-32" />
+          <BlockSoft className="h-3 w-16" />
+        </div>
+        <BlockSoft className="h-48 rounded-md" />
+      </div>
+      {/* List items */}
+      <div className="space-y-2">
+        {Array.from({ length: 4 }).map((_, i) => (
+          <div
+            key={i}
+            className="rounded-lg border bg-card/40 p-3 flex items-center gap-3"
+          >
+            <Block className="h-8 w-8 rounded-md" />
+            <div className="flex-1 space-y-1.5">
+              <Block className="h-3.5 w-2/3" />
+              <BlockSoft className="h-3 w-1/3" />
+            </div>
+            <BlockSoft className="h-3 w-10" />
           </div>
         ))}
       </div>
-      <div className="space-y-3">
-        <div className={`h-4 w-20 ${BLOCK}`} />
-        <div className={`${CARD} h-20`} />
-        <div className={`${CARD} h-20`} />
-        <div className={`h-4 w-20 mt-4 ${BLOCK}`} />
-        <div className={`${CARD} h-20`} />
-        <div className={`${CARD} h-20`} />
-      </div>
     </>
   );
 }
 
-function AnalyticsSkeletonBody() {
-  return (
-    <>
-      <div className="flex items-center justify-between gap-2 mb-4">
-        <div className="flex gap-1.5">
-          <div className={`h-8 w-12 ${BLOCK}`} />
-          <div className={`h-8 w-12 ${BLOCK_SOFT}`} />
-          <div className={`h-8 w-12 ${BLOCK_SOFT}`} />
-          <div className={`h-8 w-12 ${BLOCK_SOFT}`} />
-        </div>
-        <div className={`h-8 w-8 ${BLOCK_SOFT}`} />
-      </div>
-      <div className={`${CARD} p-1 mb-4 flex gap-1`}>
-        <div className={`h-8 flex-1 ${BLOCK}`} />
-        <div className={`h-8 flex-1 ${BLOCK_SOFT}`} />
-        <div className={`h-8 flex-1 ${BLOCK_SOFT}`} />
-        <div className={`h-8 flex-1 ${BLOCK_SOFT}`} />
-      </div>
-      <div className={`${CARD} h-48 mb-4`} />
-      <div className="space-y-2">
-        <div className={`${CARD} h-14`} />
-        <div className={`${CARD} h-14`} />
-        <div className={`${CARD} h-14`} />
-      </div>
-    </>
-  );
-}
+// ── Settings ───────────────────────────────────────────────
 
-function SettingsSkeletonBody() {
+function SettingsBody() {
   return (
     <>
-      <div className={`${CARD} p-4 mb-6 flex items-center gap-3`}>
-        <div className="h-10 w-10 rounded-full bg-muted/50" />
-        <div className="flex-1 space-y-1.5">
-          <div className={`h-4 w-32 ${BLOCK}`} />
-          <div className={`h-3 w-40 ${BLOCK_SOFT}`} />
+      {/* Account card */}
+      <div className="rounded-xl border bg-card/40 p-4 mb-6">
+        <div className="flex items-center gap-3 mb-2">
+          <Pill className="h-10 w-10" />
+          <div className="flex-1 space-y-1.5">
+            <Block className="h-4 w-40" />
+            <BlockSoft className="h-3 w-48" />
+          </div>
         </div>
+        <BlockSoft className="h-9 w-full mt-3 rounded-md" />
       </div>
+      {/* Accordion group rows */}
       <div className="space-y-2 mb-6">
         {Array.from({ length: 6 }).map((_, i) => (
           <div
             key={i}
-            className={`${CARD} px-4 py-3 flex items-center justify-between`}
+            className="rounded-lg border bg-card/40 px-4 py-3 flex items-center justify-between"
           >
             <div className="flex items-center gap-3">
-              <div className={`h-5 w-5 ${BLOCK}`} />
-              <div className={`h-4 w-28 ${BLOCK}`} />
+              <Block className="h-5 w-5" />
+              <Block className="h-4 w-32" />
             </div>
-            <div className={`h-4 w-4 ${BLOCK_SOFT}`} />
+            <BlockSoft className="h-4 w-4" />
           </div>
         ))}
       </div>
-      <div className={`h-9 w-full ${BLOCK_SOFT}`} />
+      {/* Reset + About */}
+      <BlockSoft className="h-9 w-full mb-2" />
+      <BlockSoft className="h-9 w-full" />
     </>
   );
 }
 
+// ── Dispatcher ─────────────────────────────────────────────
+
 export function PageSkeleton({ route }: { route: NavRoute }) {
   return (
-    <div className="container mx-auto max-w-lg px-4 pt-2 pb-6">
-      <SkeletonHeader route={route} />
-      {route.path === "/" && <IntakeSkeletonBody />}
-      {route.path === "/medications" && <MedicationsSkeletonBody />}
-      {route.path === "/analytics" && <AnalyticsSkeletonBody />}
-      {route.path === "/settings" && <SettingsSkeletonBody />}
+    <div className="container mx-auto max-w-lg px-4 pb-6">
+      {route.path === "/" && <IntakeBody />}
+      {route.path === "/medications" && <MedicationsBody />}
+      {route.path === "/analytics" && <AnalyticsBody />}
+      {route.path === "/settings" && <SettingsBody />}
     </div>
   );
 }

--- a/src/components/page-skeletons.tsx
+++ b/src/components/page-skeletons.tsx
@@ -1,0 +1,158 @@
+"use client";
+
+import type { NavRoute } from "@/lib/nav-routes";
+
+/**
+ * Per-route layout-mimicking skeletons rendered as drag-peek previews by the
+ * SwipeNav. Each tries to match the destination page's structural fingerprint
+ * (tab bar, week selector, accordion list, etc) so the user gets a usable
+ * preview of what they're swiping to rather than a generic placeholder.
+ *
+ * All decorative — wrapped in aria-hidden by the SwipeNav.
+ */
+
+const BLOCK = "bg-muted/40 rounded";
+const BLOCK_SOFT = "bg-muted/30 rounded";
+const CARD = "rounded-xl border bg-card/50";
+
+function SkeletonHeader({ route }: { route: NavRoute }) {
+  return (
+    <div className="-mx-4 px-4 py-4 mb-2">
+      <div className="flex items-center justify-between gap-3">
+        <div className="space-y-2">
+          <div className={`h-7 w-44 ${BLOCK}`} />
+          <div className={`h-4 w-32 ${BLOCK_SOFT}`} />
+        </div>
+        <div className="flex h-9 w-9 items-center justify-center rounded-md bg-primary/10">
+          <route.icon className="h-5 w-5 text-primary/70" />
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function IntakeSkeletonBody() {
+  return (
+    <>
+      <div className={`mb-4 h-8 w-3/4 mx-auto rounded-full ${BLOCK_SOFT}`} />
+      <div className="mb-6 space-y-2">
+        <div className={`h-3.5 w-2/3 ${BLOCK_SOFT}`} />
+        <div className={`h-3.5 w-1/2 ${BLOCK_SOFT}`} />
+      </div>
+      <div className={`${CARD} mb-4 p-4 space-y-3`}>
+        <div className="flex gap-1.5">
+          <div className={`h-7 flex-1 ${BLOCK}`} />
+          <div className={`h-7 flex-1 ${BLOCK_SOFT}`} />
+          <div className={`h-7 flex-1 ${BLOCK_SOFT}`} />
+        </div>
+        <div className={`h-20 ${BLOCK_SOFT}`} />
+      </div>
+      <div className={`${CARD} mb-6 h-28`} />
+      <div className="space-y-4 mb-6">
+        <div className={`${CARD} h-32`} />
+        <div className={`${CARD} h-24`} />
+      </div>
+      <div className="space-y-4">
+        <div className={`${CARD} h-24`} />
+        <div className={`${CARD} h-24`} />
+      </div>
+    </>
+  );
+}
+
+function MedicationsSkeletonBody() {
+  return (
+    <>
+      <div className={`${CARD} p-1 mb-4 flex justify-between`}>
+        {Array.from({ length: 5 }).map((_, i) => (
+          <div key={i} className={`h-9 flex-1 mx-0.5 ${BLOCK_SOFT}`} />
+        ))}
+      </div>
+      <div className="flex justify-between mb-6 px-1">
+        {Array.from({ length: 7 }).map((_, i) => (
+          <div key={i} className="flex flex-col items-center gap-1.5">
+            <div className={`h-3 w-6 ${BLOCK_SOFT}`} />
+            <div className="h-10 w-10 rounded-full bg-muted/40" />
+          </div>
+        ))}
+      </div>
+      <div className="space-y-3">
+        <div className={`h-4 w-20 ${BLOCK}`} />
+        <div className={`${CARD} h-20`} />
+        <div className={`${CARD} h-20`} />
+        <div className={`h-4 w-20 mt-4 ${BLOCK}`} />
+        <div className={`${CARD} h-20`} />
+        <div className={`${CARD} h-20`} />
+      </div>
+    </>
+  );
+}
+
+function AnalyticsSkeletonBody() {
+  return (
+    <>
+      <div className="flex items-center justify-between gap-2 mb-4">
+        <div className="flex gap-1.5">
+          <div className={`h-8 w-12 ${BLOCK}`} />
+          <div className={`h-8 w-12 ${BLOCK_SOFT}`} />
+          <div className={`h-8 w-12 ${BLOCK_SOFT}`} />
+          <div className={`h-8 w-12 ${BLOCK_SOFT}`} />
+        </div>
+        <div className={`h-8 w-8 ${BLOCK_SOFT}`} />
+      </div>
+      <div className={`${CARD} p-1 mb-4 flex gap-1`}>
+        <div className={`h-8 flex-1 ${BLOCK}`} />
+        <div className={`h-8 flex-1 ${BLOCK_SOFT}`} />
+        <div className={`h-8 flex-1 ${BLOCK_SOFT}`} />
+        <div className={`h-8 flex-1 ${BLOCK_SOFT}`} />
+      </div>
+      <div className={`${CARD} h-48 mb-4`} />
+      <div className="space-y-2">
+        <div className={`${CARD} h-14`} />
+        <div className={`${CARD} h-14`} />
+        <div className={`${CARD} h-14`} />
+      </div>
+    </>
+  );
+}
+
+function SettingsSkeletonBody() {
+  return (
+    <>
+      <div className={`${CARD} p-4 mb-6 flex items-center gap-3`}>
+        <div className="h-10 w-10 rounded-full bg-muted/50" />
+        <div className="flex-1 space-y-1.5">
+          <div className={`h-4 w-32 ${BLOCK}`} />
+          <div className={`h-3 w-40 ${BLOCK_SOFT}`} />
+        </div>
+      </div>
+      <div className="space-y-2 mb-6">
+        {Array.from({ length: 6 }).map((_, i) => (
+          <div
+            key={i}
+            className={`${CARD} px-4 py-3 flex items-center justify-between`}
+          >
+            <div className="flex items-center gap-3">
+              <div className={`h-5 w-5 ${BLOCK}`} />
+              <div className={`h-4 w-28 ${BLOCK}`} />
+            </div>
+            <div className={`h-4 w-4 ${BLOCK_SOFT}`} />
+          </div>
+        ))}
+      </div>
+      <div className={`h-9 w-full ${BLOCK_SOFT}`} />
+    </>
+  );
+}
+
+export function PageSkeleton({ route }: { route: NavRoute }) {
+  return (
+    <div className="container mx-auto max-w-lg px-4 pt-2 pb-6">
+      <SkeletonHeader route={route} />
+      {route.path === "/" && <IntakeSkeletonBody />}
+      {route.path === "/medications" && <MedicationsSkeletonBody />}
+      {route.path === "/analytics" && <AnalyticsSkeletonBody />}
+      {route.path === "/settings" && <SettingsSkeletonBody />}
+    </div>
+  );
+}

--- a/src/components/settings/swipe-nav-section.tsx
+++ b/src/components/settings/swipe-nav-section.tsx
@@ -1,0 +1,115 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { Hand } from "lucide-react";
+import { Label } from "@/components/ui/label";
+import { NumericInput } from "@/components/ui/numeric-input";
+import { useSettings } from "@/hooks/use-settings";
+import { validateAndSave, incrementSetting, decrementSetting } from "@/lib/settings-helpers";
+
+export function SwipeNavSection() {
+  const settings = useSettings();
+  const [distanceInput, setDistanceInput] = useState(settings.swipeNavDistanceThresholdPct.toString());
+  const [velocityInput, setVelocityInput] = useState(settings.swipeNavVelocityThreshold.toString());
+
+  useEffect(() => {
+    setDistanceInput(settings.swipeNavDistanceThresholdPct.toString());
+    setVelocityInput(settings.swipeNavVelocityThreshold.toString());
+  }, [settings.swipeNavDistanceThresholdPct, settings.swipeNavVelocityThreshold]);
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center gap-2 text-violet-600 dark:text-violet-400">
+        <Hand className="w-4 h-4" />
+        <h3 className="font-semibold">Swipe Navigation</h3>
+      </div>
+      <div className="space-y-3 pl-6">
+        <div className="space-y-2">
+          <Label htmlFor="swipe-distance-threshold">Distance Threshold (% of width)</Label>
+          <NumericInput
+            id="swipe-distance-threshold"
+            value={distanceInput}
+            onChange={setDistanceInput}
+            onBlur={() =>
+              validateAndSave(
+                distanceInput,
+                10,
+                60,
+                settings.swipeNavDistanceThresholdPct,
+                settings.setSwipeNavDistanceThresholdPct,
+                setDistanceInput,
+              )
+            }
+            min={10}
+            max={60}
+            step={1}
+            onIncrement={() =>
+              incrementSetting(
+                settings.swipeNavDistanceThresholdPct,
+                1,
+                60,
+                settings.setSwipeNavDistanceThresholdPct,
+                setDistanceInput,
+              )
+            }
+            onDecrement={() =>
+              decrementSetting(
+                settings.swipeNavDistanceThresholdPct,
+                1,
+                10,
+                settings.setSwipeNavDistanceThresholdPct,
+                setDistanceInput,
+              )
+            }
+          />
+          <p className="text-xs text-muted-foreground">
+            How far you must drag (as % of screen width) to commit the page change (10-60). Lower = more sensitive.
+          </p>
+        </div>
+
+        <div className="space-y-2">
+          <Label htmlFor="swipe-velocity-threshold">Flick Velocity (px/s)</Label>
+          <NumericInput
+            id="swipe-velocity-threshold"
+            value={velocityInput}
+            onChange={setVelocityInput}
+            onBlur={() =>
+              validateAndSave(
+                velocityInput,
+                100,
+                2000,
+                settings.swipeNavVelocityThreshold,
+                settings.setSwipeNavVelocityThreshold,
+                setVelocityInput,
+              )
+            }
+            min={100}
+            max={2000}
+            step={50}
+            onIncrement={() =>
+              incrementSetting(
+                settings.swipeNavVelocityThreshold,
+                50,
+                2000,
+                settings.setSwipeNavVelocityThreshold,
+                setVelocityInput,
+              )
+            }
+            onDecrement={() =>
+              decrementSetting(
+                settings.swipeNavVelocityThreshold,
+                50,
+                100,
+                settings.setSwipeNavVelocityThreshold,
+                setVelocityInput,
+              )
+            }
+          />
+          <p className="text-xs text-muted-foreground">
+            Minimum flick speed that commits regardless of distance (100-2000). Lower = lighter flicks.
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/swipe-nav.tsx
+++ b/src/components/swipe-nav.tsx
@@ -6,6 +6,7 @@ import {
   motion,
   useMotionValue,
   useTransform,
+  useMotionTemplate,
   animate,
   type PanInfo,
 } from "motion/react";
@@ -167,9 +168,12 @@ export function SwipeNav({ children }: { children: React.ReactNode }) {
   const nextHintScale = useTransform(x, [-140, 0], [1, 0.85]);
 
   // Skeleton overlays share the drag x but sit one viewport over so they peek
-  // in naturally as the user drags toward them.
-  const prevSkelX = useTransform(x, (v) => v - (width || 0));
-  const nextSkelX = useTransform(x, (v) => v + (width || 0));
+  // in naturally as the user drags toward them. We use CSS calc with 100vw so
+  // the offset is correct from the very first render — useTransform with a
+  // JS-tracked width is stale until x next changes, which would leave the
+  // skeletons sitting on top of the children before the first drag.
+  const prevSkelTransform = useMotionTemplate`translateX(calc(${x}px - 100vw))`;
+  const nextSkelTransform = useMotionTemplate`translateX(calc(${x}px + 100vw))`;
 
   return (
     <div className="relative overflow-x-hidden">
@@ -197,8 +201,8 @@ export function SwipeNav({ children }: { children: React.ReactNode }) {
       {isTopRoute && prevRoute && (
         <motion.div
           aria-hidden="true"
-          className="pointer-events-none absolute inset-x-0 top-0"
-          style={{ x: prevSkelX }}
+          className="pointer-events-none absolute inset-x-0 top-0 will-change-transform"
+          style={{ transform: prevSkelTransform }}
         >
           <PageSkeleton route={prevRoute} />
         </motion.div>
@@ -206,8 +210,8 @@ export function SwipeNav({ children }: { children: React.ReactNode }) {
       {isTopRoute && nextRoute && (
         <motion.div
           aria-hidden="true"
-          className="pointer-events-none absolute inset-x-0 top-0"
-          style={{ x: nextSkelX }}
+          className="pointer-events-none absolute inset-x-0 top-0 will-change-transform"
+          style={{ transform: nextSkelTransform }}
         >
           <PageSkeleton route={nextRoute} />
         </motion.div>

--- a/src/components/swipe-nav.tsx
+++ b/src/components/swipe-nav.tsx
@@ -10,9 +10,8 @@ import {
   type PanInfo,
 } from "motion/react";
 import { NAV_ROUTES } from "@/lib/nav-routes";
+import { useSettingsStore } from "@/stores/settings-store";
 
-const SWIPE_THRESHOLD_RATIO = 0.28;
-const VELOCITY_THRESHOLD = 500;
 const DIRECTION_LOCK_THRESHOLD = 8;
 const RESISTANCE = 0.25;
 const COMMIT_DURATION = 0.18;
@@ -27,6 +26,18 @@ export function SwipeNav({ children }: { children: React.ReactNode }) {
   const startedRef = useRef(false);
   const navigatingRef = useRef(false);
   const commitDirRef = useRef<"prev" | "next" | null>(null);
+  const distanceThresholdPct = useSettingsStore((s) => s.swipeNavDistanceThresholdPct);
+  const velocityThreshold = useSettingsStore((s) => s.swipeNavVelocityThreshold);
+  // Mirror reactive thresholds into refs so handlers always read live values
+  // without forcing handler reallocation on every settings change.
+  const distanceThresholdRef = useRef(distanceThresholdPct);
+  const velocityThresholdRef = useRef(velocityThreshold);
+  useEffect(() => {
+    distanceThresholdRef.current = distanceThresholdPct;
+  }, [distanceThresholdPct]);
+  useEffect(() => {
+    velocityThresholdRef.current = velocityThreshold;
+  }, [velocityThreshold]);
 
   const currentIndex = NAV_ROUTES.findIndex((r) => r.path === pathname);
   const isTopRoute = currentIndex !== -1;
@@ -118,13 +129,14 @@ export function SwipeNav({ children }: { children: React.ReactNode }) {
       }
 
       const w = window.innerWidth || width || 1;
-      const threshold = w * SWIPE_THRESHOLD_RATIO;
+      const threshold = w * (distanceThresholdRef.current / 100);
+      const vThreshold = velocityThresholdRef.current;
       const { offset, velocity } = info;
 
       const goingPrev =
-        offset.x > 0 && prevRoute && (offset.x > threshold || velocity.x > VELOCITY_THRESHOLD);
+        offset.x > 0 && prevRoute && (offset.x > threshold || velocity.x > vThreshold);
       const goingNext =
-        offset.x < 0 && nextRoute && (offset.x < -threshold || velocity.x < -VELOCITY_THRESHOLD);
+        offset.x < 0 && nextRoute && (offset.x < -threshold || velocity.x < -vThreshold);
 
       if (goingPrev || goingNext) {
         navigatingRef.current = true;

--- a/src/components/swipe-nav.tsx
+++ b/src/components/swipe-nav.tsx
@@ -23,10 +23,6 @@ export function SwipeNav({ children }: { children: React.ReactNode }) {
   const router = useRouter();
   const x = useMotionValue(0);
   const [width, setWidth] = useState(0);
-  // Hide skeletons during the post-commit enter animation so the (now stale)
-  // adjacent-route skeleton doesn't briefly slide across the screen as the
-  // new page slides in from the opposite edge.
-  const [skeletonsHidden, setSkeletonsHidden] = useState(false);
   const lockRef = useRef<"horizontal" | "vertical" | null>(null);
   const startedRef = useRef(false);
   const navigatingRef = useRef(false);
@@ -64,26 +60,11 @@ export function SwipeNav({ children }: { children: React.ReactNode }) {
   }, [prevRoute, nextRoute, router]);
 
   useLayoutEffect(() => {
-    const w = window.innerWidth;
-    if (commitDirRef.current === "next") {
-      x.set(w);
-      setSkeletonsHidden(true);
-      animate(x, 0, {
-        type: "tween",
-        ease: [0.22, 1, 0.36, 1],
-        duration: ENTER_DURATION,
-      }).then(() => setSkeletonsHidden(false));
-    } else if (commitDirRef.current === "prev") {
-      x.set(-w);
-      setSkeletonsHidden(true);
-      animate(x, 0, {
-        type: "tween",
-        ease: [0.22, 1, 0.36, 1],
-        duration: ENTER_DURATION,
-      }).then(() => setSkeletonsHidden(false));
-    } else {
-      x.set(0);
-    }
+    // After a route change the destination skeleton was already centered (it
+    // animated into place during commit), so the real page just takes its
+    // position. No slide-in animation — that would look like the page is
+    // re-entering from the edge the user just swiped from.
+    x.set(0);
     commitDirRef.current = null;
     navigatingRef.current = false;
     lockRef.current = null;
@@ -213,7 +194,7 @@ export function SwipeNav({ children }: { children: React.ReactNode }) {
         </motion.div>
       )}
 
-      {isTopRoute && prevRoute && !skeletonsHidden && (
+      {isTopRoute && prevRoute && (
         <motion.div
           aria-hidden="true"
           className="pointer-events-none absolute inset-x-0 top-0"
@@ -222,7 +203,7 @@ export function SwipeNav({ children }: { children: React.ReactNode }) {
           <PageSkeleton route={prevRoute} />
         </motion.div>
       )}
-      {isTopRoute && nextRoute && !skeletonsHidden && (
+      {isTopRoute && nextRoute && (
         <motion.div
           aria-hidden="true"
           className="pointer-events-none absolute inset-x-0 top-0"

--- a/src/components/swipe-nav.tsx
+++ b/src/components/swipe-nav.tsx
@@ -9,7 +9,7 @@ import {
   animate,
   type PanInfo,
 } from "motion/react";
-import { NAV_ROUTES, type NavRoute } from "@/lib/nav-routes";
+import { NAV_ROUTES } from "@/lib/nav-routes";
 import { useSettingsStore } from "@/stores/settings-store";
 
 const DIRECTION_LOCK_THRESHOLD = 8;
@@ -17,41 +17,11 @@ const RESISTANCE = 0.25;
 const COMMIT_DURATION = 0.18;
 const ENTER_DURATION = 0.22;
 
-function PageSkeleton({ route }: { route: NavRoute | null }) {
-  if (!route) {
-    return <div className="w-screen shrink-0" aria-hidden="true" />;
-  }
-  return (
-    <div className="w-screen shrink-0" aria-hidden="true">
-      <div className="container mx-auto max-w-lg px-4 py-6">
-        <div className="-mx-4 px-4 py-4 mb-2">
-          <div className="flex items-center justify-between gap-3">
-            <div className="space-y-2">
-              <div className="h-7 w-44 rounded bg-muted/70" />
-              <div className="h-4 w-32 rounded bg-muted/50" />
-            </div>
-            <div className="flex h-9 w-9 items-center justify-center rounded-md bg-primary/10">
-              <route.icon className="h-5 w-5 text-primary/70" />
-            </div>
-          </div>
-        </div>
-        <div className="space-y-4 pt-2">
-          <div className="h-28 rounded-xl bg-muted/40" />
-          <div className="h-28 rounded-xl bg-muted/40" />
-          <div className="h-28 rounded-xl bg-muted/40" />
-          <div className="h-28 rounded-xl bg-muted/40" />
-        </div>
-      </div>
-    </div>
-  );
-}
-
 export function SwipeNav({ children }: { children: React.ReactNode }) {
   const pathname = usePathname();
   const router = useRouter();
   const x = useMotionValue(0);
   const [width, setWidth] = useState(0);
-  const [mounted, setMounted] = useState(false);
   const lockRef = useRef<"horizontal" | "vertical" | null>(null);
   const startedRef = useRef(false);
   const navigatingRef = useRef(false);
@@ -69,50 +39,46 @@ export function SwipeNav({ children }: { children: React.ReactNode }) {
 
   const currentIndex = NAV_ROUTES.findIndex((r) => r.path === pathname);
   const isTopRoute = currentIndex !== -1;
-  const prevRoute: NavRoute | null =
+  const prevRoute =
     isTopRoute && currentIndex > 0 ? NAV_ROUTES[currentIndex - 1] ?? null : null;
-  const nextRoute: NavRoute | null =
+  const nextRoute =
     isTopRoute && currentIndex < NAV_ROUTES.length - 1
       ? NAV_ROUTES[currentIndex + 1] ?? null
       : null;
 
-  useLayoutEffect(() => {
-    setWidth(window.innerWidth);
-    setMounted(true);
-  }, []);
-
   useEffect(() => {
     const update = () => setWidth(window.innerWidth);
+    update();
     window.addEventListener("resize", update);
     return () => window.removeEventListener("resize", update);
   }, []);
 
-  // Prefetch adjacent routes so the post-commit gap is as small as possible.
+  // Prefetch adjacent routes so the post-commit gap is as short as possible.
   useEffect(() => {
     if (prevRoute) router.prefetch(prevRoute.path);
     if (nextRoute) router.prefetch(nextRoute.path);
   }, [prevRoute, nextRoute, router]);
 
-  // After a route change, snap the strip back to centered without animating —
-  // the destination skeleton was already centered when we navigated, and now
-  // the real children have taken its place.
+  // After the route changes, slide the new page in from the side the user
+  // committed toward — so a left-swipe (→ next) makes the new page enter from
+  // the right, matching the gesture. useLayoutEffect runs before paint so the
+  // user never sees the new page flash at x=0.
   useLayoutEffect(() => {
-    if (commitDirRef.current) {
-      x.set(0);
-      commitDirRef.current = null;
+    const w = window.innerWidth;
+    if (commitDirRef.current === "next") {
+      x.set(w);
+      animate(x, 0, { type: "tween", ease: [0.22, 1, 0.36, 1], duration: ENTER_DURATION });
+    } else if (commitDirRef.current === "prev") {
+      x.set(-w);
+      animate(x, 0, { type: "tween", ease: [0.22, 1, 0.36, 1], duration: ENTER_DURATION });
     } else {
-      // Non-swipe navigation (header buttons, links): no animation needed.
       x.set(0);
     }
+    commitDirRef.current = null;
     navigatingRef.current = false;
     lockRef.current = null;
     startedRef.current = false;
   }, [pathname, x]);
-
-  // Translate the strip so the *current* pane (middle of three) sits at x=0
-  // when the drag value is 0. Negative drag reveals the next pane, positive
-  // reveals the previous pane.
-  const stripX = useTransform(x, (v) => v - (width || 0));
 
   const handlePanStart = useCallback(
     (event: PointerEvent, _info: PanInfo) => {
@@ -203,29 +169,46 @@ export function SwipeNav({ children }: { children: React.ReactNode }) {
     [x, width, prevRoute, nextRoute, router],
   );
 
-  // Non-top routes (e.g. /auth/*) and the first pre-mount render skip the
-  // swipe strip and render children plainly so layout is stable and there's
-  // no risk of a one-frame flash showing the previous-skeleton pane.
-  if (!isTopRoute || !mounted) {
-    return (
-      <div className="container mx-auto max-w-lg px-4 pb-6">{children}</div>
-    );
-  }
+  // Edge hint pills (icon + label) that fade in as the user drags.
+  const prevHintOpacity = useTransform(x, [0, 60, 140], [0, 0.65, 1]);
+  const nextHintOpacity = useTransform(x, [-140, -60, 0], [1, 0.65, 0]);
+  const prevHintScale = useTransform(x, [0, 140], [0.85, 1]);
+  const nextHintScale = useTransform(x, [-140, 0], [1, 0.85]);
 
   return (
     <div className="overflow-x-hidden">
+      {isTopRoute && prevRoute && (
+        <motion.div
+          aria-hidden="true"
+          className="pointer-events-none fixed left-3 top-1/2 z-30 -translate-y-1/2 flex items-center gap-2 rounded-full border bg-background/95 px-3 py-2 shadow-lg backdrop-blur"
+          style={{ opacity: prevHintOpacity, scale: prevHintScale }}
+        >
+          <prevRoute.icon className="h-4 w-4 text-primary" />
+          <span className="text-xs font-medium">{prevRoute.title}</span>
+        </motion.div>
+      )}
+      {isTopRoute && nextRoute && (
+        <motion.div
+          aria-hidden="true"
+          className="pointer-events-none fixed right-3 top-1/2 z-30 -translate-y-1/2 flex items-center gap-2 rounded-full border bg-background/95 px-3 py-2 shadow-lg backdrop-blur"
+          style={{ opacity: nextHintOpacity, scale: nextHintScale }}
+        >
+          <span className="text-xs font-medium">{nextRoute.title}</span>
+          <nextRoute.icon className="h-4 w-4 text-primary" />
+        </motion.div>
+      )}
       <motion.div
-        className="flex will-change-transform"
-        style={{ x: stripX, touchAction: "pan-y" }}
-        onPanStart={handlePanStart}
-        onPan={handlePan}
-        onPanEnd={handlePanEnd}
+        className="will-change-transform"
+        style={{ x, touchAction: "pan-y" }}
+        {...(isTopRoute
+          ? {
+              onPanStart: handlePanStart,
+              onPan: handlePan,
+              onPanEnd: handlePanEnd,
+            }
+          : {})}
       >
-        <PageSkeleton route={prevRoute} />
-        <div className="w-screen shrink-0">
-          <div className="container mx-auto max-w-lg px-4 pb-6">{children}</div>
-        </div>
-        <PageSkeleton route={nextRoute} />
+        <div className="container mx-auto max-w-lg px-4 pb-6">{children}</div>
       </motion.div>
     </div>
   );

--- a/src/components/swipe-nav.tsx
+++ b/src/components/swipe-nav.tsx
@@ -9,7 +9,7 @@ import {
   animate,
   type PanInfo,
 } from "motion/react";
-import { NAV_ROUTES } from "@/lib/nav-routes";
+import { NAV_ROUTES, type NavRoute } from "@/lib/nav-routes";
 import { useSettingsStore } from "@/stores/settings-store";
 
 const DIRECTION_LOCK_THRESHOLD = 8;
@@ -17,11 +17,39 @@ const RESISTANCE = 0.25;
 const COMMIT_DURATION = 0.18;
 const ENTER_DURATION = 0.22;
 
+function PageSkeleton({ route }: { route: NavRoute }) {
+  return (
+    <div className="container mx-auto max-w-lg px-4 pt-2 pb-6" aria-hidden="true">
+      <div className="-mx-4 px-4 py-4 mb-2">
+        <div className="flex items-center justify-between gap-3">
+          <div className="space-y-2">
+            <div className="h-7 w-44 rounded bg-muted/70" />
+            <div className="h-4 w-32 rounded bg-muted/50" />
+          </div>
+          <div className="flex h-9 w-9 items-center justify-center rounded-md bg-primary/10">
+            <route.icon className="h-5 w-5 text-primary/70" />
+          </div>
+        </div>
+      </div>
+      <div className="space-y-4 pt-2">
+        <div className="h-28 rounded-xl bg-muted/40" />
+        <div className="h-28 rounded-xl bg-muted/40" />
+        <div className="h-28 rounded-xl bg-muted/40" />
+        <div className="h-28 rounded-xl bg-muted/40" />
+      </div>
+    </div>
+  );
+}
+
 export function SwipeNav({ children }: { children: React.ReactNode }) {
   const pathname = usePathname();
   const router = useRouter();
   const x = useMotionValue(0);
   const [width, setWidth] = useState(0);
+  // Hide skeletons during the post-commit enter animation so the (now stale)
+  // adjacent-route skeleton doesn't briefly slide across the screen as the
+  // new page slides in from the opposite edge.
+  const [skeletonsHidden, setSkeletonsHidden] = useState(false);
   const lockRef = useRef<"horizontal" | "vertical" | null>(null);
   const startedRef = useRef(false);
   const navigatingRef = useRef(false);
@@ -53,24 +81,29 @@ export function SwipeNav({ children }: { children: React.ReactNode }) {
     return () => window.removeEventListener("resize", update);
   }, []);
 
-  // Prefetch adjacent routes so the post-commit gap is as short as possible.
   useEffect(() => {
     if (prevRoute) router.prefetch(prevRoute.path);
     if (nextRoute) router.prefetch(nextRoute.path);
   }, [prevRoute, nextRoute, router]);
 
-  // After the route changes, slide the new page in from the side the user
-  // committed toward — so a left-swipe (→ next) makes the new page enter from
-  // the right, matching the gesture. useLayoutEffect runs before paint so the
-  // user never sees the new page flash at x=0.
   useLayoutEffect(() => {
     const w = window.innerWidth;
     if (commitDirRef.current === "next") {
       x.set(w);
-      animate(x, 0, { type: "tween", ease: [0.22, 1, 0.36, 1], duration: ENTER_DURATION });
+      setSkeletonsHidden(true);
+      animate(x, 0, {
+        type: "tween",
+        ease: [0.22, 1, 0.36, 1],
+        duration: ENTER_DURATION,
+      }).then(() => setSkeletonsHidden(false));
     } else if (commitDirRef.current === "prev") {
       x.set(-w);
-      animate(x, 0, { type: "tween", ease: [0.22, 1, 0.36, 1], duration: ENTER_DURATION });
+      setSkeletonsHidden(true);
+      animate(x, 0, {
+        type: "tween",
+        ease: [0.22, 1, 0.36, 1],
+        duration: ENTER_DURATION,
+      }).then(() => setSkeletonsHidden(false));
     } else {
       x.set(0);
     }
@@ -169,14 +202,19 @@ export function SwipeNav({ children }: { children: React.ReactNode }) {
     [x, width, prevRoute, nextRoute, router],
   );
 
-  // Edge hint pills (icon + label) that fade in as the user drags.
+  // Edge hint pills (icon + label) fade in as the user drags.
   const prevHintOpacity = useTransform(x, [0, 60, 140], [0, 0.65, 1]);
   const nextHintOpacity = useTransform(x, [-140, -60, 0], [1, 0.65, 0]);
   const prevHintScale = useTransform(x, [0, 140], [0.85, 1]);
   const nextHintScale = useTransform(x, [-140, 0], [1, 0.85]);
 
+  // Skeleton overlays share the drag x but sit one viewport over so they peek
+  // in naturally as the user drags toward them.
+  const prevSkelX = useTransform(x, (v) => v - (width || 0));
+  const nextSkelX = useTransform(x, (v) => v + (width || 0));
+
   return (
-    <div className="overflow-x-hidden">
+    <div className="relative overflow-x-hidden">
       {isTopRoute && prevRoute && (
         <motion.div
           aria-hidden="true"
@@ -197,6 +235,26 @@ export function SwipeNav({ children }: { children: React.ReactNode }) {
           <nextRoute.icon className="h-4 w-4 text-primary" />
         </motion.div>
       )}
+
+      {isTopRoute && prevRoute && !skeletonsHidden && (
+        <motion.div
+          aria-hidden="true"
+          className="pointer-events-none absolute inset-x-0 top-0"
+          style={{ x: prevSkelX }}
+        >
+          <PageSkeleton route={prevRoute} />
+        </motion.div>
+      )}
+      {isTopRoute && nextRoute && !skeletonsHidden && (
+        <motion.div
+          aria-hidden="true"
+          className="pointer-events-none absolute inset-x-0 top-0"
+          style={{ x: nextSkelX }}
+        >
+          <PageSkeleton route={nextRoute} />
+        </motion.div>
+      )}
+
       <motion.div
         className="will-change-transform"
         style={{ x, touchAction: "pan-y" }}

--- a/src/components/swipe-nav.tsx
+++ b/src/components/swipe-nav.tsx
@@ -167,6 +167,7 @@ export function SwipeNav({ children }: { children: React.ReactNode }) {
     <>
       {isTopRoute && prevRoute && (
         <motion.div
+          aria-hidden="true"
           className="pointer-events-none fixed left-3 top-1/2 z-30 -translate-y-1/2 flex items-center gap-2 rounded-full border bg-background/95 px-3 py-2 shadow-lg backdrop-blur"
           style={{ opacity: prevHintOpacity, scale: prevHintScale }}
         >
@@ -176,6 +177,7 @@ export function SwipeNav({ children }: { children: React.ReactNode }) {
       )}
       {isTopRoute && nextRoute && (
         <motion.div
+          aria-hidden="true"
           className="pointer-events-none fixed right-3 top-1/2 z-30 -translate-y-1/2 flex items-center gap-2 rounded-full border bg-background/95 px-3 py-2 shadow-lg backdrop-blur"
           style={{ opacity: nextHintOpacity, scale: nextHintScale }}
         >

--- a/src/components/swipe-nav.tsx
+++ b/src/components/swipe-nav.tsx
@@ -6,7 +6,6 @@ import {
   motion,
   useMotionValue,
   useTransform,
-  useMotionTemplate,
   animate,
   type PanInfo,
 } from "motion/react";
@@ -167,14 +166,6 @@ export function SwipeNav({ children }: { children: React.ReactNode }) {
   const prevHintScale = useTransform(x, [0, 140], [0.85, 1]);
   const nextHintScale = useTransform(x, [-140, 0], [1, 0.85]);
 
-  // Skeleton overlays share the drag x but sit one viewport over so they peek
-  // in naturally as the user drags toward them. We use CSS calc with 100vw so
-  // the offset is correct from the very first render — useTransform with a
-  // JS-tracked width is stale until x next changes, which would leave the
-  // skeletons sitting on top of the children before the first drag.
-  const prevSkelTransform = useMotionTemplate`translateX(calc(${x}px - 100vw))`;
-  const nextSkelTransform = useMotionTemplate`translateX(calc(${x}px + 100vw))`;
-
   return (
     <div className="relative overflow-x-hidden">
       {isTopRoute && prevRoute && (
@@ -198,11 +189,21 @@ export function SwipeNav({ children }: { children: React.ReactNode }) {
         </motion.div>
       )}
 
+      {/* Skeleton overlays. They share the drag motion value `x` for the
+          translateX, but the resting offset (one viewport over) is set via
+          plain CSS `left`. Doing the offset via `left` instead of folding it
+          into the transform avoids two problems:
+            1. motion components manage `transform` internally via the `x`/`y`
+               shortcuts, so setting a `transform` string via `style` is not
+               reliably applied alongside `x`.
+            2. useTransform(x, v => v ± width) with width as React state is
+               stale until x next changes — the skeletons would sit on top of
+               the children on first render. */}
       {isTopRoute && prevRoute && (
         <motion.div
           aria-hidden="true"
-          className="pointer-events-none absolute inset-x-0 top-0 will-change-transform"
-          style={{ transform: prevSkelTransform }}
+          className="pointer-events-none absolute top-0 w-screen will-change-transform"
+          style={{ left: "-100vw", x }}
         >
           <PageSkeleton route={prevRoute} />
         </motion.div>
@@ -210,8 +211,8 @@ export function SwipeNav({ children }: { children: React.ReactNode }) {
       {isTopRoute && nextRoute && (
         <motion.div
           aria-hidden="true"
-          className="pointer-events-none absolute inset-x-0 top-0 will-change-transform"
-          style={{ transform: nextSkelTransform }}
+          className="pointer-events-none absolute top-0 w-screen will-change-transform"
+          style={{ left: "100vw", x }}
         >
           <PageSkeleton route={nextRoute} />
         </motion.div>

--- a/src/components/swipe-nav.tsx
+++ b/src/components/swipe-nav.tsx
@@ -9,37 +9,14 @@ import {
   animate,
   type PanInfo,
 } from "motion/react";
-import { NAV_ROUTES, type NavRoute } from "@/lib/nav-routes";
+import { NAV_ROUTES } from "@/lib/nav-routes";
 import { useSettingsStore } from "@/stores/settings-store";
+import { PageSkeleton } from "@/components/page-skeletons";
 
 const DIRECTION_LOCK_THRESHOLD = 8;
 const RESISTANCE = 0.25;
 const COMMIT_DURATION = 0.18;
 const ENTER_DURATION = 0.22;
-
-function PageSkeleton({ route }: { route: NavRoute }) {
-  return (
-    <div className="container mx-auto max-w-lg px-4 pt-2 pb-6" aria-hidden="true">
-      <div className="-mx-4 px-4 py-4 mb-2">
-        <div className="flex items-center justify-between gap-3">
-          <div className="space-y-2">
-            <div className="h-7 w-44 rounded bg-muted/70" />
-            <div className="h-4 w-32 rounded bg-muted/50" />
-          </div>
-          <div className="flex h-9 w-9 items-center justify-center rounded-md bg-primary/10">
-            <route.icon className="h-5 w-5 text-primary/70" />
-          </div>
-        </div>
-      </div>
-      <div className="space-y-4 pt-2">
-        <div className="h-28 rounded-xl bg-muted/40" />
-        <div className="h-28 rounded-xl bg-muted/40" />
-        <div className="h-28 rounded-xl bg-muted/40" />
-        <div className="h-28 rounded-xl bg-muted/40" />
-      </div>
-    </div>
-  );
-}
 
 export function SwipeNav({ children }: { children: React.ReactNode }) {
   const pathname = usePathname();

--- a/src/components/swipe-nav.tsx
+++ b/src/components/swipe-nav.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useLayoutEffect, useRef, useState } from "react";
 import { usePathname, useRouter } from "next/navigation";
 import {
   motion,
@@ -9,7 +9,7 @@ import {
   animate,
   type PanInfo,
 } from "motion/react";
-import { NAV_ROUTES } from "@/lib/nav-routes";
+import { NAV_ROUTES, type NavRoute } from "@/lib/nav-routes";
 import { useSettingsStore } from "@/stores/settings-store";
 
 const DIRECTION_LOCK_THRESHOLD = 8;
@@ -17,19 +17,47 @@ const RESISTANCE = 0.25;
 const COMMIT_DURATION = 0.18;
 const ENTER_DURATION = 0.22;
 
+function PageSkeleton({ route }: { route: NavRoute | null }) {
+  if (!route) {
+    return <div className="w-screen shrink-0" aria-hidden="true" />;
+  }
+  return (
+    <div className="w-screen shrink-0" aria-hidden="true">
+      <div className="container mx-auto max-w-lg px-4 py-6">
+        <div className="-mx-4 px-4 py-4 mb-2">
+          <div className="flex items-center justify-between gap-3">
+            <div className="space-y-2">
+              <div className="h-7 w-44 rounded bg-muted/70" />
+              <div className="h-4 w-32 rounded bg-muted/50" />
+            </div>
+            <div className="flex h-9 w-9 items-center justify-center rounded-md bg-primary/10">
+              <route.icon className="h-5 w-5 text-primary/70" />
+            </div>
+          </div>
+        </div>
+        <div className="space-y-4 pt-2">
+          <div className="h-28 rounded-xl bg-muted/40" />
+          <div className="h-28 rounded-xl bg-muted/40" />
+          <div className="h-28 rounded-xl bg-muted/40" />
+          <div className="h-28 rounded-xl bg-muted/40" />
+        </div>
+      </div>
+    </div>
+  );
+}
+
 export function SwipeNav({ children }: { children: React.ReactNode }) {
   const pathname = usePathname();
   const router = useRouter();
   const x = useMotionValue(0);
   const [width, setWidth] = useState(0);
+  const [mounted, setMounted] = useState(false);
   const lockRef = useRef<"horizontal" | "vertical" | null>(null);
   const startedRef = useRef(false);
   const navigatingRef = useRef(false);
   const commitDirRef = useRef<"prev" | "next" | null>(null);
   const distanceThresholdPct = useSettingsStore((s) => s.swipeNavDistanceThresholdPct);
   const velocityThreshold = useSettingsStore((s) => s.swipeNavVelocityThreshold);
-  // Mirror reactive thresholds into refs so handlers always read live values
-  // without forcing handler reallocation on every settings change.
   const distanceThresholdRef = useRef(distanceThresholdPct);
   const velocityThresholdRef = useRef(velocityThreshold);
   useEffect(() => {
@@ -41,34 +69,50 @@ export function SwipeNav({ children }: { children: React.ReactNode }) {
 
   const currentIndex = NAV_ROUTES.findIndex((r) => r.path === pathname);
   const isTopRoute = currentIndex !== -1;
-  const prevRoute = isTopRoute && currentIndex > 0 ? NAV_ROUTES[currentIndex - 1] : null;
-  const nextRoute = isTopRoute && currentIndex < NAV_ROUTES.length - 1 ? NAV_ROUTES[currentIndex + 1] : null;
+  const prevRoute: NavRoute | null =
+    isTopRoute && currentIndex > 0 ? NAV_ROUTES[currentIndex - 1] ?? null : null;
+  const nextRoute: NavRoute | null =
+    isTopRoute && currentIndex < NAV_ROUTES.length - 1
+      ? NAV_ROUTES[currentIndex + 1] ?? null
+      : null;
+
+  useLayoutEffect(() => {
+    setWidth(window.innerWidth);
+    setMounted(true);
+  }, []);
 
   useEffect(() => {
     const update = () => setWidth(window.innerWidth);
-    update();
     window.addEventListener("resize", update);
     return () => window.removeEventListener("resize", update);
   }, []);
 
-  // Entry animation after route change
+  // Prefetch adjacent routes so the post-commit gap is as small as possible.
   useEffect(() => {
-    const w = window.innerWidth;
-    if (commitDirRef.current === "next") {
-      // Just navigated to the next route — slide new page in from the right
-      x.set(w);
-      animate(x, 0, { type: "tween", ease: [0.22, 1, 0.36, 1], duration: ENTER_DURATION });
-    } else if (commitDirRef.current === "prev") {
-      x.set(-w);
-      animate(x, 0, { type: "tween", ease: [0.22, 1, 0.36, 1], duration: ENTER_DURATION });
+    if (prevRoute) router.prefetch(prevRoute.path);
+    if (nextRoute) router.prefetch(nextRoute.path);
+  }, [prevRoute, nextRoute, router]);
+
+  // After a route change, snap the strip back to centered without animating —
+  // the destination skeleton was already centered when we navigated, and now
+  // the real children have taken its place.
+  useLayoutEffect(() => {
+    if (commitDirRef.current) {
+      x.set(0);
+      commitDirRef.current = null;
     } else {
+      // Non-swipe navigation (header buttons, links): no animation needed.
       x.set(0);
     }
-    commitDirRef.current = null;
     navigatingRef.current = false;
     lockRef.current = null;
     startedRef.current = false;
   }, [pathname, x]);
+
+  // Translate the strip so the *current* pane (middle of three) sits at x=0
+  // when the drag value is 0. Negative drag reveals the next pane, positive
+  // reveals the previous pane.
+  const stripX = useTransform(x, (v) => v - (width || 0));
 
   const handlePanStart = useCallback(
     (event: PointerEvent, _info: PanInfo) => {
@@ -77,7 +121,6 @@ export function SwipeNav({ children }: { children: React.ReactNode }) {
         return;
       }
       const target = event.target as HTMLElement | null;
-      // Opt-out: any ancestor with data-no-swipe (e.g. carousels, h-scroll regions)
       if (target?.closest?.("[data-no-swipe]")) {
         lockRef.current = "vertical";
         return;
@@ -108,7 +151,6 @@ export function SwipeNav({ children }: { children: React.ReactNode }) {
 
       if (lockRef.current === "horizontal") {
         let next = offset.x;
-        // Apply resistance when there is no neighbor in that direction
         if (next > 0 && !prevRoute) next = next * RESISTANCE;
         if (next < 0 && !nextRoute) next = next * RESISTANCE;
         x.set(next);
@@ -151,49 +193,40 @@ export function SwipeNav({ children }: { children: React.ReactNode }) {
           router.push(dest.path);
         });
       } else {
-        animate(x, 0, { type: "spring", stiffness: 400, damping: 40 });
+        animate(x, 0, {
+          type: "tween",
+          ease: [0.22, 1, 0.36, 1],
+          duration: ENTER_DURATION,
+        });
       }
     },
     [x, width, prevRoute, nextRoute, router],
   );
 
-  // Edge hint pills (icon + label) that fade in as the user drags
-  const prevHintOpacity = useTransform(x, [0, 60, 140], [0, 0.65, 1]);
-  const nextHintOpacity = useTransform(x, [-140, -60, 0], [1, 0.65, 0]);
-  const prevHintScale = useTransform(x, [0, 140], [0.85, 1]);
-  const nextHintScale = useTransform(x, [-140, 0], [1, 0.85]);
+  // Non-top routes (e.g. /auth/*) and the first pre-mount render skip the
+  // swipe strip and render children plainly so layout is stable and there's
+  // no risk of a one-frame flash showing the previous-skeleton pane.
+  if (!isTopRoute || !mounted) {
+    return (
+      <div className="container mx-auto max-w-lg px-4 pb-6">{children}</div>
+    );
+  }
 
   return (
-    <>
-      {isTopRoute && prevRoute && (
-        <motion.div
-          aria-hidden="true"
-          className="pointer-events-none fixed left-3 top-1/2 z-30 -translate-y-1/2 flex items-center gap-2 rounded-full border bg-background/95 px-3 py-2 shadow-lg backdrop-blur"
-          style={{ opacity: prevHintOpacity, scale: prevHintScale }}
-        >
-          <prevRoute.icon className="h-4 w-4 text-primary" />
-          <span className="text-xs font-medium">{prevRoute.title}</span>
-        </motion.div>
-      )}
-      {isTopRoute && nextRoute && (
-        <motion.div
-          aria-hidden="true"
-          className="pointer-events-none fixed right-3 top-1/2 z-30 -translate-y-1/2 flex items-center gap-2 rounded-full border bg-background/95 px-3 py-2 shadow-lg backdrop-blur"
-          style={{ opacity: nextHintOpacity, scale: nextHintScale }}
-        >
-          <span className="text-xs font-medium">{nextRoute.title}</span>
-          <nextRoute.icon className="h-4 w-4 text-primary" />
-        </motion.div>
-      )}
+    <div className="overflow-x-hidden">
       <motion.div
-        style={{ x, touchAction: "pan-y" }}
+        className="flex will-change-transform"
+        style={{ x: stripX, touchAction: "pan-y" }}
         onPanStart={handlePanStart}
         onPan={handlePan}
         onPanEnd={handlePanEnd}
-        className="will-change-transform"
       >
-        {children}
+        <PageSkeleton route={prevRoute} />
+        <div className="w-screen shrink-0">
+          <div className="container mx-auto max-w-lg px-4 pb-6">{children}</div>
+        </div>
+        <PageSkeleton route={nextRoute} />
       </motion.div>
-    </>
+    </div>
   );
 }

--- a/src/components/swipe-nav.tsx
+++ b/src/components/swipe-nav.tsx
@@ -1,0 +1,185 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import { usePathname, useRouter } from "next/navigation";
+import {
+  motion,
+  useMotionValue,
+  useTransform,
+  animate,
+  type PanInfo,
+} from "motion/react";
+import { NAV_ROUTES } from "@/lib/nav-routes";
+
+const SWIPE_THRESHOLD_RATIO = 0.28;
+const VELOCITY_THRESHOLD = 500;
+const DIRECTION_LOCK_THRESHOLD = 8;
+const RESISTANCE = 0.25;
+const COMMIT_DURATION = 0.18;
+const ENTER_DURATION = 0.22;
+
+export function SwipeNav({ children }: { children: React.ReactNode }) {
+  const pathname = usePathname();
+  const router = useRouter();
+  const x = useMotionValue(0);
+  const [width, setWidth] = useState(0);
+  const lockRef = useRef<"horizontal" | "vertical" | null>(null);
+  const startedRef = useRef(false);
+  const navigatingRef = useRef(false);
+  const commitDirRef = useRef<"prev" | "next" | null>(null);
+
+  const currentIndex = NAV_ROUTES.findIndex((r) => r.path === pathname);
+  const isTopRoute = currentIndex !== -1;
+  const prevRoute = isTopRoute && currentIndex > 0 ? NAV_ROUTES[currentIndex - 1] : null;
+  const nextRoute = isTopRoute && currentIndex < NAV_ROUTES.length - 1 ? NAV_ROUTES[currentIndex + 1] : null;
+
+  useEffect(() => {
+    const update = () => setWidth(window.innerWidth);
+    update();
+    window.addEventListener("resize", update);
+    return () => window.removeEventListener("resize", update);
+  }, []);
+
+  // Entry animation after route change
+  useEffect(() => {
+    const w = window.innerWidth;
+    if (commitDirRef.current === "next") {
+      // Just navigated to the next route — slide new page in from the right
+      x.set(w);
+      animate(x, 0, { type: "tween", ease: [0.22, 1, 0.36, 1], duration: ENTER_DURATION });
+    } else if (commitDirRef.current === "prev") {
+      x.set(-w);
+      animate(x, 0, { type: "tween", ease: [0.22, 1, 0.36, 1], duration: ENTER_DURATION });
+    } else {
+      x.set(0);
+    }
+    commitDirRef.current = null;
+    navigatingRef.current = false;
+    lockRef.current = null;
+    startedRef.current = false;
+  }, [pathname, x]);
+
+  const handlePanStart = useCallback(
+    (event: PointerEvent, _info: PanInfo) => {
+      if (!isTopRoute || navigatingRef.current) {
+        lockRef.current = "vertical";
+        return;
+      }
+      const target = event.target as HTMLElement | null;
+      // Opt-out: any ancestor with data-no-swipe (e.g. carousels, h-scroll regions)
+      if (target?.closest?.("[data-no-swipe]")) {
+        lockRef.current = "vertical";
+        return;
+      }
+      lockRef.current = null;
+      startedRef.current = true;
+    },
+    [isTopRoute],
+  );
+
+  const handlePan = useCallback(
+    (_event: PointerEvent, info: PanInfo) => {
+      if (!startedRef.current || navigatingRef.current) return;
+      if (lockRef.current === "vertical") return;
+
+      const { offset } = info;
+
+      if (lockRef.current === null) {
+        const absX = Math.abs(offset.x);
+        const absY = Math.abs(offset.y);
+        if (absX < DIRECTION_LOCK_THRESHOLD && absY < DIRECTION_LOCK_THRESHOLD) return;
+        if (absY > absX) {
+          lockRef.current = "vertical";
+          return;
+        }
+        lockRef.current = "horizontal";
+      }
+
+      if (lockRef.current === "horizontal") {
+        let next = offset.x;
+        // Apply resistance when there is no neighbor in that direction
+        if (next > 0 && !prevRoute) next = next * RESISTANCE;
+        if (next < 0 && !nextRoute) next = next * RESISTANCE;
+        x.set(next);
+      }
+    },
+    [x, prevRoute, nextRoute],
+  );
+
+  const handlePanEnd = useCallback(
+    (_event: PointerEvent, info: PanInfo) => {
+      const wasHorizontal = lockRef.current === "horizontal";
+      startedRef.current = false;
+      lockRef.current = null;
+
+      if (!wasHorizontal || navigatingRef.current) {
+        animate(x, 0, { type: "spring", stiffness: 400, damping: 40 });
+        return;
+      }
+
+      const w = window.innerWidth || width || 1;
+      const threshold = w * SWIPE_THRESHOLD_RATIO;
+      const { offset, velocity } = info;
+
+      const goingPrev =
+        offset.x > 0 && prevRoute && (offset.x > threshold || velocity.x > VELOCITY_THRESHOLD);
+      const goingNext =
+        offset.x < 0 && nextRoute && (offset.x < -threshold || velocity.x < -VELOCITY_THRESHOLD);
+
+      if (goingPrev || goingNext) {
+        navigatingRef.current = true;
+        commitDirRef.current = goingPrev ? "prev" : "next";
+        const target = goingPrev ? w : -w;
+        const dest = goingPrev ? prevRoute! : nextRoute!;
+        animate(x, target, {
+          type: "tween",
+          ease: [0.4, 0, 0.2, 1],
+          duration: COMMIT_DURATION,
+        }).then(() => {
+          router.push(dest.path);
+        });
+      } else {
+        animate(x, 0, { type: "spring", stiffness: 400, damping: 40 });
+      }
+    },
+    [x, width, prevRoute, nextRoute, router],
+  );
+
+  // Edge hint pills (icon + label) that fade in as the user drags
+  const prevHintOpacity = useTransform(x, [0, 60, 140], [0, 0.65, 1]);
+  const nextHintOpacity = useTransform(x, [-140, -60, 0], [1, 0.65, 0]);
+  const prevHintScale = useTransform(x, [0, 140], [0.85, 1]);
+  const nextHintScale = useTransform(x, [-140, 0], [1, 0.85]);
+
+  return (
+    <>
+      {isTopRoute && prevRoute && (
+        <motion.div
+          className="pointer-events-none fixed left-3 top-1/2 z-30 -translate-y-1/2 flex items-center gap-2 rounded-full border bg-background/95 px-3 py-2 shadow-lg backdrop-blur"
+          style={{ opacity: prevHintOpacity, scale: prevHintScale }}
+        >
+          <prevRoute.icon className="h-4 w-4 text-primary" />
+          <span className="text-xs font-medium">{prevRoute.title}</span>
+        </motion.div>
+      )}
+      {isTopRoute && nextRoute && (
+        <motion.div
+          className="pointer-events-none fixed right-3 top-1/2 z-30 -translate-y-1/2 flex items-center gap-2 rounded-full border bg-background/95 px-3 py-2 shadow-lg backdrop-blur"
+          style={{ opacity: nextHintOpacity, scale: nextHintScale }}
+        >
+          <span className="text-xs font-medium">{nextRoute.title}</span>
+          <nextRoute.icon className="h-4 w-4 text-primary" />
+        </motion.div>
+      )}
+      <motion.div
+        style={{ x, touchAction: "pan-y" }}
+        onPanStart={handlePanStart}
+        onPan={handlePan}
+        onPanEnd={handlePanEnd}
+        className="will-change-transform"
+      >
+        {children}
+      </motion.div>
+    </>
+  );
+}

--- a/src/lib/nav-routes.ts
+++ b/src/lib/nav-routes.ts
@@ -1,0 +1,16 @@
+import { Droplets, Pill, BarChart3, Settings, type LucideIcon } from "lucide-react";
+
+export interface NavRoute {
+  path: string;
+  icon: LucideIcon;
+  label: string;
+  title: string;
+  subtitle: string;
+}
+
+export const NAV_ROUTES = [
+  { path: "/", icon: Droplets, label: "Intake", title: "Intake Tracker", subtitle: "Daily budget tracking" },
+  { path: "/medications", icon: Pill, label: "Meds", title: "Medications", subtitle: "Medicine schedule & tracking" },
+  { path: "/analytics", icon: BarChart3, label: "Analytics", title: "Analytics", subtitle: "Insights & record browsing" },
+  { path: "/settings", icon: Settings, label: "Settings", title: "Settings", subtitle: "Configure preferences" },
+] as const satisfies readonly NavRoute[];

--- a/src/stores/medication-ui-store.ts
+++ b/src/stores/medication-ui-store.ts
@@ -1,0 +1,24 @@
+import { create } from "zustand";
+import type { MedTab } from "@/components/medications/med-footer";
+
+/**
+ * Ephemeral UI state for the medications page. Shared with the layout-level
+ * MedicationsFloatingBars so the FAB can be rendered outside the SwipeNav's
+ * transform layer (where position: fixed against the viewport works) while
+ * still reacting to the page's active tab and opening the same wizard.
+ *
+ * Not persisted — same lifetime semantics as the previous useState pair.
+ */
+interface MedicationUIState {
+  activeTab: MedTab;
+  setActiveTab: (tab: MedTab) => void;
+  wizardOpen: boolean;
+  setWizardOpen: (open: boolean) => void;
+}
+
+export const useMedicationUIStore = create<MedicationUIState>((set) => ({
+  activeTab: "schedule",
+  setActiveTab: (tab) => set({ activeTab: tab }),
+  wizardOpen: false,
+  setWizardOpen: (open) => set({ wizardOpen: open }),
+}));

--- a/src/stores/settings-store.ts
+++ b/src/stores/settings-store.ts
@@ -56,6 +56,10 @@ export interface Settings {
   autoHideDelayMs: number;         // delay after scroll before header+footer hide (0-2000)
   barTransitionDurationMs: number; // header/footer slide in/out speed (50-500)
 
+  // Swipe navigation release thresholds
+  swipeNavDistanceThresholdPct: number; // % of viewport width to commit (10-60)
+  swipeNavVelocityThreshold: number;    // px/s flick velocity to commit (100-2000)
+
   // Tracking defaults
   urinationDefaultAmount: "small" | "medium" | "large";
   defecationDefaultAmount: "small" | "medium" | "large";
@@ -109,6 +113,8 @@ interface SettingsActions {
   setScrollDurationMs: (value: number) => void;
   setAutoHideDelayMs: (value: number) => void;
   setBarTransitionDurationMs: (value: number) => void;
+  setSwipeNavDistanceThresholdPct: (value: number) => void;
+  setSwipeNavVelocityThreshold: (value: number) => void;
   setUrinationDefaultAmount: (value: "small" | "medium" | "large") => void;
   setDefecationDefaultAmount: (value: "small" | "medium" | "large") => void;
   setWeightGraphShowEating: (value: boolean) => void;
@@ -154,6 +160,8 @@ const defaultSettings: Settings = {
   scrollDurationMs: 300,
   autoHideDelayMs: 500,
   barTransitionDurationMs: 200,
+  swipeNavDistanceThresholdPct: 28,
+  swipeNavVelocityThreshold: 500,
   urinationDefaultAmount: "small" as const,
   defecationDefaultAmount: "medium" as const,
   weightGraphShowEating: true,
@@ -230,6 +238,10 @@ export const useSettingsStore = create<Settings & SettingsActions>()(
         set({ autoHideDelayMs: sanitizeNumericInput(value, 0, 2000) }),
       setBarTransitionDurationMs: (value) =>
         set({ barTransitionDurationMs: sanitizeNumericInput(value, 50, 500) }),
+      setSwipeNavDistanceThresholdPct: (value) =>
+        set({ swipeNavDistanceThresholdPct: sanitizeNumericInput(value, 10, 60) }),
+      setSwipeNavVelocityThreshold: (value) =>
+        set({ swipeNavVelocityThreshold: sanitizeNumericInput(value, 100, 2000) }),
 
       setUrinationDefaultAmount: (value) => set({ urinationDefaultAmount: value }),
       setDefecationDefaultAmount: (value) => set({ defecationDefaultAmount: value }),
@@ -296,7 +308,7 @@ export const useSettingsStore = create<Settings & SettingsActions>()(
     {
       name: "intake-tracker-settings",
       storage: createJSONStorage(() => localStorage),
-      version: 8,
+      version: 9,
       migrate: (persisted, version) => {
         const state = persisted as Record<string, unknown>;
         if (version === 0) {
@@ -343,6 +355,10 @@ export const useSettingsStore = create<Settings & SettingsActions>()(
         }
         if (version < 8) {
           state.storageMode = "local";
+        }
+        if (version < 9) {
+          state.swipeNavDistanceThresholdPct = 28;
+          state.swipeNavVelocityThreshold = 500;
         }
         return state as unknown as Settings & SettingsActions;
       },


### PR DESCRIPTION
## Summary
Implements gesture-based navigation allowing users to swipe left/right between the four main app routes (Intake → Medications → Analytics → Settings). Includes configurable distance and velocity thresholds in settings, visual hint pills that fade in during drag, and smooth entry/exit animations.

## Key Changes

- **New `SwipeNav` component** (`src/components/swipe-nav.tsx`)
  - Wraps main content to intercept pan gestures
  - Detects horizontal vs. vertical swipes with direction-lock threshold
  - Applies resistance when swiping toward non-existent routes
  - Commits navigation on distance threshold OR velocity threshold
  - Renders animated hint pills (icon + label) for adjacent routes
  - Respects `data-no-swipe` attribute for opting out (carousels, horizontal scrollers)

- **Settings UI for swipe tuning** (`src/components/settings/swipe-nav-section.tsx`)
  - Distance Threshold: 10–60% of screen width (default 28%)
  - Flick Velocity: 100–2000 px/s (default 500 px/s)
  - Includes increment/decrement buttons and validation

- **Settings store updates** (`src/stores/settings-store.ts`)
  - Added `swipeNavDistanceThresholdPct` and `swipeNavVelocityThreshold` to persisted settings
  - Incremented schema version to 9 with migration logic

- **Navigation routes centralized** (`src/lib/nav-routes.ts`)
  - Extracted route definitions into reusable `NAV_ROUTES` constant
  - Updated `AppHeader` to use centralized routes

- **Layout integration** (`src/app/layout.tsx`)
  - Wrapped main content with `SwipeNav` component
  - Added `overflow-x-hidden` to prevent horizontal scroll during animations

## Implementation Details

- Uses Framer Motion (`motion/react`) for pan detection and smooth animations
- Refs (`distanceThresholdRef`, `velocityThresholdRef`) mirror reactive settings to avoid handler reallocation on every settings change
- Entry animations slide new pages in from left/right based on navigation direction
- Hint pills use `useTransform` to fade and scale based on drag distance
- `touchAction: "pan-y"` allows vertical scrolling while capturing horizontal swipes

https://claude.ai/code/session_01WVzzUoLmNy9uyX4xw89rSa

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Horizontal swipe navigation with peek previews between Intake, Medications, Analytics, and Settings.
  * Route-specific skeleton previews shown during swipe peeks.
  * Home floating chrome (voice launch, quick-nav) and Medications floating "Add medication" action with dialog.
  * App header now appears only on top-level routes and syncs its visibility with scroll/settings.

* **Customization**
  * New settings to fine-tune swipe distance and swipe velocity thresholds for gesture sensitivity.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/RyRy79261/intake-tracker/pull/81?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->