### PR TITLE
Add user-supplied AI API key management and usage tracking

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -8,9 +8,10 @@
 #   NEXT_PUBLIC_APP_VERSION        - App version display
 #
 # Server-only secrets (NEVER prefix with NEXT_PUBLIC_):
-#   ANTHROPIC_API_KEY              - Anthropic Claude API key
-#   GROQ_API_KEY                   - Groq API key (experimental voice metrics)
-#   ALLOWED_EMAILS                 - Auth whitelist
+#   ANTHROPIC_API_KEY              - Server-side fallback Anthropic key (used only for ALLOWED_EMAILS users)
+#   GROQ_API_KEY                   - Server-side fallback Groq key (used only for ALLOWED_EMAILS users)
+#   ALLOWED_EMAILS                 - Auth whitelist + env-var key access list
+#   API_KEY_ENCRYPTION_SECRET      - 32 bytes (base64) — encrypts user-provided keys at rest
 #   DATABASE_URL                   - NeonDB connection string (Neon Auth + push tables)
 #   BETTER_AUTH_SECRET             - Neon Auth session secret (openssl rand -base64 32)
 #   BETTER_AUTH_URL                - Public URL of the deployed app
@@ -21,14 +22,22 @@
 BETTER_AUTH_SECRET=generate-with-openssl-rand-base64-32
 BETTER_AUTH_URL=http://localhost:3000
 
-# Anthropic (Claude AI)
+# Anthropic (Claude AI) — server-side fallback only; non-whitelisted users
+# must provide their own key in Settings → AI features.
 ANTHROPIC_API_KEY=sk-ant-xxx
 
-# Groq (experimental: voice health metrics — Whisper transcription)
+# Groq (voice transcription) — same: server fallback for ALLOWED_EMAILS only.
 GROQ_API_KEY=gsk_xxx
 
-# Whitelist (your email)
+# Whitelist: who can sign in, AND who is allowed to use the server-side
+# fallback API keys above. Anyone else who signs in must supply their own
+# key (or use a key shared with them by another user).
 ALLOWED_EMAILS=you@gmail.com
+
+# 32 random bytes (base64) — encrypts user-supplied API keys at rest in
+# Neon. Generate with: openssl rand -base64 32
+# Rotating this value invalidates every stored key (users re-enter).
+API_KEY_ENCRYPTION_SECRET=generate-with-openssl-rand-base64-32
 
 # Recommended for most uses
 DATABASE_URL=postgresql://neondb_owner:.../neondb?sslmode=require

--- a/drizzle.config.ts
+++ b/drizzle.config.ts
@@ -6,7 +6,7 @@ loadEnvConfig(process.cwd());
 /**
  * Drizzle Kit configuration — Phase 42.
  *
- * Schema source of truth: src/db/schema.ts (20 tables: 16 Dexie-mirrored + 4 push).
+ * Schema source of truth: src/db/schema.ts (23 tables: 16 Dexie-mirrored + 4 push + 3 AI keys/usage).
  * Migrations live in /drizzle/ and are committed to the repo.
  *
  * Usage:

--- a/drizzle/0004_regular_thundra.sql
+++ b/drizzle/0004_regular_thundra.sql
@@ -1,0 +1,49 @@
+CREATE TABLE "ai_usage" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"timestamp" timestamp with time zone DEFAULT now() NOT NULL,
+	"user_id" text NOT NULL,
+	"key_owner_id" text,
+	"key_source" text NOT NULL,
+	"provider" text NOT NULL,
+	"model" text NOT NULL,
+	"route" text NOT NULL,
+	"input_tokens" integer DEFAULT 0 NOT NULL,
+	"output_tokens" integer DEFAULT 0 NOT NULL,
+	"cache_read_tokens" integer DEFAULT 0 NOT NULL,
+	"cache_create_tokens" integer DEFAULT 0 NOT NULL,
+	"audio_seconds" integer,
+	"status" text NOT NULL,
+	"duration_ms" integer,
+	CONSTRAINT "ai_usage_key_source_check" CHECK ("ai_usage"."key_source" IN ('own_stored','shared_from','env_var')),
+	CONSTRAINT "ai_usage_provider_check" CHECK ("ai_usage"."provider" IN ('anthropic','groq')),
+	CONSTRAINT "ai_usage_status_check" CHECK ("ai_usage"."status" IN ('success','error'))
+);
+--> statement-breakpoint
+CREATE TABLE "user_api_keys" (
+	"user_id" text PRIMARY KEY NOT NULL,
+	"anthropic_key_encrypted" text,
+	"anthropic_last4" text,
+	"groq_key_encrypted" text,
+	"groq_last4" text,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "user_key_shares" (
+	"grantor_id" text NOT NULL,
+	"grantee_id" text NOT NULL,
+	"provider" text NOT NULL,
+	"grantee_email" text NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "user_key_shares_grantor_id_grantee_id_provider_pk" PRIMARY KEY("grantor_id","grantee_id","provider"),
+	CONSTRAINT "user_key_shares_provider_check" CHECK ("user_key_shares"."provider" IN ('anthropic','groq'))
+);
+--> statement-breakpoint
+ALTER TABLE "ai_usage" ADD CONSTRAINT "ai_usage_user_id_users_sync_id_fk" FOREIGN KEY ("user_id") REFERENCES "neon_auth"."users_sync"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "ai_usage" ADD CONSTRAINT "ai_usage_key_owner_id_users_sync_id_fk" FOREIGN KEY ("key_owner_id") REFERENCES "neon_auth"."users_sync"("id") ON DELETE set null ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "user_api_keys" ADD CONSTRAINT "user_api_keys_user_id_users_sync_id_fk" FOREIGN KEY ("user_id") REFERENCES "neon_auth"."users_sync"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "user_key_shares" ADD CONSTRAINT "user_key_shares_grantor_id_users_sync_id_fk" FOREIGN KEY ("grantor_id") REFERENCES "neon_auth"."users_sync"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "user_key_shares" ADD CONSTRAINT "user_key_shares_grantee_id_users_sync_id_fk" FOREIGN KEY ("grantee_id") REFERENCES "neon_auth"."users_sync"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "idx_ai_usage_user_ts" ON "ai_usage" USING btree ("user_id","timestamp");--> statement-breakpoint
+CREATE INDEX "idx_ai_usage_owner_ts" ON "ai_usage" USING btree ("key_owner_id","timestamp");--> statement-breakpoint
+CREATE INDEX "idx_user_key_shares_grantee" ON "user_key_shares" USING btree ("grantee_id","provider");

--- a/drizzle/meta/0004_snapshot.json
+++ b/drizzle/meta/0004_snapshot.json
@@ -1,0 +1,3445 @@
+{
+  "id": "3b777f61-7508-4831-9821-328a4c77090e",
+  "prevId": "14140e99-d05f-4e58-a8b7-cc505f5a40d9",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.ai_usage": {
+      "name": "ai_usage",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_owner_id": {
+          "name": "key_owner_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "key_source": {
+          "name": "key_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "route": {
+          "name": "route",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "cache_read_tokens": {
+          "name": "cache_read_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "cache_create_tokens": {
+          "name": "cache_create_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "audio_seconds": {
+          "name": "audio_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_ai_usage_user_ts": {
+          "name": "idx_ai_usage_user_ts",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_ai_usage_owner_ts": {
+          "name": "idx_ai_usage_owner_ts",
+          "columns": [
+            {
+              "expression": "key_owner_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ai_usage_user_id_users_sync_id_fk": {
+          "name": "ai_usage_user_id_users_sync_id_fk",
+          "tableFrom": "ai_usage",
+          "tableTo": "users_sync",
+          "schemaTo": "neon_auth",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "ai_usage_key_owner_id_users_sync_id_fk": {
+          "name": "ai_usage_key_owner_id_users_sync_id_fk",
+          "tableFrom": "ai_usage",
+          "tableTo": "users_sync",
+          "schemaTo": "neon_auth",
+          "columnsFrom": [
+            "key_owner_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "ai_usage_key_source_check": {
+          "name": "ai_usage_key_source_check",
+          "value": "\"ai_usage\".\"key_source\" IN ('own_stored','shared_from','env_var')"
+        },
+        "ai_usage_provider_check": {
+          "name": "ai_usage_provider_check",
+          "value": "\"ai_usage\".\"provider\" IN ('anthropic','groq')"
+        },
+        "ai_usage_status_check": {
+          "name": "ai_usage_status_check",
+          "value": "\"ai_usage\".\"status\" IN ('success','error')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.audit_logs": {
+      "name": "audit_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "details": {
+          "name": "details",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "device_id": {
+          "name": "device_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_audit_user_updated": {
+          "name": "idx_audit_user_updated",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_audit_action_ts": {
+          "name": "idx_audit_action_ts",
+          "columns": [
+            {
+              "expression": "action",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "audit_logs_user_id_users_sync_id_fk": {
+          "name": "audit_logs_user_id_users_sync_id_fk",
+          "tableFrom": "audit_logs",
+          "tableTo": "users_sync",
+          "schemaTo": "neon_auth",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "audit_logs_action_check": {
+          "name": "audit_logs_action_check",
+          "value": "\"audit_logs\".\"action\" IN (\n        'ai_parse_request','ai_parse_success','ai_parse_error','data_export',\n        'data_import','data_clear','settings_change','api_key_set','api_key_clear',\n        'pin_set','pin_verify_success','pin_verify_failure','dose_taken',\n        'dose_skipped','dose_rescheduled','prescription_added','prescription_updated',\n        'inventory_adjusted','phase_activated','validation_error','dose_untaken',\n        'prescription_deleted','phase_completed','phase_started','stock_recalculated',\n        'inventory_added','inventory_deleted','titration_plan_updated','timezone_adjusted'\n      )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.blood_pressure_records": {
+      "name": "blood_pressure_records",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "systolic": {
+          "name": "systolic",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "diastolic": {
+          "name": "diastolic",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "heart_rate": {
+          "name": "heart_rate",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "irregular_heartbeat": {
+          "name": "irregular_heartbeat",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position": {
+          "name": "position",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "arm": {
+          "name": "arm",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "device_id": {
+          "name": "device_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_bp_user_updated": {
+          "name": "idx_bp_user_updated",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_bp_ts": {
+          "name": "idx_bp_ts",
+          "columns": [
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "blood_pressure_records_user_id_users_sync_id_fk": {
+          "name": "blood_pressure_records_user_id_users_sync_id_fk",
+          "tableFrom": "blood_pressure_records",
+          "tableTo": "users_sync",
+          "schemaTo": "neon_auth",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "blood_pressure_records_position_check": {
+          "name": "blood_pressure_records_position_check",
+          "value": "\"blood_pressure_records\".\"position\" IN ('standing','sitting')"
+        },
+        "blood_pressure_records_arm_check": {
+          "name": "blood_pressure_records_arm_check",
+          "value": "\"blood_pressure_records\".\"arm\" IN ('left','right')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.daily_notes": {
+      "name": "daily_notes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prescription_id": {
+          "name": "prescription_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dose_log_id": {
+          "name": "dose_log_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "device_id": {
+          "name": "device_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_daily_notes_user_updated": {
+          "name": "idx_daily_notes_user_updated",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_daily_notes_date": {
+          "name": "idx_daily_notes_date",
+          "columns": [
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_daily_notes_prescription": {
+          "name": "idx_daily_notes_prescription",
+          "columns": [
+            {
+              "expression": "prescription_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "daily_notes_user_id_users_sync_id_fk": {
+          "name": "daily_notes_user_id_users_sync_id_fk",
+          "tableFrom": "daily_notes",
+          "tableTo": "users_sync",
+          "schemaTo": "neon_auth",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "daily_notes_prescription_id_prescriptions_id_fk": {
+          "name": "daily_notes_prescription_id_prescriptions_id_fk",
+          "tableFrom": "daily_notes",
+          "tableTo": "prescriptions",
+          "columnsFrom": [
+            "prescription_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "daily_notes_dose_log_id_dose_logs_id_fk": {
+          "name": "daily_notes_dose_log_id_dose_logs_id_fk",
+          "tableFrom": "daily_notes",
+          "tableTo": "dose_logs",
+          "columnsFrom": [
+            "dose_log_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.defecation_records": {
+      "name": "defecation_records",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount_estimate": {
+          "name": "amount_estimate",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "device_id": {
+          "name": "device_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_defecation_user_updated": {
+          "name": "idx_defecation_user_updated",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "defecation_records_user_id_users_sync_id_fk": {
+          "name": "defecation_records_user_id_users_sync_id_fk",
+          "tableFrom": "defecation_records",
+          "tableTo": "users_sync",
+          "schemaTo": "neon_auth",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.dose_logs": {
+      "name": "dose_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prescription_id": {
+          "name": "prescription_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "phase_id": {
+          "name": "phase_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "schedule_id": {
+          "name": "schedule_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "inventory_item_id": {
+          "name": "inventory_item_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scheduled_date": {
+          "name": "scheduled_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scheduled_time": {
+          "name": "scheduled_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action_timestamp": {
+          "name": "action_timestamp",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rescheduled_to": {
+          "name": "rescheduled_to",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "skip_reason": {
+          "name": "skip_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "device_id": {
+          "name": "device_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_dose_logs_user_updated": {
+          "name": "idx_dose_logs_user_updated",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_dose_logs_prescription_date": {
+          "name": "idx_dose_logs_prescription_date",
+          "columns": [
+            {
+              "expression": "prescription_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "scheduled_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_dose_logs_status": {
+          "name": "idx_dose_logs_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "dose_logs_user_id_users_sync_id_fk": {
+          "name": "dose_logs_user_id_users_sync_id_fk",
+          "tableFrom": "dose_logs",
+          "tableTo": "users_sync",
+          "schemaTo": "neon_auth",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "dose_logs_prescription_id_prescriptions_id_fk": {
+          "name": "dose_logs_prescription_id_prescriptions_id_fk",
+          "tableFrom": "dose_logs",
+          "tableTo": "prescriptions",
+          "columnsFrom": [
+            "prescription_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "dose_logs_phase_id_medication_phases_id_fk": {
+          "name": "dose_logs_phase_id_medication_phases_id_fk",
+          "tableFrom": "dose_logs",
+          "tableTo": "medication_phases",
+          "columnsFrom": [
+            "phase_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "dose_logs_schedule_id_phase_schedules_id_fk": {
+          "name": "dose_logs_schedule_id_phase_schedules_id_fk",
+          "tableFrom": "dose_logs",
+          "tableTo": "phase_schedules",
+          "columnsFrom": [
+            "schedule_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "dose_logs_inventory_item_id_inventory_items_id_fk": {
+          "name": "dose_logs_inventory_item_id_inventory_items_id_fk",
+          "tableFrom": "dose_logs",
+          "tableTo": "inventory_items",
+          "columnsFrom": [
+            "inventory_item_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "dose_logs_status_check": {
+          "name": "dose_logs_status_check",
+          "value": "\"dose_logs\".\"status\" IN ('taken','skipped','rescheduled','pending')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.eating_records": {
+      "name": "eating_records",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "grams": {
+          "name": "grams",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "original_input_text": {
+          "name": "original_input_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "group_source": {
+          "name": "group_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "device_id": {
+          "name": "device_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_eating_user_updated": {
+          "name": "idx_eating_user_updated",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_eating_group": {
+          "name": "idx_eating_group",
+          "columns": [
+            {
+              "expression": "group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "eating_records_user_id_users_sync_id_fk": {
+          "name": "eating_records_user_id_users_sync_id_fk",
+          "tableFrom": "eating_records",
+          "tableTo": "users_sync",
+          "schemaTo": "neon_auth",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.intake_records": {
+      "name": "intake_records",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "original_input_text": {
+          "name": "original_input_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "group_source": {
+          "name": "group_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "device_id": {
+          "name": "device_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_intake_user_updated": {
+          "name": "idx_intake_user_updated",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_intake_type_ts": {
+          "name": "idx_intake_type_ts",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_intake_group": {
+          "name": "idx_intake_group",
+          "columns": [
+            {
+              "expression": "group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "intake_records_user_id_users_sync_id_fk": {
+          "name": "intake_records_user_id_users_sync_id_fk",
+          "tableFrom": "intake_records",
+          "tableTo": "users_sync",
+          "schemaTo": "neon_auth",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "intake_records_type_check": {
+          "name": "intake_records_type_check",
+          "value": "\"intake_records\".\"type\" IN ('water','salt')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.inventory_items": {
+      "name": "inventory_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prescription_id": {
+          "name": "prescription_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "brand_name": {
+          "name": "brand_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "current_stock": {
+          "name": "current_stock",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "strength": {
+          "name": "strength",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "unit": {
+          "name": "unit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pill_shape": {
+          "name": "pill_shape",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pill_color": {
+          "name": "pill_color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "visual_identification": {
+          "name": "visual_identification",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refill_alert_days": {
+          "name": "refill_alert_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refill_alert_pills": {
+          "name": "refill_alert_pills",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_archived": {
+          "name": "is_archived",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "device_id": {
+          "name": "device_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_inventory_user_updated": {
+          "name": "idx_inventory_user_updated",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_inventory_prescription": {
+          "name": "idx_inventory_prescription",
+          "columns": [
+            {
+              "expression": "prescription_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_inventory_active": {
+          "name": "idx_inventory_active",
+          "columns": [
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "inventory_items_user_id_users_sync_id_fk": {
+          "name": "inventory_items_user_id_users_sync_id_fk",
+          "tableFrom": "inventory_items",
+          "tableTo": "users_sync",
+          "schemaTo": "neon_auth",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "inventory_items_prescription_id_prescriptions_id_fk": {
+          "name": "inventory_items_prescription_id_prescriptions_id_fk",
+          "tableFrom": "inventory_items",
+          "tableTo": "prescriptions",
+          "columnsFrom": [
+            "prescription_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "inventory_items_pill_shape_check": {
+          "name": "inventory_items_pill_shape_check",
+          "value": "\"inventory_items\".\"pill_shape\" IN ('round','oval','capsule','diamond','tablet')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.inventory_transactions": {
+      "name": "inventory_transactions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "inventory_item_id": {
+          "name": "inventory_item_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dose_log_id": {
+          "name": "dose_log_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "device_id": {
+          "name": "device_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_inventory_tx_user_updated": {
+          "name": "idx_inventory_tx_user_updated",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_inventory_tx_item_ts": {
+          "name": "idx_inventory_tx_item_ts",
+          "columns": [
+            {
+              "expression": "inventory_item_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_inventory_tx_type": {
+          "name": "idx_inventory_tx_type",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "inventory_transactions_user_id_users_sync_id_fk": {
+          "name": "inventory_transactions_user_id_users_sync_id_fk",
+          "tableFrom": "inventory_transactions",
+          "tableTo": "users_sync",
+          "schemaTo": "neon_auth",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "inventory_transactions_inventory_item_id_inventory_items_id_fk": {
+          "name": "inventory_transactions_inventory_item_id_inventory_items_id_fk",
+          "tableFrom": "inventory_transactions",
+          "tableTo": "inventory_items",
+          "columnsFrom": [
+            "inventory_item_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "inventory_transactions_dose_log_id_dose_logs_id_fk": {
+          "name": "inventory_transactions_dose_log_id_dose_logs_id_fk",
+          "tableFrom": "inventory_transactions",
+          "tableTo": "dose_logs",
+          "columnsFrom": [
+            "dose_log_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "inventory_transactions_type_check": {
+          "name": "inventory_transactions_type_check",
+          "value": "\"inventory_transactions\".\"type\" IN ('refill','consumed','adjusted','initial')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.medication_phases": {
+      "name": "medication_phases",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prescription_id": {
+          "name": "prescription_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "unit": {
+          "name": "unit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "food_instruction": {
+          "name": "food_instruction",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "food_note": {
+          "name": "food_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "titration_plan_id": {
+          "name": "titration_plan_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "device_id": {
+          "name": "device_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_phases_user_updated": {
+          "name": "idx_phases_user_updated",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_phases_prescription": {
+          "name": "idx_phases_prescription",
+          "columns": [
+            {
+              "expression": "prescription_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_phases_status_type": {
+          "name": "idx_phases_status_type",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "medication_phases_user_id_users_sync_id_fk": {
+          "name": "medication_phases_user_id_users_sync_id_fk",
+          "tableFrom": "medication_phases",
+          "tableTo": "users_sync",
+          "schemaTo": "neon_auth",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "medication_phases_prescription_id_prescriptions_id_fk": {
+          "name": "medication_phases_prescription_id_prescriptions_id_fk",
+          "tableFrom": "medication_phases",
+          "tableTo": "prescriptions",
+          "columnsFrom": [
+            "prescription_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "medication_phases_titration_plan_id_titration_plans_id_fk": {
+          "name": "medication_phases_titration_plan_id_titration_plans_id_fk",
+          "tableFrom": "medication_phases",
+          "tableTo": "titration_plans",
+          "columnsFrom": [
+            "titration_plan_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "medication_phases_type_check": {
+          "name": "medication_phases_type_check",
+          "value": "\"medication_phases\".\"type\" IN ('maintenance','titration')"
+        },
+        "medication_phases_food_instruction_check": {
+          "name": "medication_phases_food_instruction_check",
+          "value": "\"medication_phases\".\"food_instruction\" IN ('before','after','none')"
+        },
+        "medication_phases_status_check": {
+          "name": "medication_phases_status_check",
+          "value": "\"medication_phases\".\"status\" IN ('active','completed','cancelled','pending')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.phase_schedules": {
+      "name": "phase_schedules",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "phase_id": {
+          "name": "phase_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "time": {
+          "name": "time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "schedule_time_utc": {
+          "name": "schedule_time_utc",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "anchor_timezone": {
+          "name": "anchor_timezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dosage": {
+          "name": "dosage",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "days_of_week": {
+          "name": "days_of_week",
+          "type": "integer[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "unit": {
+          "name": "unit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "device_id": {
+          "name": "device_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_phase_schedules_user_updated": {
+          "name": "idx_phase_schedules_user_updated",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_phase_schedules_phase": {
+          "name": "idx_phase_schedules_phase",
+          "columns": [
+            {
+              "expression": "phase_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_phase_schedules_enabled": {
+          "name": "idx_phase_schedules_enabled",
+          "columns": [
+            {
+              "expression": "enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "phase_schedules_user_id_users_sync_id_fk": {
+          "name": "phase_schedules_user_id_users_sync_id_fk",
+          "tableFrom": "phase_schedules",
+          "tableTo": "users_sync",
+          "schemaTo": "neon_auth",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "phase_schedules_phase_id_medication_phases_id_fk": {
+          "name": "phase_schedules_phase_id_medication_phases_id_fk",
+          "tableFrom": "phase_schedules",
+          "tableTo": "medication_phases",
+          "columnsFrom": [
+            "phase_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.prescriptions": {
+      "name": "prescriptions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "generic_name": {
+          "name": "generic_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "indication": {
+          "name": "indication",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contraindications": {
+          "name": "contraindications",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "warnings": {
+          "name": "warnings",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "device_id": {
+          "name": "device_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_prescriptions_user_updated": {
+          "name": "idx_prescriptions_user_updated",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_prescriptions_active": {
+          "name": "idx_prescriptions_active",
+          "columns": [
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "prescriptions_user_id_users_sync_id_fk": {
+          "name": "prescriptions_user_id_users_sync_id_fk",
+          "tableFrom": "prescriptions",
+          "tableTo": "users_sync",
+          "schemaTo": "neon_auth",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.push_schedules": {
+      "name": "push_schedules",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "time_slot": {
+          "name": "time_slot",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "day_of_week": {
+          "name": "day_of_week",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "medications_json": {
+          "name": "medications_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "push_schedules_user_slot_dow_uq": {
+          "name": "push_schedules_user_slot_dow_uq",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "time_slot",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "day_of_week",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "push_schedules_user_id_users_sync_id_fk": {
+          "name": "push_schedules_user_id_users_sync_id_fk",
+          "tableFrom": "push_schedules",
+          "tableTo": "users_sync",
+          "schemaTo": "neon_auth",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.push_sent_log": {
+      "name": "push_sent_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "time_slot": {
+          "name": "time_slot",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sent_date": {
+          "name": "sent_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "follow_up_index": {
+          "name": "follow_up_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "sent_at": {
+          "name": "sent_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "push_sent_log_uq": {
+          "name": "push_sent_log_uq",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "time_slot",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sent_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "follow_up_index",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "push_sent_log_user_id_users_sync_id_fk": {
+          "name": "push_sent_log_user_id_users_sync_id_fk",
+          "tableFrom": "push_sent_log",
+          "tableTo": "users_sync",
+          "schemaTo": "neon_auth",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.push_settings": {
+      "name": "push_settings",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "follow_up_count": {
+          "name": "follow_up_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 2
+        },
+        "follow_up_interval_minutes": {
+          "name": "follow_up_interval_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 10
+        },
+        "day_start_hour": {
+          "name": "day_start_hour",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 2
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "push_settings_user_id_users_sync_id_fk": {
+          "name": "push_settings_user_id_users_sync_id_fk",
+          "tableFrom": "push_settings",
+          "tableTo": "users_sync",
+          "schemaTo": "neon_auth",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.push_subscriptions": {
+      "name": "push_subscriptions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "endpoint": {
+          "name": "endpoint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "p256dh": {
+          "name": "p256dh",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auth_key": {
+          "name": "auth_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'UTC'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "push_subscriptions_user_id_users_sync_id_fk": {
+          "name": "push_subscriptions_user_id_users_sync_id_fk",
+          "tableFrom": "push_subscriptions",
+          "tableTo": "users_sync",
+          "schemaTo": "neon_auth",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "push_subscriptions_user_id_unique": {
+          "name": "push_subscriptions_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.substance_records": {
+      "name": "substance_records",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount_mg": {
+          "name": "amount_mg",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "amount_standard_drinks": {
+          "name": "amount_standard_drinks",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "volume_ml": {
+          "name": "volume_ml",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_record_id": {
+          "name": "source_record_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ai_enriched": {
+          "name": "ai_enriched",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "original_input_text": {
+          "name": "original_input_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "group_source": {
+          "name": "group_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "device_id": {
+          "name": "device_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_substance_user_updated": {
+          "name": "idx_substance_user_updated",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_substance_type_ts": {
+          "name": "idx_substance_type_ts",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_substance_group": {
+          "name": "idx_substance_group",
+          "columns": [
+            {
+              "expression": "group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "substance_records_user_id_users_sync_id_fk": {
+          "name": "substance_records_user_id_users_sync_id_fk",
+          "tableFrom": "substance_records",
+          "tableTo": "users_sync",
+          "schemaTo": "neon_auth",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "substance_records_source_record_id_intake_records_id_fk": {
+          "name": "substance_records_source_record_id_intake_records_id_fk",
+          "tableFrom": "substance_records",
+          "tableTo": "intake_records",
+          "columnsFrom": [
+            "source_record_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "substance_records_type_check": {
+          "name": "substance_records_type_check",
+          "value": "\"substance_records\".\"type\" IN ('caffeine','alcohol')"
+        },
+        "substance_records_source_check": {
+          "name": "substance_records_source_check",
+          "value": "\"substance_records\".\"source\" IN ('water_intake','eating','standalone')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.titration_plans": {
+      "name": "titration_plans",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "condition_label": {
+          "name": "condition_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recommended_start_date": {
+          "name": "recommended_start_date",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "warnings": {
+          "name": "warnings",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "device_id": {
+          "name": "device_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_titration_user_updated": {
+          "name": "idx_titration_user_updated",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_titration_condition": {
+          "name": "idx_titration_condition",
+          "columns": [
+            {
+              "expression": "condition_label",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_titration_status": {
+          "name": "idx_titration_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "titration_plans_user_id_users_sync_id_fk": {
+          "name": "titration_plans_user_id_users_sync_id_fk",
+          "tableFrom": "titration_plans",
+          "tableTo": "users_sync",
+          "schemaTo": "neon_auth",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "titration_plans_status_check": {
+          "name": "titration_plans_status_check",
+          "value": "\"titration_plans\".\"status\" IN ('draft','active','completed','cancelled')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.urination_records": {
+      "name": "urination_records",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount_estimate": {
+          "name": "amount_estimate",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "device_id": {
+          "name": "device_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_urination_user_updated": {
+          "name": "idx_urination_user_updated",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "urination_records_user_id_users_sync_id_fk": {
+          "name": "urination_records_user_id_users_sync_id_fk",
+          "tableFrom": "urination_records",
+          "tableTo": "users_sync",
+          "schemaTo": "neon_auth",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_api_keys": {
+      "name": "user_api_keys",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "anthropic_key_encrypted": {
+          "name": "anthropic_key_encrypted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "anthropic_last4": {
+          "name": "anthropic_last4",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "groq_key_encrypted": {
+          "name": "groq_key_encrypted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "groq_last4": {
+          "name": "groq_last4",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_api_keys_user_id_users_sync_id_fk": {
+          "name": "user_api_keys_user_id_users_sync_id_fk",
+          "tableFrom": "user_api_keys",
+          "tableTo": "users_sync",
+          "schemaTo": "neon_auth",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_key_shares": {
+      "name": "user_key_shares",
+      "schema": "",
+      "columns": {
+        "grantor_id": {
+          "name": "grantor_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "grantee_id": {
+          "name": "grantee_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "grantee_email": {
+          "name": "grantee_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_user_key_shares_grantee": {
+          "name": "idx_user_key_shares_grantee",
+          "columns": [
+            {
+              "expression": "grantee_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_key_shares_grantor_id_users_sync_id_fk": {
+          "name": "user_key_shares_grantor_id_users_sync_id_fk",
+          "tableFrom": "user_key_shares",
+          "tableTo": "users_sync",
+          "schemaTo": "neon_auth",
+          "columnsFrom": [
+            "grantor_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_key_shares_grantee_id_users_sync_id_fk": {
+          "name": "user_key_shares_grantee_id_users_sync_id_fk",
+          "tableFrom": "user_key_shares",
+          "tableTo": "users_sync",
+          "schemaTo": "neon_auth",
+          "columnsFrom": [
+            "grantee_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "user_key_shares_grantor_id_grantee_id_provider_pk": {
+          "name": "user_key_shares_grantor_id_grantee_id_provider_pk",
+          "columns": [
+            "grantor_id",
+            "grantee_id",
+            "provider"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "user_key_shares_provider_check": {
+          "name": "user_key_shares_provider_check",
+          "value": "\"user_key_shares\".\"provider\" IN ('anthropic','groq')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "neon_auth.users_sync": {
+      "name": "users_sync",
+      "schema": "neon_auth",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.weight_records": {
+      "name": "weight_records",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "weight": {
+          "name": "weight",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "device_id": {
+          "name": "device_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_weight_user_updated": {
+          "name": "idx_weight_user_updated",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "weight_records_user_id_users_sync_id_fk": {
+          "name": "weight_records_user_id_users_sync_id_fk",
+          "tableFrom": "weight_records",
+          "tableTo": "users_sync",
+          "schemaTo": "neon_auth",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -29,6 +29,13 @@
       "when": 1778848856611,
       "tag": "0003_polite_callisto",
       "breakpoints": true
+    },
+    {
+      "idx": 4,
+      "version": "7",
+      "when": 1779200319516,
+      "tag": "0004_regular_thundra",
+      "breakpoints": true
     }
   ]
 }

--- a/scripts/verify-schema.ts
+++ b/scripts/verify-schema.ts
@@ -17,9 +17,11 @@
  */
 import { neon } from "@neondatabase/serverless";
 
-// Pinned expected count: 20 app+push tables. drizzle-kit 0.31.x stores its
-// __drizzle_migrations journal in the "drizzle" schema, not "public".
-const EXPECTED_TABLE_COUNT = 20;
+// Pinned expected count: 20 app+push tables + 3 AI-keys/usage tables added
+// in migration 0004 (user_api_keys, user_key_shares, ai_usage) = 23.
+// drizzle-kit 0.31.x stores its __drizzle_migrations journal in the
+// "drizzle" schema, not "public".
+const EXPECTED_TABLE_COUNT = 23;
 
 // Representative tables spot-checked by name. Three is enough to catch
 // a schema that happened to have the right COUNT but the wrong shape

--- a/src/app/api/ai/_shared/ai-error-response.ts
+++ b/src/app/api/ai/_shared/ai-error-response.ts
@@ -1,0 +1,38 @@
+import { NextResponse } from "next/server";
+import Anthropic from "@anthropic-ai/sdk";
+import { NoAiKeyError } from "@/lib/ai-key-resolver";
+
+/**
+ * Translate provider / key-resolution errors into responses the client UI
+ * can act on. Anything not recognised returns `null` so the caller can
+ * surface its own generic 502.
+ *
+ * Codes the client checks:
+ *   NO_AI_KEY   — user has not configured a key for this provider.
+ *   INVALID_KEY — the resolved key was rejected upstream (401/403).
+ */
+export function aiErrorResponse(error: unknown): NextResponse | null {
+  if (error instanceof NoAiKeyError) {
+    return NextResponse.json(
+      {
+        error: `No ${error.provider} API key configured. Add one in Settings → AI features.`,
+        code: "NO_AI_KEY",
+        provider: error.provider,
+      },
+      { status: 402 },
+    );
+  }
+
+  if (error instanceof Anthropic.AuthenticationError) {
+    return NextResponse.json(
+      {
+        error: "Anthropic rejected the API key. Update it in Settings → AI features.",
+        code: "INVALID_KEY",
+        provider: "anthropic",
+      },
+      { status: 400 },
+    );
+  }
+
+  return null;
+}

--- a/src/app/api/ai/_shared/claude-client.ts
+++ b/src/app/api/ai/_shared/claude-client.ts
@@ -1,17 +1,25 @@
 import Anthropic from "@anthropic-ai/sdk";
+import { resolveAiKey, type ResolvedKey } from "@/lib/ai-key-resolver";
 
-let cachedClient: Anthropic | null = null;
-
-export function getClaudeClient(): Anthropic {
-  if (cachedClient) return cachedClient;
-
-  const apiKey = process.env.ANTHROPIC_API_KEY;
-  if (!apiKey) {
-    throw new Error("ANTHROPIC_API_KEY is not configured");
-  }
-
-  cachedClient = new Anthropic({ apiKey });
-  return cachedClient;
+/**
+ * Build an Anthropic SDK client for a given authenticated user.
+ *
+ * Resolves the key via priority chain (own stored → shared → env-var
+ * whitelist; see ai-key-resolver.ts). Returns the resolved-key metadata
+ * alongside the client so the route can record token usage against the
+ * correct owner.
+ *
+ * No process-wide caching: different users have different keys. Constructing
+ * a new SDK instance per request is cheap (~ms); decrypting the stored key
+ * via `node:crypto` is also cheap (~µs).
+ */
+export async function getClaudeClientForUser(
+  userId: string,
+  email: string | undefined,
+): Promise<{ client: Anthropic; resolved: ResolvedKey }> {
+  const resolved = await resolveAiKey(userId, email, "anthropic");
+  const client = new Anthropic({ apiKey: resolved.apiKey });
+  return { client, resolved };
 }
 
 export const CLAUDE_MODELS = {

--- a/src/app/api/ai/_shared/usage-tracker.ts
+++ b/src/app/api/ai/_shared/usage-tracker.ts
@@ -1,0 +1,74 @@
+/**
+ * Fire-and-forget AI usage logging into the `ai_usage` table.
+ *
+ * Every AI route is expected to call `recordUsage` once per upstream provider
+ * response (success or error). The promise is intentionally not awaited by
+ * the route handler — a logging failure must not affect the user-facing
+ * response. Lost rows on crash are acceptable.
+ */
+
+import { db } from "@/lib/drizzle";
+import { aiUsage } from "@/db/schema";
+import type { AiProvider, KeySource } from "@/lib/ai-key-resolver";
+
+export interface UsageRecord {
+  userId: string;
+  keyOwnerId: string | null;
+  keySource: KeySource;
+  provider: AiProvider;
+  model: string;
+  route: string;
+  status: "success" | "error";
+  inputTokens?: number | undefined;
+  outputTokens?: number | undefined;
+  cacheReadTokens?: number | undefined;
+  cacheCreateTokens?: number | undefined;
+  audioSeconds?: number | undefined;
+  durationMs?: number | undefined;
+}
+
+export function recordUsage(record: UsageRecord): void {
+  // Intentional fire-and-forget. We catch and log so an unhandled rejection
+  // doesn't crash the runtime, but the route handler does not await this.
+  void db
+    .insert(aiUsage)
+    .values({
+      userId: record.userId,
+      keyOwnerId: record.keyOwnerId,
+      keySource: record.keySource,
+      provider: record.provider,
+      model: record.model,
+      route: record.route,
+      status: record.status,
+      inputTokens: record.inputTokens ?? 0,
+      outputTokens: record.outputTokens ?? 0,
+      cacheReadTokens: record.cacheReadTokens ?? 0,
+      cacheCreateTokens: record.cacheCreateTokens ?? 0,
+      audioSeconds: record.audioSeconds ?? null,
+      durationMs: record.durationMs ?? null,
+    })
+    .catch((e) => {
+      console.error("[ai-usage] failed to record usage:", e);
+    });
+}
+
+/**
+ * Extract token counts from an Anthropic `Message` response. The SDK types
+ * cache fields as optional so we coerce to 0 when missing.
+ */
+export function tokensFromAnthropic(usage: {
+  input_tokens: number;
+  output_tokens: number;
+  cache_read_input_tokens?: number | null;
+  cache_creation_input_tokens?: number | null;
+}): Pick<
+  UsageRecord,
+  "inputTokens" | "outputTokens" | "cacheReadTokens" | "cacheCreateTokens"
+> {
+  return {
+    inputTokens: usage.input_tokens ?? 0,
+    outputTokens: usage.output_tokens ?? 0,
+    cacheReadTokens: usage.cache_read_input_tokens ?? 0,
+    cacheCreateTokens: usage.cache_creation_input_tokens ?? 0,
+  };
+}

--- a/src/app/api/ai/_shared/usage-tracker.ts
+++ b/src/app/api/ai/_shared/usage-tracker.ts
@@ -47,8 +47,12 @@ export function recordUsage(record: UsageRecord): void {
       audioSeconds: record.audioSeconds ?? null,
       durationMs: record.durationMs ?? null,
     })
-    .catch((e) => {
-      console.error("[ai-usage] failed to record usage:", e);
+    .catch((e: unknown) => {
+      // Sanitize: DB errors can echo SQL fragments and parameter values
+      // (potentially including user ids). Log only the human-readable
+      // message; the full error stays inside the unhandled-rejection.
+      const message = e instanceof Error ? e.message : String(e);
+      console.error("[ai-usage] failed to record usage:", { message });
     });
 }
 

--- a/src/app/api/ai/interaction-check/route.ts
+++ b/src/app/api/ai/interaction-check/route.ts
@@ -2,9 +2,11 @@ import { NextResponse } from "next/server";
 import { z } from "zod";
 import { withAuth } from "@/lib/auth-middleware";
 import { sanitizeForAI } from "@/lib/security";
-import { getClaudeClient, CLAUDE_MODELS } from "../_shared/claude-client";
+import { getClaudeClientForUser, CLAUDE_MODELS } from "../_shared/claude-client";
 import { parseJsonBody, zodErrorResponse } from "@/app/api/_shared/validation";
 import { createRateLimiter, getClientIp } from "@/app/api/_shared/rate-limit";
+import { recordUsage, tokensFromAnthropic } from "../_shared/usage-tracker";
+import { aiErrorResponse } from "../_shared/ai-error-response";
 
 // --- Zod Schemas (co-located per project convention) ---
 
@@ -111,13 +113,13 @@ export const POST = withAuth(async ({ request, auth }) => {
     }
 
     let client;
+    let resolved;
     try {
-      client = getClaudeClient();
-    } catch {
-      return NextResponse.json(
-        { error: "AI service not configured" },
-        { status: 503 }
-      );
+      ({ client, resolved } = await getClaudeClientForUser(auth.userId!, auth.email));
+    } catch (e) {
+      const mapped = aiErrorResponse(e);
+      if (mapped) return mapped;
+      throw e;
     }
 
     const { activePrescriptions } = parsed.data;
@@ -138,6 +140,7 @@ export const POST = withAuth(async ({ request, auth }) => {
 
     console.log(`[AUDIT] Interaction check request from user: ${auth.userId}, mode: ${parsed.data.mode}`);
 
+    const startedAt = Date.now();
     const response = await client.messages.create({
       model: CLAUDE_MODELS.premium,
       max_tokens: 2048,
@@ -146,6 +149,17 @@ export const POST = withAuth(async ({ request, auth }) => {
       tools: [INTERACTION_CHECK_TOOL],
       tool_choice: { type: "tool", name: "interaction_check_result" },
       messages: [{ role: "user", content: prompt }],
+    });
+    recordUsage({
+      userId: auth.userId!,
+      keyOwnerId: resolved.keyOwnerId,
+      keySource: resolved.source,
+      provider: "anthropic",
+      model: CLAUDE_MODELS.premium,
+      route: "/api/ai/interaction-check",
+      status: "success",
+      durationMs: Date.now() - startedAt,
+      ...tokensFromAnthropic(response.usage),
     });
 
     const toolBlock = response.content.find(b => b.type === "tool_use");
@@ -167,6 +181,8 @@ export const POST = withAuth(async ({ request, auth }) => {
 
     return NextResponse.json(validated.data);
   } catch (error) {
+    const mapped = aiErrorResponse(error);
+    if (mapped) return mapped;
     console.error("Interaction check error:", error);
     return NextResponse.json(
       { error: "Failed to check interactions" },

--- a/src/app/api/ai/medicine-search/route.ts
+++ b/src/app/api/ai/medicine-search/route.ts
@@ -2,9 +2,11 @@ import { NextResponse } from "next/server";
 import { z } from "zod";
 import { withAuth } from "@/lib/auth-middleware";
 import { sanitizeForAI } from "@/lib/security";
-import { getClaudeClient, CLAUDE_MODELS } from "../_shared/claude-client";
+import { getClaudeClientForUser, CLAUDE_MODELS } from "../_shared/claude-client";
 import { parseJsonBody, zodErrorResponse } from "@/app/api/_shared/validation";
 import { createRateLimiter, getClientIp } from "@/app/api/_shared/rate-limit";
+import { recordUsage, tokensFromAnthropic } from "../_shared/usage-tracker";
+import { aiErrorResponse } from "../_shared/ai-error-response";
 
 // --- Zod Schemas (co-located per user decision) ---
 
@@ -101,13 +103,13 @@ export const POST = withAuth(async ({ request, auth }) => {
     console.log(`[AUDIT] Medicine search request from user: ${auth.userId}`);
 
     let client;
+    let resolved;
     try {
-      client = getClaudeClient();
-    } catch {
-      return NextResponse.json(
-        { error: "AI service not configured on server" },
-        { status: 503 }
-      );
+      ({ client, resolved } = await getClaudeClientForUser(auth.userId!, auth.email));
+    } catch (e) {
+      const mapped = aiErrorResponse(e);
+      if (mapped) return mapped;
+      throw e;
     }
 
     const sanitized = sanitizeForAI(query.trim());
@@ -116,6 +118,7 @@ export const POST = withAuth(async ({ request, auth }) => {
       ? `Look up this medication and provide detailed pharmaceutical information, focusing specifically on brands and availability in ${country}: "${sanitized}"`
       : `Look up this medication and provide detailed pharmaceutical information: "${sanitized}"`;
 
+    const startedAt = Date.now();
     const response = await client.messages.create({
       model: CLAUDE_MODELS.premium,
       max_tokens: 2048,
@@ -124,6 +127,17 @@ export const POST = withAuth(async ({ request, auth }) => {
       tools: [MEDICINE_SEARCH_TOOL],
       tool_choice: { type: "tool", name: "medicine_search_result" },
       messages: [{ role: "user", content: prompt }],
+    });
+    recordUsage({
+      userId: auth.userId!,
+      keyOwnerId: resolved.keyOwnerId,
+      keySource: resolved.source,
+      provider: "anthropic",
+      model: CLAUDE_MODELS.premium,
+      route: "/api/ai/medicine-search",
+      status: "success",
+      durationMs: Date.now() - startedAt,
+      ...tokensFromAnthropic(response.usage),
     });
 
     const toolBlock = response.content.find(b => b.type === "tool_use");
@@ -145,6 +159,8 @@ export const POST = withAuth(async ({ request, auth }) => {
 
     return NextResponse.json(validated.data);
   } catch (error) {
+    const mapped = aiErrorResponse(error);
+    if (mapped) return mapped;
     console.error("Medicine search error:", error);
     return NextResponse.json(
       { error: "Failed to process request" },

--- a/src/app/api/ai/medicine-search/route.ts
+++ b/src/app/api/ai/medicine-search/route.ts
@@ -113,9 +113,10 @@ export const POST = withAuth(async ({ request, auth }) => {
     }
 
     const sanitized = sanitizeForAI(query.trim());
+    const sanitizedCountry = country ? sanitizeForAI(country.trim()) : "";
 
-    const prompt = country
-      ? `Look up this medication and provide detailed pharmaceutical information, focusing specifically on brands and availability in ${country}: "${sanitized}"`
+    const prompt = sanitizedCountry
+      ? `Look up this medication and provide detailed pharmaceutical information, focusing specifically on brands and availability in ${sanitizedCountry}: "${sanitized}"`
       : `Look up this medication and provide detailed pharmaceutical information: "${sanitized}"`;
 
     const startedAt = Date.now();

--- a/src/app/api/ai/parse/route.ts
+++ b/src/app/api/ai/parse/route.ts
@@ -3,9 +3,11 @@ import { z } from "zod";
 import type Anthropic from "@anthropic-ai/sdk";
 import { withAuth } from "@/lib/auth-middleware";
 import { sanitizeForAI } from "@/lib/security";
-import { getClaudeClient, CLAUDE_MODELS, WEB_SEARCH_TOOL } from "../_shared/claude-client";
+import { getClaudeClientForUser, CLAUDE_MODELS, WEB_SEARCH_TOOL } from "../_shared/claude-client";
 import { parseJsonBody, zodErrorResponse } from "@/app/api/_shared/validation";
 import { createRateLimiter, getClientIp } from "@/app/api/_shared/rate-limit";
+import { recordUsage, tokensFromAnthropic } from "../_shared/usage-tracker";
+import { aiErrorResponse } from "../_shared/ai-error-response";
 
 /**
  * Server-side AI parsing for food / drink descriptions.
@@ -113,13 +115,13 @@ export const POST = withAuth(async ({ request, auth }) => {
     console.log(`[AUDIT] AI parse from user: ${auth.userId}`);
 
     let client;
+    let resolved;
     try {
-      client = getClaudeClient();
-    } catch {
-      return NextResponse.json(
-        { error: "AI service not configured on server" },
-        { status: 503 }
-      );
+      ({ client, resolved } = await getClaudeClientForUser(auth.userId!, auth.email));
+    } catch (e) {
+      const mapped = aiErrorResponse(e);
+      if (mapped) return mapped;
+      throw e;
     }
 
     const sanitizedInput = sanitizeForAI(input);
@@ -132,6 +134,7 @@ export const POST = withAuth(async ({ request, auth }) => {
 
     const userMessage = `Estimate water (ml) and sodium (mg) for: "${sanitizedInput}". Use web_search for branded or regional items, then call parse_food_result.`;
 
+    const startedAt = Date.now();
     const response = await client.messages.create({
       model: CLAUDE_MODELS.quality,
       max_tokens: 4096,
@@ -140,12 +143,24 @@ export const POST = withAuth(async ({ request, auth }) => {
       tools: [WEB_SEARCH_TOOL, PARSE_RESULT_TOOL],
       messages: [{ role: "user", content: userMessage }],
     });
+    recordUsage({
+      userId: auth.userId!,
+      keyOwnerId: resolved.keyOwnerId,
+      keySource: resolved.source,
+      provider: "anthropic",
+      model: CLAUDE_MODELS.quality,
+      route: "/api/ai/parse",
+      status: "success",
+      durationMs: Date.now() - startedAt,
+      ...tokensFromAnthropic(response.usage),
+    });
 
     let toolBlock = findToolUse(response.content, PARSE_RESULT_TOOL.name);
 
     // If the model finished with text instead of calling the structured tool,
     // run a second turn that forces the tool with the prior context.
     if (!toolBlock) {
+      const followupStartedAt = Date.now();
       const followup = await client.messages.create({
         model: CLAUDE_MODELS.quality,
         max_tokens: 1024,
@@ -164,6 +179,17 @@ export const POST = withAuth(async ({ request, auth }) => {
             content: "Now return the final estimate via the parse_food_result tool.",
           },
         ],
+      });
+      recordUsage({
+        userId: auth.userId!,
+        keyOwnerId: resolved.keyOwnerId,
+        keySource: resolved.source,
+        provider: "anthropic",
+        model: CLAUDE_MODELS.quality,
+        route: "/api/ai/parse",
+        status: "success",
+        durationMs: Date.now() - followupStartedAt,
+        ...tokensFromAnthropic(followup.usage),
       });
       toolBlock = findToolUse(followup.content, PARSE_RESULT_TOOL.name);
     }
@@ -197,6 +223,8 @@ export const POST = withAuth(async ({ request, auth }) => {
       ...(validated.data.reasoning !== undefined && { reasoning: validated.data.reasoning }),
     });
   } catch (error) {
+    const mapped = aiErrorResponse(error);
+    if (mapped) return mapped;
     console.error("AI parse error:", error);
     return NextResponse.json(
       { error: "Failed to process request" },

--- a/src/app/api/ai/status/route.ts
+++ b/src/app/api/ai/status/route.ts
@@ -1,18 +1,18 @@
 import { NextResponse } from "next/server";
 
 /**
- * Public endpoint to check AI service configuration status.
- * Returns only boolean config flags — no sensitive data (key length, format, etc.).
- *
- * As of phase 41 (Neon Auth replacement), Privy is removed entirely. Auth is
- * now enforced server-side via withAuth() reading the Neon Auth cookie session.
+ * Public endpoint to check AI service configuration status. Reports only
+ * whether the server has fallback env-var keys configured — never anything
+ * about a specific user's stored keys (those go through /api/user/api-keys
+ * which is auth-gated).
  */
 export async function GET() {
   return NextResponse.json({
     timestamp: new Date().toISOString(),
     config: {
       authConfigured: !!process.env.DATABASE_URL,
-      serverApiKeyConfigured: !!process.env.ANTHROPIC_API_KEY,
+      serverAnthropicKeyConfigured: !!process.env.ANTHROPIC_API_KEY,
+      serverGroqKeyConfigured: !!process.env.GROQ_API_KEY,
     },
     environment: process.env.NODE_ENV,
   });

--- a/src/app/api/ai/substance-enrich/route.ts
+++ b/src/app/api/ai/substance-enrich/route.ts
@@ -3,10 +3,12 @@ import { z } from "zod";
 import type Anthropic from "@anthropic-ai/sdk";
 import { withAuth } from "@/lib/auth-middleware";
 import { sanitizeForAI } from "@/lib/security";
-import { getClaudeClient, CLAUDE_MODELS, WEB_SEARCH_TOOL } from "../_shared/claude-client";
+import { getClaudeClientForUser, CLAUDE_MODELS, WEB_SEARCH_TOOL } from "../_shared/claude-client";
 import { ethanolGrams, standardDrinksFromAbv } from "@/lib/alcohol-units";
 import { parseJsonBody, zodErrorResponse } from "@/app/api/_shared/validation";
 import { createRateLimiter, getClientIp } from "@/app/api/_shared/rate-limit";
+import { recordUsage, tokensFromAnthropic } from "../_shared/usage-tracker";
+import { aiErrorResponse } from "../_shared/ai-error-response";
 
 /**
  * AI enrichment for caffeine / alcohol "Other" entries. Uses Opus + web_search
@@ -138,13 +140,13 @@ export const POST = withAuth(async ({ request, auth }) => {
     console.log(`[AUDIT] Substance enrich from user: ${auth.userId}, type: ${type}`);
 
     let client;
+    let resolved;
     try {
-      client = getClaudeClient();
-    } catch {
-      return NextResponse.json(
-        { error: "AI service not configured on server" },
-        { status: 503 }
-      );
+      ({ client, resolved } = await getClaudeClientForUser(auth.userId!, auth.email));
+    } catch (e) {
+      const mapped = aiErrorResponse(e);
+      if (mapped) return mapped;
+      throw e;
     }
 
     const sanitized = sanitizeForAI(description);
@@ -162,6 +164,7 @@ export const POST = withAuth(async ({ request, auth }) => {
         ? `Estimate caffeine (mg) and volume (ml) for: "${sanitized}". Use web_search for branded items, then call caffeine_enrichment.`
         : `Estimate ABV (%) and volume (ml) for: "${sanitized}". Use web_search if branded or unfamiliar, then call alcohol_enrichment. Return ABV as a percentage, NOT grams.`;
 
+    const startedAt = Date.now();
     const response = await client.messages.create({
       model: CLAUDE_MODELS.quality,
       max_tokens: 4096,
@@ -170,10 +173,22 @@ export const POST = withAuth(async ({ request, auth }) => {
       tools: [WEB_SEARCH_TOOL, tool],
       messages: [{ role: "user", content: userPrompt }],
     });
+    recordUsage({
+      userId: auth.userId!,
+      keyOwnerId: resolved.keyOwnerId,
+      keySource: resolved.source,
+      provider: "anthropic",
+      model: CLAUDE_MODELS.quality,
+      route: "/api/ai/substance-enrich",
+      status: "success",
+      durationMs: Date.now() - startedAt,
+      ...tokensFromAnthropic(response.usage),
+    });
 
     let toolBlock = findToolUse(response.content, tool.name);
 
     if (!toolBlock) {
+      const followupStartedAt = Date.now();
       const followup = await client.messages.create({
         model: CLAUDE_MODELS.quality,
         max_tokens: 1024,
@@ -192,6 +207,17 @@ export const POST = withAuth(async ({ request, auth }) => {
             content: `Now return the final answer via the ${tool.name} tool.`,
           },
         ],
+      });
+      recordUsage({
+        userId: auth.userId!,
+        keyOwnerId: resolved.keyOwnerId,
+        keySource: resolved.source,
+        provider: "anthropic",
+        model: CLAUDE_MODELS.quality,
+        route: "/api/ai/substance-enrich",
+        status: "success",
+        durationMs: Date.now() - followupStartedAt,
+        ...tokensFromAnthropic(followup.usage),
       });
       toolBlock = findToolUse(followup.content, tool.name);
     }
@@ -242,6 +268,8 @@ export const POST = withAuth(async ({ request, auth }) => {
       ...(validated.data.reasoning !== undefined && { reasoning: validated.data.reasoning }),
     });
   } catch (error) {
+    const mapped = aiErrorResponse(error);
+    if (mapped) return mapped;
     console.error("Substance enrich error:", error);
     return NextResponse.json(
       { error: "Failed to process request" },

--- a/src/app/api/ai/substance-lookup/route.ts
+++ b/src/app/api/ai/substance-lookup/route.ts
@@ -3,10 +3,12 @@ import { z } from "zod";
 import type Anthropic from "@anthropic-ai/sdk";
 import { withAuth } from "@/lib/auth-middleware";
 import { sanitizeForAI } from "@/lib/security";
-import { getClaudeClient, CLAUDE_MODELS, WEB_SEARCH_TOOL } from "../_shared/claude-client";
+import { getClaudeClientForUser, CLAUDE_MODELS, WEB_SEARCH_TOOL } from "../_shared/claude-client";
 import { SubstanceLookupResponseSchema, SUBSTANCE_LOOKUP_TOOL } from "./schema";
 import { parseJsonBody, zodErrorResponse } from "@/app/api/_shared/validation";
 import { createRateLimiter, getClientIp } from "@/app/api/_shared/rate-limit";
+import { recordUsage, tokensFromAnthropic } from "../_shared/usage-tracker";
+import { aiErrorResponse } from "../_shared/ai-error-response";
 
 const RequestSchema = z.object({
   query: z.string().min(1).max(200),
@@ -98,13 +100,13 @@ export const POST = withAuth(async ({ request, auth }) => {
     console.log(`[AUDIT] Substance lookup from user: ${auth.userId}, type: ${type}`);
 
     let client;
+    let resolved;
     try {
-      client = getClaudeClient();
-    } catch {
-      return NextResponse.json(
-        { error: "AI service not configured on server" },
-        { status: 503 }
-      );
+      ({ client, resolved } = await getClaudeClientForUser(auth.userId!, auth.email));
+    } catch (e) {
+      const mapped = aiErrorResponse(e);
+      if (mapped) return mapped;
+      throw e;
     }
 
     const systemPrompt = buildSystemPrompt(type);
@@ -113,6 +115,7 @@ export const POST = withAuth(async ({ request, auth }) => {
         ? `Look up caffeine content per 100 ml for: "${sanitized}". Use web_search if it is a branded product, then call substance_lookup_result.`
         : `Look up the ABV (% alcohol by volume) for: "${sanitized}". Use web_search if it is a branded product, then call substance_lookup_result. Return the ABV as a percentage (e.g. 5, 13, 40), NOT grams of ethanol.`;
 
+    const startedAt = Date.now();
     const response = await client.messages.create({
       model: CLAUDE_MODELS.quality,
       max_tokens: 4096,
@@ -121,10 +124,22 @@ export const POST = withAuth(async ({ request, auth }) => {
       tools: [WEB_SEARCH_TOOL, SUBSTANCE_LOOKUP_TOOL],
       messages: [{ role: "user", content: userPrompt }],
     });
+    recordUsage({
+      userId: auth.userId!,
+      keyOwnerId: resolved.keyOwnerId,
+      keySource: resolved.source,
+      provider: "anthropic",
+      model: CLAUDE_MODELS.quality,
+      route: "/api/ai/substance-lookup",
+      status: "success",
+      durationMs: Date.now() - startedAt,
+      ...tokensFromAnthropic(response.usage),
+    });
 
     let toolBlock = findToolUse(response.content, SUBSTANCE_LOOKUP_TOOL.name);
 
     if (!toolBlock) {
+      const followupStartedAt = Date.now();
       const followup = await client.messages.create({
         model: CLAUDE_MODELS.quality,
         max_tokens: 1024,
@@ -144,6 +159,17 @@ export const POST = withAuth(async ({ request, auth }) => {
           },
         ],
       });
+      recordUsage({
+        userId: auth.userId!,
+        keyOwnerId: resolved.keyOwnerId,
+        keySource: resolved.source,
+        provider: "anthropic",
+        model: CLAUDE_MODELS.quality,
+        route: "/api/ai/substance-lookup",
+        status: "success",
+        durationMs: Date.now() - followupStartedAt,
+        ...tokensFromAnthropic(followup.usage),
+      });
       toolBlock = findToolUse(followup.content, SUBSTANCE_LOOKUP_TOOL.name);
     }
 
@@ -162,6 +188,8 @@ export const POST = withAuth(async ({ request, auth }) => {
 
     return NextResponse.json(validated.data);
   } catch (error) {
+    const mapped = aiErrorResponse(error);
+    if (mapped) return mapped;
     console.error("Substance lookup error:", error);
     return NextResponse.json({ error: "Failed to process request" }, { status: 500 });
   }

--- a/src/app/api/ai/titration-warnings/route.ts
+++ b/src/app/api/ai/titration-warnings/route.ts
@@ -2,8 +2,10 @@ import { NextResponse } from "next/server";
 import { z } from "zod";
 import { withAuth } from "@/lib/auth-middleware";
 import { sanitizeForAI } from "@/lib/security";
-import { getClaudeClient, CLAUDE_MODELS } from "../_shared/claude-client";
+import { getClaudeClientForUser, CLAUDE_MODELS } from "../_shared/claude-client";
 import { parseJsonBody, zodErrorResponse } from "@/app/api/_shared/validation";
+import { recordUsage, tokensFromAnthropic } from "../_shared/usage-tracker";
+import { aiErrorResponse } from "../_shared/ai-error-response";
 
 const RequestSchema = z.object({
   prescriptions: z
@@ -73,13 +75,13 @@ export const POST = withAuth(async ({ request, auth }) => {
     }
 
     let client;
+    let resolved;
     try {
-      client = getClaudeClient();
-    } catch {
-      return NextResponse.json(
-        { error: "AI service not configured" },
-        { status: 503 },
-      );
+      ({ client, resolved } = await getClaudeClientForUser(auth.userId!, auth.email));
+    } catch (e) {
+      const mapped = aiErrorResponse(e);
+      if (mapped) return mapped;
+      throw e;
     }
 
     const { prescriptions, otherMedications, title } = parsed.data;
@@ -113,6 +115,7 @@ export const POST = withAuth(async ({ request, auth }) => {
 
     console.log(`[AUDIT] Titration warnings request from user: ${auth.userId}`);
 
+    const startedAt = Date.now();
     const response = await client.messages.create({
       model: CLAUDE_MODELS.premium,
       max_tokens: 1536,
@@ -121,6 +124,17 @@ export const POST = withAuth(async ({ request, auth }) => {
       tools: [TITRATION_WARNINGS_TOOL],
       tool_choice: { type: "tool", name: "titration_warnings_result" },
       messages: [{ role: "user", content: prompt }],
+    });
+    recordUsage({
+      userId: auth.userId!,
+      keyOwnerId: resolved.keyOwnerId,
+      keySource: resolved.source,
+      provider: "anthropic",
+      model: CLAUDE_MODELS.premium,
+      route: "/api/ai/titration-warnings",
+      status: "success",
+      durationMs: Date.now() - startedAt,
+      ...tokensFromAnthropic(response.usage),
     });
 
     const toolBlock = response.content.find(b => b.type === "tool_use");
@@ -142,6 +156,8 @@ export const POST = withAuth(async ({ request, auth }) => {
 
     return NextResponse.json(validated.data);
   } catch (error) {
+    const mapped = aiErrorResponse(error);
+    if (mapped) return mapped;
     console.error("Titration warnings error:", error);
     return NextResponse.json(
       { error: "Failed to generate warnings" },

--- a/src/app/api/ai/voice-parse/route.ts
+++ b/src/app/api/ai/voice-parse/route.ts
@@ -3,9 +3,11 @@ import { z } from "zod";
 import type Anthropic from "@anthropic-ai/sdk";
 import { withAuth } from "@/lib/auth-middleware";
 import { sanitizeForAI } from "@/lib/security";
-import { getClaudeClient, CLAUDE_MODELS } from "../_shared/claude-client";
+import { getClaudeClientForUser, CLAUDE_MODELS } from "../_shared/claude-client";
 import { parseJsonBody, zodErrorResponse } from "@/app/api/_shared/validation";
 import { createRateLimiter, getClientIp } from "@/app/api/_shared/rate-limit";
+import { recordUsage, tokensFromAnthropic } from "../_shared/usage-tracker";
+import { aiErrorResponse } from "../_shared/ai-error-response";
 
 /**
  * Parse a voice transcript into a heterogeneous list of health record items
@@ -196,13 +198,13 @@ export const POST = withAuth(async ({ request, auth }) => {
     }
 
     let client;
+    let resolved;
     try {
-      client = getClaudeClient();
-    } catch {
-      return NextResponse.json(
-        { error: "AI service not configured on server" },
-        { status: 503 }
-      );
+      ({ client, resolved } = await getClaudeClientForUser(auth.userId!, auth.email));
+    } catch (e) {
+      const mapped = aiErrorResponse(e);
+      if (mapped) return mapped;
+      throw e;
     }
 
     const sanitized = sanitizeForAI(parsed.data.transcript);
@@ -221,6 +223,7 @@ export const POST = withAuth(async ({ request, auth }) => {
     const REQUEST_TIMEOUT_MS = 60_000;
 
     let response: Anthropic.Messages.Message;
+    const startedAt = Date.now();
     try {
       response = await client.messages.create(
         {
@@ -239,11 +242,23 @@ export const POST = withAuth(async ({ request, auth }) => {
       }
       throw e;
     }
+    recordUsage({
+      userId: auth.userId!,
+      keyOwnerId: resolved.keyOwnerId,
+      keySource: resolved.source,
+      provider: "anthropic",
+      model: CLAUDE_MODELS.quality,
+      route: "/api/ai/voice-parse",
+      status: "success",
+      durationMs: Date.now() - startedAt,
+      ...tokensFromAnthropic(response.usage),
+    });
 
     let toolBlock = findToolUse(response.content, PARSE_TOOL.name);
 
     if (!toolBlock) {
       let followup: Anthropic.Messages.Message;
+      const followupStartedAt = Date.now();
       try {
         followup = await client.messages.create(
           {
@@ -270,6 +285,17 @@ export const POST = withAuth(async ({ request, auth }) => {
         }
         throw e;
       }
+      recordUsage({
+        userId: auth.userId!,
+        keyOwnerId: resolved.keyOwnerId,
+        keySource: resolved.source,
+        provider: "anthropic",
+        model: CLAUDE_MODELS.quality,
+        route: "/api/ai/voice-parse",
+        status: "success",
+        durationMs: Date.now() - followupStartedAt,
+        ...tokensFromAnthropic(followup.usage),
+      });
       toolBlock = findToolUse(followup.content, PARSE_TOOL.name);
     }
 
@@ -294,6 +320,8 @@ export const POST = withAuth(async ({ request, auth }) => {
 
     return NextResponse.json(validated.data);
   } catch (error) {
+    const mapped = aiErrorResponse(error);
+    if (mapped) return mapped;
     console.error("voice-parse error:", error);
     return NextResponse.json(
       { error: "Failed to parse transcript" },

--- a/src/app/api/ai/voice-transcribe/route.ts
+++ b/src/app/api/ai/voice-transcribe/route.ts
@@ -1,6 +1,9 @@
 import { NextResponse } from "next/server";
 import { withAuth } from "@/lib/auth-middleware";
 import { createRateLimiter, getClientIp } from "@/app/api/_shared/rate-limit";
+import { resolveAiKey } from "@/lib/ai-key-resolver";
+import { recordUsage } from "../_shared/usage-tracker";
+import { aiErrorResponse } from "../_shared/ai-error-response";
 
 /**
  * Transcribe a short audio clip using Groq's hosted
@@ -36,13 +39,15 @@ export const POST = withAuth(async ({ request, auth }) => {
       );
     }
 
-    const apiKey = process.env.GROQ_API_KEY;
-    if (!apiKey) {
-      return NextResponse.json(
-        { error: "Voice transcription not configured on server (GROQ_API_KEY missing)" },
-        { status: 503 }
-      );
+    let resolved;
+    try {
+      resolved = await resolveAiKey(auth.userId!, auth.email, "groq");
+    } catch (e) {
+      const mapped = aiErrorResponse(e);
+      if (mapped) return mapped;
+      throw e;
     }
+    const apiKey = resolved.apiKey;
 
     const form = await request.formData();
     const file = form.get("audio");
@@ -79,13 +84,15 @@ export const POST = withAuth(async ({ request, auth }) => {
     upstream.append("file", file, file.name || "clip.webm");
     upstream.append("model", GROQ_MODEL);
     upstream.append("prompt", DOMAIN_PROMPT);
-    upstream.append("response_format", "json");
+    // verbose_json includes a `duration` field (seconds) we record for usage.
+    upstream.append("response_format", "verbose_json");
     upstream.append("temperature", "0");
 
     const controller = new AbortController();
     const timeoutId = setTimeout(() => controller.abort(), 30_000);
 
     let response: Response;
+    const startedAt = Date.now();
     try {
       response = await fetch(GROQ_ENDPOINT, {
         method: "POST",
@@ -104,18 +111,43 @@ export const POST = withAuth(async ({ request, auth }) => {
     } finally {
       clearTimeout(timeoutId);
     }
+    const durationMs = Date.now() - startedAt;
 
     if (!response.ok) {
       const detail = await response.text().catch(() => "");
       console.error(`[voice-transcribe] Groq ${response.status}: ${detail.slice(0, 500)}`);
+      recordUsage({
+        userId: auth.userId!,
+        keyOwnerId: resolved.keyOwnerId,
+        keySource: resolved.source,
+        provider: "groq",
+        model: GROQ_MODEL,
+        route: "/api/ai/voice-transcribe",
+        status: "error",
+        durationMs,
+      });
+      if (response.status === 401 || response.status === 403) {
+        return NextResponse.json(
+          {
+            error: "Groq rejected the API key. Update it in Settings → AI features.",
+            code: "INVALID_KEY",
+            provider: "groq",
+          },
+          { status: 400 }
+        );
+      }
       return NextResponse.json(
         { error: "Transcription service failed", status: response.status },
         { status: 502 }
       );
     }
 
-    const body = (await response.json()) as { text?: unknown };
+    const body = (await response.json()) as { text?: unknown; duration?: unknown };
     const text = typeof body.text === "string" ? body.text.trim() : "";
+    const audioSeconds =
+      typeof body.duration === "number" && Number.isFinite(body.duration)
+        ? Math.round(body.duration)
+        : undefined;
 
     if (!text) {
       return NextResponse.json(
@@ -124,8 +156,22 @@ export const POST = withAuth(async ({ request, auth }) => {
       );
     }
 
+    recordUsage({
+      userId: auth.userId!,
+      keyOwnerId: resolved.keyOwnerId,
+      keySource: resolved.source,
+      provider: "groq",
+      model: GROQ_MODEL,
+      route: "/api/ai/voice-transcribe",
+      status: "success",
+      durationMs,
+      audioSeconds,
+    });
+
     return NextResponse.json({ text });
   } catch (error) {
+    const mapped = aiErrorResponse(error);
+    if (mapped) return mapped;
     console.error("voice-transcribe error:", error);
     return NextResponse.json(
       { error: "Failed to transcribe audio" },

--- a/src/app/api/user/ai-usage/route.ts
+++ b/src/app/api/user/ai-usage/route.ts
@@ -1,0 +1,122 @@
+import { NextResponse } from "next/server";
+import { and, eq, gte, sql as drizzleSql } from "drizzle-orm";
+import { neon } from "@neondatabase/serverless";
+import { withAuth } from "@/lib/auth-middleware";
+import { db } from "@/lib/drizzle";
+import { aiUsage } from "@/db/schema";
+
+/**
+ * GET /api/user/ai-usage
+ *   → {
+ *       mine: {
+ *         anthropic: { totalCalls, inputTokens, outputTokens },
+ *         groq: { totalCalls, audioSeconds },
+ *         byRoute: [{ route, calls, inputTokens, outputTokens }],
+ *       },
+ *       asGrantor: {
+ *         byGrantee: [{ granteeEmail, provider, calls, inputTokens, outputTokens }],
+ *       },
+ *     }
+ *
+ * Mine: usage I incurred (regardless of whose key was used).
+ * AsGrantor: usage others incurred against my stored key.
+ *
+ * `?days=30` controls the window (default 30, max 365).
+ */
+export const GET = withAuth(async ({ request, auth }) => {
+  const userId = auth.userId!;
+  const url = new URL(request.url);
+  const daysParam = Number(url.searchParams.get("days") ?? "30");
+  const days = Math.max(1, Math.min(365, Number.isFinite(daysParam) ? daysParam : 30));
+  const cutoff = new Date(Date.now() - days * 24 * 60 * 60 * 1000);
+
+  // --- Mine, totals by provider ---
+  const mineByProvider = await db
+    .select({
+      provider: aiUsage.provider,
+      calls: drizzleSql<number>`count(*)::int`,
+      inputTokens: drizzleSql<number>`coalesce(sum(${aiUsage.inputTokens}), 0)::int`,
+      outputTokens: drizzleSql<number>`coalesce(sum(${aiUsage.outputTokens}), 0)::int`,
+      cacheReadTokens: drizzleSql<number>`coalesce(sum(${aiUsage.cacheReadTokens}), 0)::int`,
+      cacheCreateTokens: drizzleSql<number>`coalesce(sum(${aiUsage.cacheCreateTokens}), 0)::int`,
+      audioSeconds: drizzleSql<number>`coalesce(sum(${aiUsage.audioSeconds}), 0)::int`,
+    })
+    .from(aiUsage)
+    .where(
+      and(
+        eq(aiUsage.userId, userId),
+        eq(aiUsage.status, "success"),
+        gte(aiUsage.timestamp, cutoff),
+      ),
+    )
+    .groupBy(aiUsage.provider);
+
+  // --- Mine, by route ---
+  const mineByRoute = await db
+    .select({
+      route: aiUsage.route,
+      provider: aiUsage.provider,
+      calls: drizzleSql<number>`count(*)::int`,
+      inputTokens: drizzleSql<number>`coalesce(sum(${aiUsage.inputTokens}), 0)::int`,
+      outputTokens: drizzleSql<number>`coalesce(sum(${aiUsage.outputTokens}), 0)::int`,
+    })
+    .from(aiUsage)
+    .where(
+      and(
+        eq(aiUsage.userId, userId),
+        eq(aiUsage.status, "success"),
+        gte(aiUsage.timestamp, cutoff),
+      ),
+    )
+    .groupBy(aiUsage.route, aiUsage.provider);
+
+  // --- As grantor: who consumed my key ---
+  // Join with neon_auth.users_sync via raw SQL to get the grantee email.
+  const rawSql = neon(process.env.DATABASE_URL!);
+  const cutoffIso = cutoff.toISOString();
+  const asGrantor = (await rawSql`
+    SELECT
+      ai.user_id            AS grantee_id,
+      u.email               AS grantee_email,
+      ai.provider           AS provider,
+      COUNT(*)::int         AS calls,
+      COALESCE(SUM(ai.input_tokens), 0)::int   AS input_tokens,
+      COALESCE(SUM(ai.output_tokens), 0)::int  AS output_tokens,
+      COALESCE(SUM(ai.audio_seconds), 0)::int  AS audio_seconds
+    FROM ai_usage ai
+    LEFT JOIN neon_auth.users_sync u ON u.id = ai.user_id
+    WHERE ai.key_owner_id = ${userId}
+      AND ai.user_id <> ${userId}
+      AND ai.status = 'success'
+      AND ai.timestamp >= ${cutoffIso}
+    GROUP BY ai.user_id, u.email, ai.provider
+    ORDER BY calls DESC
+  `) as Array<{
+    grantee_id: string;
+    grantee_email: string | null;
+    provider: string;
+    calls: number;
+    input_tokens: number;
+    output_tokens: number;
+    audio_seconds: number;
+  }>;
+
+  return NextResponse.json({
+    windowDays: days,
+    mine: {
+      byProvider: mineByProvider,
+      byRoute: mineByRoute,
+    },
+    asGrantor: {
+      byGrantee: asGrantor.map((r) => ({
+        granteeId: r.grantee_id,
+        granteeEmail: r.grantee_email ?? "(unknown)",
+        provider: r.provider,
+        calls: r.calls,
+        inputTokens: r.input_tokens,
+        outputTokens: r.output_tokens,
+        audioSeconds: r.audio_seconds,
+      })),
+    },
+  });
+});

--- a/src/app/api/user/api-keys/route.ts
+++ b/src/app/api/user/api-keys/route.ts
@@ -1,0 +1,166 @@
+import { NextResponse } from "next/server";
+import { z } from "zod";
+import { eq, sql } from "drizzle-orm";
+import { withAuth } from "@/lib/auth-middleware";
+import { db } from "@/lib/drizzle";
+import { userApiKeys } from "@/db/schema";
+import { encryptKey, lastFourOf, type KeyVaultAad } from "@/lib/key-vault";
+import { parseJsonBody, zodErrorResponse } from "@/app/api/_shared/validation";
+
+/**
+ * GET  /api/user/api-keys
+ *   → { anthropic: { configured, last4 } | null, groq: { configured, last4 } | null }
+ *
+ * PUT  /api/user/api-keys
+ *   body: { provider: "anthropic" | "groq", key: string }
+ *   → { configured: true, last4 }
+ *
+ * DELETE /api/user/api-keys?provider=anthropic
+ *   → { configured: false }
+ *
+ * The raw key is never returned. `last4` is the only plaintext fragment we
+ * persist or expose; everything else is encrypted via key-vault.ts.
+ */
+
+const PutSchema = z.object({
+  provider: z.enum(["anthropic", "groq"]),
+  key: z.string().min(8).max(500),
+});
+
+function validateKeyFormat(provider: "anthropic" | "groq", key: string): string | null {
+  const trimmed = key.trim();
+  if (!trimmed) return "Key is empty";
+  if (provider === "anthropic" && !trimmed.startsWith("sk-ant-")) {
+    return "Anthropic keys must start with 'sk-ant-'";
+  }
+  if (provider === "groq" && !trimmed.startsWith("gsk_")) {
+    return "Groq keys must start with 'gsk_'";
+  }
+  return null;
+}
+
+export const GET = withAuth(async ({ auth }) => {
+  const rows = await db
+    .select()
+    .from(userApiKeys)
+    .where(eq(userApiKeys.userId, auth.userId!))
+    .limit(1);
+  const row = rows[0];
+  return NextResponse.json({
+    anthropic: row?.anthropicKeyEncrypted
+      ? { configured: true, last4: row.anthropicLast4 ?? "" }
+      : null,
+    groq: row?.groqKeyEncrypted
+      ? { configured: true, last4: row.groqLast4 ?? "" }
+      : null,
+  });
+});
+
+export const PUT = withAuth(async ({ request, auth }) => {
+  const json = await parseJsonBody(request);
+  if (!json.ok) return json.response;
+
+  const parsed = PutSchema.safeParse(json.body);
+  if (!parsed.success) {
+    return zodErrorResponse("api-keys PUT", parsed.error);
+  }
+
+  const { provider, key } = parsed.data;
+  const trimmed = key.trim();
+  const formatError = validateKeyFormat(provider, trimmed);
+  if (formatError) {
+    return NextResponse.json({ error: formatError }, { status: 400 });
+  }
+
+  const aad: KeyVaultAad = { userId: auth.userId!, provider };
+  let encrypted: string;
+  try {
+    encrypted = encryptKey(trimmed, aad);
+  } catch (e) {
+    console.error("[api-keys] encryption failed:", e);
+    return NextResponse.json(
+      { error: "Server encryption is not configured" },
+      { status: 503 },
+    );
+  }
+
+  const last4 = lastFourOf(trimmed);
+  const now = new Date();
+
+  if (provider === "anthropic") {
+    await db
+      .insert(userApiKeys)
+      .values({
+        userId: auth.userId!,
+        anthropicKeyEncrypted: encrypted,
+        anthropicLast4: last4,
+        createdAt: now,
+        updatedAt: now,
+      })
+      .onConflictDoUpdate({
+        target: userApiKeys.userId,
+        set: {
+          anthropicKeyEncrypted: encrypted,
+          anthropicLast4: last4,
+          updatedAt: now,
+        },
+      });
+  } else {
+    await db
+      .insert(userApiKeys)
+      .values({
+        userId: auth.userId!,
+        groqKeyEncrypted: encrypted,
+        groqLast4: last4,
+        createdAt: now,
+        updatedAt: now,
+      })
+      .onConflictDoUpdate({
+        target: userApiKeys.userId,
+        set: {
+          groqKeyEncrypted: encrypted,
+          groqLast4: last4,
+          updatedAt: now,
+        },
+      });
+  }
+
+  console.log(`[AUDIT] api-key set: user=${auth.userId}, provider=${provider}`);
+
+  return NextResponse.json({ configured: true, last4 });
+});
+
+export const DELETE = withAuth(async ({ request, auth }) => {
+  const url = new URL(request.url);
+  const provider = url.searchParams.get("provider");
+  if (provider !== "anthropic" && provider !== "groq") {
+    return NextResponse.json(
+      { error: "provider query param must be 'anthropic' or 'groq'" },
+      { status: 400 },
+    );
+  }
+
+  const now = new Date();
+  if (provider === "anthropic") {
+    await db
+      .update(userApiKeys)
+      .set({
+        anthropicKeyEncrypted: sql`NULL`,
+        anthropicLast4: sql`NULL`,
+        updatedAt: now,
+      })
+      .where(eq(userApiKeys.userId, auth.userId!));
+  } else {
+    await db
+      .update(userApiKeys)
+      .set({
+        groqKeyEncrypted: sql`NULL`,
+        groqLast4: sql`NULL`,
+        updatedAt: now,
+      })
+      .where(eq(userApiKeys.userId, auth.userId!));
+  }
+
+  console.log(`[AUDIT] api-key clear: user=${auth.userId}, provider=${provider}`);
+  return NextResponse.json({ configured: false });
+});

--- a/src/app/api/user/api-keys/shares/route.ts
+++ b/src/app/api/user/api-keys/shares/route.ts
@@ -1,0 +1,212 @@
+import { NextResponse } from "next/server";
+import { z } from "zod";
+import { and, asc, desc, eq, or } from "drizzle-orm";
+import { neon } from "@neondatabase/serverless";
+import { withAuth } from "@/lib/auth-middleware";
+import { db } from "@/lib/drizzle";
+import { userApiKeys, userKeyShares } from "@/db/schema";
+import { parseJsonBody, zodErrorResponse } from "@/app/api/_shared/validation";
+
+/**
+ * GET    /api/user/api-keys/shares
+ *   → {
+ *       granted: [{ granteeEmail, provider, createdAt }],  // I shared with these
+ *       received: [{ grantorEmail, provider, createdAt }], // shared with me
+ *     }
+ *
+ * POST   /api/user/api-keys/shares
+ *   body: { granteeEmail: string, provider: "anthropic" | "groq" }
+ *   → 200 on success, 404 if grantee email doesn't have an account yet,
+ *     400 if I don't have the corresponding key configured.
+ *
+ * DELETE /api/user/api-keys/shares?granteeId=...&provider=...
+ *   → revokes a grant I made.
+ */
+
+const PostSchema = z.object({
+  granteeEmail: z.string().email().max(320),
+  provider: z.enum(["anthropic", "groq"]),
+});
+
+interface UserByEmailRow {
+  id: string;
+  email: string;
+}
+
+function rawSql() {
+  return neon(process.env.DATABASE_URL!);
+}
+
+async function findUserByEmail(email: string): Promise<UserByEmailRow | null> {
+  const sql = rawSql();
+  const rows = (await sql`
+    SELECT id, email FROM neon_auth.users_sync
+    WHERE LOWER(email) = LOWER(${email})
+    LIMIT 1
+  `) as UserByEmailRow[];
+  return rows[0] ?? null;
+}
+
+async function getEmailById(id: string): Promise<string | null> {
+  const sql = rawSql();
+  const rows = (await sql`
+    SELECT email FROM neon_auth.users_sync WHERE id = ${id} LIMIT 1
+  `) as { email: string | null }[];
+  return rows[0]?.email ?? null;
+}
+
+export const GET = withAuth(async ({ auth }) => {
+  const userId = auth.userId!;
+
+  const sharesGranted = await db
+    .select({
+      granteeId: userKeyShares.granteeId,
+      granteeEmail: userKeyShares.granteeEmail,
+      provider: userKeyShares.provider,
+      createdAt: userKeyShares.createdAt,
+    })
+    .from(userKeyShares)
+    .where(eq(userKeyShares.grantorId, userId))
+    .orderBy(asc(userKeyShares.createdAt));
+
+  const sharesReceived = await db
+    .select({
+      grantorId: userKeyShares.grantorId,
+      provider: userKeyShares.provider,
+      createdAt: userKeyShares.createdAt,
+    })
+    .from(userKeyShares)
+    .where(eq(userKeyShares.granteeId, userId))
+    .orderBy(desc(userKeyShares.createdAt));
+
+  // Resolve grantor emails so the UI can show "shared by alice@..." without
+  // exposing internal user ids. One round-trip per unique grantor; in
+  // practice this list is short.
+  const uniqueGrantorIds = Array.from(new Set(sharesReceived.map((s) => s.grantorId)));
+  const grantorEmails: Record<string, string | null> = {};
+  for (const gid of uniqueGrantorIds) {
+    grantorEmails[gid] = await getEmailById(gid);
+  }
+
+  return NextResponse.json({
+    granted: sharesGranted.map((s) => ({
+      granteeId: s.granteeId,
+      granteeEmail: s.granteeEmail,
+      provider: s.provider,
+      createdAt: s.createdAt,
+    })),
+    received: sharesReceived.map((s) => ({
+      grantorEmail: grantorEmails[s.grantorId] ?? "(unknown)",
+      provider: s.provider,
+      createdAt: s.createdAt,
+    })),
+  });
+});
+
+export const POST = withAuth(async ({ request, auth }) => {
+  const json = await parseJsonBody(request);
+  if (!json.ok) return json.response;
+  const parsed = PostSchema.safeParse(json.body);
+  if (!parsed.success) {
+    return zodErrorResponse("share POST", parsed.error);
+  }
+
+  const { granteeEmail, provider } = parsed.data;
+  const userId = auth.userId!;
+
+  // I must have a stored key for the requested provider to share.
+  const ownRows = await db
+    .select()
+    .from(userApiKeys)
+    .where(eq(userApiKeys.userId, userId))
+    .limit(1);
+  const own = ownRows[0];
+  const ownHasKey =
+    provider === "anthropic" ? !!own?.anthropicKeyEncrypted : !!own?.groqKeyEncrypted;
+  if (!ownHasKey) {
+    return NextResponse.json(
+      {
+        error: `You don't have a stored ${provider} key to share. Add one first.`,
+        code: "NO_OWN_KEY",
+      },
+      { status: 400 },
+    );
+  }
+
+  const grantee = await findUserByEmail(granteeEmail);
+  if (!grantee) {
+    return NextResponse.json(
+      {
+        error: "No account exists for that email. The grantee must sign in once first.",
+        code: "GRANTEE_NOT_FOUND",
+      },
+      { status: 404 },
+    );
+  }
+
+  if (grantee.id === userId) {
+    return NextResponse.json(
+      { error: "You can't share a key with yourself" },
+      { status: 400 },
+    );
+  }
+
+  await db
+    .insert(userKeyShares)
+    .values({
+      grantorId: userId,
+      granteeId: grantee.id,
+      provider,
+      granteeEmail: grantee.email.toLowerCase(),
+    })
+    .onConflictDoNothing();
+
+  console.log(
+    `[AUDIT] share grant: grantor=${userId}, grantee=${grantee.id}, provider=${provider}`,
+  );
+  return NextResponse.json({ ok: true });
+});
+
+export const DELETE = withAuth(async ({ request, auth }) => {
+  const url = new URL(request.url);
+  const granteeId = url.searchParams.get("granteeId");
+  const provider = url.searchParams.get("provider");
+
+  if (!granteeId) {
+    return NextResponse.json(
+      { error: "granteeId query param is required" },
+      { status: 400 },
+    );
+  }
+  if (provider !== "anthropic" && provider !== "groq") {
+    return NextResponse.json(
+      { error: "provider query param must be 'anthropic' or 'groq'" },
+      { status: 400 },
+    );
+  }
+
+  // A user can revoke either direction: as the grantor (taking access away)
+  // or as the grantee (declining a share they no longer want).
+  await db
+    .delete(userKeyShares)
+    .where(
+      and(
+        eq(userKeyShares.provider, provider),
+        or(
+          and(
+            eq(userKeyShares.grantorId, auth.userId!),
+            eq(userKeyShares.granteeId, granteeId),
+          ),
+          and(
+            eq(userKeyShares.granteeId, auth.userId!),
+            eq(userKeyShares.grantorId, granteeId),
+          ),
+        ),
+      ),
+    );
+
+  console.log(
+    `[AUDIT] share revoke: actor=${auth.userId}, other=${granteeId}, provider=${provider}`,
+  );
+  return NextResponse.json({ ok: true });
+});

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -58,6 +58,15 @@ function SettingsContent() {
       </div>
 
       <Accordion type="single" collapsible className="pb-8">
+        <SettingsAccordionGroup value="ai-features" icon={Sparkles} label="AI features" iconColorClass="text-amber-600 dark:text-amber-400">
+          <AiKeysSection />
+        </SettingsAccordionGroup>
+
+        <SettingsAccordionGroup value="data-storage" icon={Database} label="Data & Storage" iconColorClass="text-amber-600 dark:text-amber-400">
+          <StorageInfoSection />
+          <DataManagementSection />
+        </SettingsAccordionGroup>
+
         <SettingsAccordionGroup value="tracking" icon={Activity} label="Tracking" iconColorClass="text-indigo-600 dark:text-indigo-400">
           <DaySettingsSection />
           <WaterSettingsSection />
@@ -75,15 +84,6 @@ function SettingsContent() {
 
         <SettingsAccordionGroup value="medication" icon={Pill} label="Medication" iconColorClass="text-teal-600 dark:text-teal-400">
           <MedicationSettingsSection />
-        </SettingsAccordionGroup>
-
-        <SettingsAccordionGroup value="data-storage" icon={Database} label="Data & Storage" iconColorClass="text-amber-600 dark:text-amber-400">
-          <StorageInfoSection />
-          <DataManagementSection />
-        </SettingsAccordionGroup>
-
-        <SettingsAccordionGroup value="ai-features" icon={Sparkles} label="AI features" iconColorClass="text-amber-600 dark:text-amber-400">
-          <AiKeysSection />
         </SettingsAccordionGroup>
 
         <SettingsAccordionGroup value="privacy-security" icon={Shield} label="Privacy & Security" iconColorClass="text-emerald-600 dark:text-emerald-400">

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -2,7 +2,7 @@
 
 import { Button } from "@/components/ui/button";
 import { Accordion } from "@/components/ui/accordion";
-import { RotateCcw, Activity, Palette, Pill, Database, Shield, Bug, Download } from "lucide-react";
+import { RotateCcw, Activity, Palette, Pill, Database, Shield, Bug, Download, Sparkles } from "lucide-react";
 import { useSettings } from "@/hooks/use-settings";
 import { useToast } from "@/hooks/use-toast";
 import { useScrollHide } from "@/hooks/use-scroll-hide";
@@ -25,6 +25,7 @@ import { UrinationDefecationDefaults } from "@/components/settings/urination-def
 import { MedicationSettingsSection } from "@/components/settings/medication-settings-section";
 import { AnimationTimingSection } from "@/components/settings/animation-timing-section";
 import { StorageInfoSection } from "@/components/settings/storage-info-section";
+import { AiKeysSection } from "@/components/settings/ai-keys-section";
 
 
 function SettingsContent() {
@@ -79,6 +80,10 @@ function SettingsContent() {
         <SettingsAccordionGroup value="data-storage" icon={Database} label="Data & Storage" iconColorClass="text-amber-600 dark:text-amber-400">
           <StorageInfoSection />
           <DataManagementSection />
+        </SettingsAccordionGroup>
+
+        <SettingsAccordionGroup value="ai-features" icon={Sparkles} label="AI features" iconColorClass="text-amber-600 dark:text-amber-400">
+          <AiKeysSection />
         </SettingsAccordionGroup>
 
         <SettingsAccordionGroup value="privacy-security" icon={Shield} label="Privacy & Security" iconColorClass="text-emerald-600 dark:text-emerald-400">

--- a/src/components/settings/ai-keys-section.tsx
+++ b/src/components/settings/ai-keys-section.tsx
@@ -1,0 +1,478 @@
+"use client";
+
+import { useState } from "react";
+import { Sparkles, Mic, KeyRound, Share2, Activity, Trash2, Plus } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { useToast } from "@/hooks/use-toast";
+import { useAuth } from "@/components/auth-guard";
+import {
+  useApiKeyStatus,
+  useSetApiKey,
+  useDeleteApiKey,
+  useKeyShares,
+  useGrantShare,
+  useRevokeShare,
+  useAiUsage,
+  type AiProvider,
+} from "@/hooks/use-ai-keys";
+
+interface ProviderMeta {
+  id: AiProvider;
+  name: string;
+  description: string;
+  icon: typeof Sparkles;
+  iconColor: string;
+  prefix: string;
+  placeholder: string;
+  consoleUrl: string;
+  consoleLabel: string;
+}
+
+const PROVIDERS: ProviderMeta[] = [
+  {
+    id: "anthropic",
+    name: "Anthropic",
+    description: "Powers food & drink parsing, substance lookup, medicine search.",
+    icon: Sparkles,
+    iconColor: "text-amber-500",
+    prefix: "sk-ant-",
+    placeholder: "sk-ant-…",
+    consoleUrl: "https://console.anthropic.com/settings/keys",
+    consoleLabel: "console.anthropic.com",
+  },
+  {
+    id: "groq",
+    name: "Groq",
+    description: "Powers voice transcription (Whisper).",
+    icon: Mic,
+    iconColor: "text-purple-500",
+    prefix: "gsk_",
+    placeholder: "gsk_…",
+    consoleUrl: "https://console.groq.com/keys",
+    consoleLabel: "console.groq.com",
+  },
+];
+
+function ProviderCard({ meta }: { meta: ProviderMeta }) {
+  const { data: status, isLoading } = useApiKeyStatus();
+  const { data: shares } = useKeyShares();
+  const setKey = useSetApiKey();
+  const deleteKey = useDeleteApiKey();
+  const { toast } = useToast();
+  const [editing, setEditing] = useState(false);
+  const [keyValue, setKeyValue] = useState("");
+
+  const entry = status?.[meta.id] ?? null;
+  const receivedShare = shares?.received.find((s) => s.provider === meta.id);
+  const Icon = meta.icon;
+
+  const handleSave = async () => {
+    const trimmed = keyValue.trim();
+    if (!trimmed) {
+      toast({ title: "Enter a key", variant: "destructive" });
+      return;
+    }
+    if (!trimmed.startsWith(meta.prefix)) {
+      toast({
+        title: `Invalid ${meta.name} key`,
+        description: `${meta.name} keys start with ${meta.prefix}`,
+        variant: "destructive",
+      });
+      return;
+    }
+    try {
+      await setKey.mutateAsync({ provider: meta.id, key: trimmed });
+      setKeyValue("");
+      setEditing(false);
+      toast({ title: `${meta.name} key saved`, variant: "success" });
+    } catch (err) {
+      toast({
+        title: `Failed to save ${meta.name} key`,
+        description: err instanceof Error ? err.message : "Unknown error",
+        variant: "destructive",
+      });
+    }
+  };
+
+  const handleRemove = async () => {
+    try {
+      await deleteKey.mutateAsync(meta.id);
+      toast({ title: `${meta.name} key removed`, variant: "success" });
+    } catch (err) {
+      toast({
+        title: `Failed to remove ${meta.name} key`,
+        description: err instanceof Error ? err.message : "Unknown error",
+        variant: "destructive",
+      });
+    }
+  };
+
+  let statusBlock: React.ReactNode;
+  if (isLoading) {
+    statusBlock = (
+      <p className="text-xs text-muted-foreground">Loading…</p>
+    );
+  } else if (entry?.configured) {
+    statusBlock = (
+      <p className="text-xs text-muted-foreground">
+        Using your key ending in <span className="font-mono">{entry.last4 || "????"}</span>
+      </p>
+    );
+  } else if (receivedShare) {
+    statusBlock = (
+      <p className="text-xs text-muted-foreground">
+        Granted by{" "}
+        <span className="font-mono">{receivedShare.grantorEmail}</span>
+      </p>
+    );
+  } else {
+    statusBlock = (
+      <p className="text-xs text-muted-foreground">
+        Not configured. Add a key, or ask someone to share theirs.
+      </p>
+    );
+  }
+
+  return (
+    <div className="rounded-lg border p-4 space-y-3">
+      <div className="flex items-start gap-3">
+        <Icon className={`w-4 h-4 mt-0.5 ${meta.iconColor}`} />
+        <div className="flex-1 min-w-0">
+          <p className="text-sm font-medium">{meta.name}</p>
+          <p className="text-xs text-muted-foreground">{meta.description}</p>
+        </div>
+      </div>
+
+      {statusBlock}
+
+      {editing ? (
+        <div className="space-y-2">
+          <Label htmlFor={`key-${meta.id}`} className="text-xs">
+            Paste {meta.name} API key
+          </Label>
+          <Input
+            id={`key-${meta.id}`}
+            type="password"
+            placeholder={meta.placeholder}
+            value={keyValue}
+            onChange={(e) => setKeyValue(e.target.value)}
+            autoComplete="off"
+          />
+          <p className="text-[11px] text-muted-foreground">
+            Get a key from{" "}
+            <a
+              href={meta.consoleUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="underline"
+            >
+              {meta.consoleLabel}
+            </a>
+            . Stored encrypted on the server.
+          </p>
+          <div className="flex gap-2">
+            <Button
+              size="sm"
+              onClick={handleSave}
+              disabled={setKey.isPending || !keyValue.trim()}
+            >
+              {setKey.isPending ? "Saving…" : "Save"}
+            </Button>
+            <Button
+              size="sm"
+              variant="ghost"
+              onClick={() => {
+                setEditing(false);
+                setKeyValue("");
+              }}
+            >
+              Cancel
+            </Button>
+          </div>
+        </div>
+      ) : (
+        <div className="flex gap-2">
+          <Button
+            size="sm"
+            variant="outline"
+            onClick={() => setEditing(true)}
+            className="gap-1"
+          >
+            <KeyRound className="w-3.5 h-3.5" />
+            {entry?.configured ? "Replace key" : "Add key"}
+          </Button>
+          {entry?.configured && (
+            <Button
+              size="sm"
+              variant="ghost"
+              onClick={handleRemove}
+              disabled={deleteKey.isPending}
+              className="gap-1 text-red-600 hover:text-red-700 hover:bg-red-50 dark:hover:bg-red-950/30"
+            >
+              <Trash2 className="w-3.5 h-3.5" />
+              Remove
+            </Button>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function ShareControls() {
+  const { data: status } = useApiKeyStatus();
+  const { data: shares } = useKeyShares();
+  const grant = useGrantShare();
+  const revoke = useRevokeShare();
+  const { toast } = useToast();
+  const [email, setEmail] = useState("");
+  const [provider, setProvider] = useState<AiProvider>("anthropic");
+
+  const ownHasAnthropic = !!status?.anthropic?.configured;
+  const ownHasGroq = !!status?.groq?.configured;
+  const canShareAny = ownHasAnthropic || ownHasGroq;
+
+  // Default the provider selector to one we can actually share.
+  if (provider === "anthropic" && !ownHasAnthropic && ownHasGroq) {
+    setProvider("groq");
+  } else if (provider === "groq" && !ownHasGroq && ownHasAnthropic) {
+    setProvider("anthropic");
+  }
+
+  const handleGrant = async () => {
+    const trimmed = email.trim();
+    if (!trimmed) return;
+    try {
+      await grant.mutateAsync({ granteeEmail: trimmed, provider });
+      setEmail("");
+      toast({
+        title: `Shared with ${trimmed}`,
+        description: `They can now use your ${provider} key.`,
+        variant: "success",
+      });
+    } catch (err) {
+      toast({
+        title: "Share failed",
+        description: err instanceof Error ? err.message : "Unknown error",
+        variant: "destructive",
+      });
+    }
+  };
+
+  const handleRevoke = async (granteeId: string, p: AiProvider) => {
+    try {
+      await revoke.mutateAsync({ granteeId, provider: p });
+      toast({ title: "Share revoked", variant: "success" });
+    } catch (err) {
+      toast({
+        title: "Revoke failed",
+        description: err instanceof Error ? err.message : "Unknown error",
+        variant: "destructive",
+      });
+    }
+  };
+
+  if (!canShareAny) {
+    return (
+      <p className="text-xs text-muted-foreground">
+        Add a key above to share it with another user.
+      </p>
+    );
+  }
+
+  return (
+    <div className="space-y-3">
+      <div className="space-y-2">
+        <Label htmlFor="share-email" className="text-xs">
+          Share with email
+        </Label>
+        <div className="flex gap-2">
+          <Input
+            id="share-email"
+            type="email"
+            placeholder="user@example.com"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            className="flex-1"
+          />
+          <select
+            value={provider}
+            onChange={(e) => setProvider(e.target.value as AiProvider)}
+            className="h-10 rounded-md border border-input bg-background px-2 text-sm"
+          >
+            {ownHasAnthropic && <option value="anthropic">Anthropic</option>}
+            {ownHasGroq && <option value="groq">Groq</option>}
+          </select>
+          <Button
+            size="sm"
+            onClick={handleGrant}
+            disabled={grant.isPending || !email.trim()}
+            className="gap-1"
+          >
+            <Plus className="w-3.5 h-3.5" />
+            Share
+          </Button>
+        </div>
+        <p className="text-[11px] text-muted-foreground">
+          They must have signed in at least once before you can share.
+        </p>
+      </div>
+
+      {shares && shares.granted.length > 0 && (
+        <div className="space-y-1">
+          <p className="text-xs font-medium">Currently shared:</p>
+          <ul className="space-y-1">
+            {shares.granted.map((g) => (
+              <li
+                key={`${g.granteeId}:${g.provider}`}
+                className="flex items-center justify-between text-xs"
+              >
+                <span className="font-mono truncate">
+                  {g.granteeEmail}
+                  <span className="text-muted-foreground"> · {g.provider}</span>
+                </span>
+                <Button
+                  size="sm"
+                  variant="ghost"
+                  onClick={() => handleRevoke(g.granteeId, g.provider)}
+                  disabled={revoke.isPending}
+                  className="h-7 px-2 text-red-600 hover:text-red-700"
+                >
+                  Revoke
+                </Button>
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function UsageSummary() {
+  const { data, isLoading } = useAiUsage(30);
+  if (isLoading) {
+    return (
+      <p className="text-xs text-muted-foreground">Loading usage…</p>
+    );
+  }
+  if (!data || data.mine.byProvider.length === 0) {
+    return (
+      <p className="text-xs text-muted-foreground">
+        No AI usage in the last {data?.windowDays ?? 30} days.
+      </p>
+    );
+  }
+
+  return (
+    <div className="space-y-2">
+      {data.mine.byProvider.map((p) => (
+        <div key={p.provider} className="text-xs">
+          <p className="font-medium capitalize">{p.provider}</p>
+          <p className="text-muted-foreground">
+            {p.calls} call{p.calls === 1 ? "" : "s"}
+            {p.provider === "anthropic" && (
+              <>
+                {" · "}
+                {p.inputTokens.toLocaleString()} in / {p.outputTokens.toLocaleString()} out tokens
+              </>
+            )}
+            {p.provider === "groq" && p.audioSeconds > 0 && (
+              <>
+                {" · "}
+                {Math.round(p.audioSeconds)} s of audio
+              </>
+            )}
+          </p>
+        </div>
+      ))}
+
+      {data.asGrantor.byGrantee.length > 0 && (
+        <div className="pt-2 border-t">
+          <p className="text-xs font-medium mb-1">Consumption against your shared keys:</p>
+          <ul className="space-y-1">
+            {data.asGrantor.byGrantee.map((g) => (
+              <li
+                key={`${g.granteeId}:${g.provider}`}
+                className="text-xs text-muted-foreground"
+              >
+                <span className="font-mono">{g.granteeEmail}</span> · {g.provider}:{" "}
+                {g.calls} call{g.calls === 1 ? "" : "s"}
+                {g.provider === "anthropic" && (
+                  <>
+                    , {g.inputTokens.toLocaleString()} in / {g.outputTokens.toLocaleString()} out tokens
+                  </>
+                )}
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+    </div>
+  );
+}
+
+export function AiKeysSection() {
+  const { ready, authenticated } = useAuth();
+
+  if (!ready) {
+    return null;
+  }
+
+  if (!authenticated) {
+    return (
+      <div className="space-y-4">
+        <div className="flex items-center gap-2 text-amber-600 dark:text-amber-400">
+          <Sparkles className="w-4 h-4" />
+          <h3 className="font-semibold">AI features</h3>
+        </div>
+        <div className="p-3 rounded-lg border bg-muted/30">
+          <p className="text-sm font-medium">Sign in to manage AI keys</p>
+          <p className="text-xs text-muted-foreground mt-1">
+            Once signed in you can add your own Anthropic and Groq API keys, or
+            use a key someone has shared with you.
+          </p>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-5">
+      <div className="flex items-center gap-2 text-amber-600 dark:text-amber-400">
+        <Sparkles className="w-4 h-4" />
+        <h3 className="font-semibold">AI features</h3>
+      </div>
+
+      <p className="text-xs text-muted-foreground">
+        AI features run through your own provider keys, billed directly by
+        Anthropic and Groq. Add a key below, or use one someone has shared with
+        you. Keys are encrypted at rest on the server.
+      </p>
+
+      <div className="space-y-3">
+        {PROVIDERS.map((p) => (
+          <ProviderCard key={p.id} meta={p} />
+        ))}
+      </div>
+
+      <div className="space-y-2 pt-2 border-t">
+        <div className="flex items-center gap-2">
+          <Share2 className="w-3.5 h-3.5 text-muted-foreground" />
+          <p className="text-sm font-medium">Share your key</p>
+        </div>
+        <ShareControls />
+      </div>
+
+      <div className="space-y-2 pt-2 border-t">
+        <div className="flex items-center gap-2">
+          <Activity className="w-3.5 h-3.5 text-muted-foreground" />
+          <p className="text-sm font-medium">Usage (last 30 days)</p>
+        </div>
+        <UsageSummary />
+      </div>
+    </div>
+  );
+}

--- a/src/components/settings/ai-keys-section.tsx
+++ b/src/components/settings/ai-keys-section.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { Sparkles, Mic, KeyRound, Share2, Activity, Trash2, Plus } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -234,12 +234,15 @@ function ShareControls() {
   const ownHasGroq = !!status?.groq?.configured;
   const canShareAny = ownHasAnthropic || ownHasGroq;
 
-  // Default the provider selector to one we can actually share.
-  if (provider === "anthropic" && !ownHasAnthropic && ownHasGroq) {
-    setProvider("groq");
-  } else if (provider === "groq" && !ownHasGroq && ownHasAnthropic) {
-    setProvider("anthropic");
-  }
+  // Keep the provider selector pointed at a provider we can actually share.
+  // Runs as an effect to avoid setState-during-render warnings.
+  useEffect(() => {
+    if (provider === "anthropic" && !ownHasAnthropic && ownHasGroq) {
+      setProvider("groq");
+    } else if (provider === "groq" && !ownHasGroq && ownHasAnthropic) {
+      setProvider("anthropic");
+    }
+  }, [provider, ownHasAnthropic, ownHasGroq]);
 
   const handleGrant = async () => {
     const trimmed = email.trim();

--- a/src/components/settings/storage-info-section.tsx
+++ b/src/components/settings/storage-info-section.tsx
@@ -1,17 +1,21 @@
 "use client";
 
 import { useState, useEffect } from "react";
-import { HardDrive, Cloud, Upload } from "lucide-react";
+import { useRouter } from "next/navigation";
+import { HardDrive, Cloud, Upload, LogIn } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { useStorageInfo } from "@/hooks/use-storage-info";
 import { useSettingsStore } from "@/stores/settings-store";
 import { useSyncStatusStore } from "@/stores/sync-status-store";
+import { useAuth } from "@/components/auth-guard";
 // eslint-disable-next-line no-restricted-imports
 import { checkInterruptedMigration } from "@/lib/migration-service";
 import { MigrationWizard } from "@/components/migration/migration-wizard";
 
 export function StorageInfoSection() {
+  const router = useRouter();
+  const { ready, authenticated } = useAuth();
   const { storageUsage, storageQuota, totalRecords } = useStorageInfo();
   const storageMode = useSettingsStore((s) => s.storageMode);
   const lastPushedAt = useSyncStatusStore((s) => s.lastPushedAt);
@@ -55,7 +59,23 @@ export function StorageInfoSection() {
           </p>
         )}
 
-        {storageMode === "local" && hasInterrupted && (
+        {storageMode === "local" && ready && !authenticated && (
+          <div className="rounded-lg border bg-muted/30 p-3 space-y-2">
+            <p className="text-xs text-muted-foreground">
+              Sign in to enable cloud sync across your devices.
+            </p>
+            <Button
+              size="sm"
+              className="gap-2"
+              onClick={() => router.push("/auth")}
+            >
+              <LogIn className="h-3 w-3" />
+              Sign In
+            </Button>
+          </div>
+        )}
+
+        {storageMode === "local" && authenticated && hasInterrupted && (
           <Button
             variant="outline"
             size="sm"
@@ -67,7 +87,7 @@ export function StorageInfoSection() {
           </Button>
         )}
 
-        {storageMode === "local" && !hasInterrupted && (
+        {storageMode === "local" && authenticated && !hasInterrupted && (
           <Button
             variant="outline"
             size="sm"

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -1,8 +1,10 @@
 /**
- * Postgres schema — single source of truth for all 20 tables.
+ * Postgres schema — single source of truth for all 23 tables.
  *
- * Mirrors src/lib/db.ts Dexie v15 interfaces exactly (16 app tables) and
- * includes 4 push notification tables that replace scripts/push-migration.sql.
+ * Mirrors src/lib/db.ts Dexie v15 interfaces exactly (16 app tables),
+ * includes 4 push notification tables that replace scripts/push-migration.sql,
+ * and 3 server-only AI tables (user_api_keys, user_key_shares, ai_usage)
+ * that have no Dexie counterpart.
  *
  * Conventions:
  *   - TS property: camelCase (matches Dexie interfaces)

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -34,6 +34,7 @@ import {
   check,
   index,
   uniqueIndex,
+  primaryKey,
 } from "drizzle-orm/pg-core";
 import { sql } from "drizzle-orm";
 
@@ -696,3 +697,105 @@ export const pushSettings = pgTable("push_settings", {
   dayStartHour: integer("day_start_hour").notNull().default(2),
 });
 
+// ─────────────────────────────────────────────────────────────────────────
+// User-supplied AI provider keys.
+//
+// One row per user. Each provider column stores a versioned encrypted blob
+// (see src/lib/key-vault.ts). The `*Last4` columns hold the last 4 plaintext
+// characters for UI display only — never the whole key. Encryption secret
+// lives in API_KEY_ENCRYPTION_SECRET; rotating it invalidates every stored
+// key (users re-enter). KMS migration: add a "v2:" prefix to the blob in
+// the same column.
+// ─────────────────────────────────────────────────────────────────────────
+
+export const userApiKeys = pgTable("user_api_keys", {
+  userId: text("user_id")
+    .primaryKey()
+    .references(() => usersSync.id, { onDelete: "cascade" }),
+  anthropicKeyEncrypted: text("anthropic_key_encrypted"),
+  anthropicLast4: text("anthropic_last4"),
+  groqKeyEncrypted: text("groq_key_encrypted"),
+  groqLast4: text("groq_last4"),
+  createdAt: timestamp("created_at", { withTimezone: true }).defaultNow().notNull(),
+  updatedAt: timestamp("updated_at", { withTimezone: true }).defaultNow().notNull(),
+});
+
+// ─────────────────────────────────────────────────────────────────────────
+// Key sharing — a grantor lets a grantee use the grantor's stored key for a
+// specific provider. Both ids reference users_sync; the composite primary key
+// (grantor, grantee, provider) prevents duplicate grants.
+// ─────────────────────────────────────────────────────────────────────────
+
+export const userKeyShares = pgTable(
+  "user_key_shares",
+  {
+    grantorId: text("grantor_id")
+      .notNull()
+      .references(() => usersSync.id, { onDelete: "cascade" }),
+    granteeId: text("grantee_id")
+      .notNull()
+      .references(() => usersSync.id, { onDelete: "cascade" }),
+    provider: text("provider").notNull(),
+    granteeEmail: text("grantee_email").notNull(),
+    createdAt: timestamp("created_at", { withTimezone: true })
+      .defaultNow()
+      .notNull(),
+  },
+  (t) => ({
+    pk: primaryKey({ columns: [t.grantorId, t.granteeId, t.provider] }),
+    providerCheck: check(
+      "user_key_shares_provider_check",
+      sql`${t.provider} IN ('anthropic','groq')`,
+    ),
+    granteeIdx: index("idx_user_key_shares_grantee").on(t.granteeId, t.provider),
+  }),
+);
+
+// ─────────────────────────────────────────────────────────────────────────
+// AI usage tracking — one row per AI call, fire-and-forget insert after the
+// upstream provider responds. `userId` is the caller; `keyOwnerId` is whose
+// key was used (self, a grantor, or null for the env-var fallback).
+// ─────────────────────────────────────────────────────────────────────────
+
+export const aiUsage = pgTable(
+  "ai_usage",
+  {
+    id: serial("id").primaryKey(),
+    timestamp: timestamp("timestamp", { withTimezone: true })
+      .defaultNow()
+      .notNull(),
+    userId: text("user_id")
+      .notNull()
+      .references(() => usersSync.id, { onDelete: "cascade" }),
+    keyOwnerId: text("key_owner_id").references(() => usersSync.id, {
+      onDelete: "set null",
+    }),
+    keySource: text("key_source").notNull(),
+    provider: text("provider").notNull(),
+    model: text("model").notNull(),
+    route: text("route").notNull(),
+    inputTokens: integer("input_tokens").notNull().default(0),
+    outputTokens: integer("output_tokens").notNull().default(0),
+    cacheReadTokens: integer("cache_read_tokens").notNull().default(0),
+    cacheCreateTokens: integer("cache_create_tokens").notNull().default(0),
+    audioSeconds: integer("audio_seconds"),
+    status: text("status").notNull(),
+    durationMs: integer("duration_ms"),
+  },
+  (t) => ({
+    keySourceCheck: check(
+      "ai_usage_key_source_check",
+      sql`${t.keySource} IN ('own_stored','shared_from','env_var')`,
+    ),
+    providerCheck: check(
+      "ai_usage_provider_check",
+      sql`${t.provider} IN ('anthropic','groq')`,
+    ),
+    statusCheck: check(
+      "ai_usage_status_check",
+      sql`${t.status} IN ('success','error')`,
+    ),
+    userTsIdx: index("idx_ai_usage_user_ts").on(t.userId, t.timestamp),
+    keyOwnerTsIdx: index("idx_ai_usage_owner_ts").on(t.keyOwnerId, t.timestamp),
+  }),
+);

--- a/src/hooks/use-ai-keys.ts
+++ b/src/hooks/use-ai-keys.ts
@@ -1,0 +1,176 @@
+"use client";
+
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { apiFetch } from "@/lib/api-fetch";
+
+export type AiProvider = "anthropic" | "groq";
+
+export interface KeyStatusEntry {
+  configured: boolean;
+  last4: string;
+}
+
+export interface KeyStatus {
+  anthropic: KeyStatusEntry | null;
+  groq: KeyStatusEntry | null;
+}
+
+const KEYS_QUERY_KEY = ["user", "api-keys"] as const;
+const SHARES_QUERY_KEY = ["user", "api-keys", "shares"] as const;
+const USAGE_QUERY_KEY = ["user", "ai-usage"] as const;
+
+async function asJson<T>(res: Response): Promise<T> {
+  if (!res.ok) {
+    const body = await res.json().catch(() => ({ error: res.statusText }));
+    throw new Error(body.error ?? `Request failed: ${res.status}`);
+  }
+  return res.json();
+}
+
+export function useApiKeyStatus() {
+  return useQuery<KeyStatus>({
+    queryKey: KEYS_QUERY_KEY,
+    queryFn: async () => asJson<KeyStatus>(await apiFetch("/api/user/api-keys")),
+  });
+}
+
+export function useSetApiKey() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: async ({ provider, key }: { provider: AiProvider; key: string }) =>
+      asJson<{ configured: true; last4: string }>(
+        await apiFetch("/api/user/api-keys", {
+          method: "PUT",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ provider, key }),
+        }),
+      ),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: KEYS_QUERY_KEY });
+    },
+  });
+}
+
+export function useDeleteApiKey() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: async (provider: AiProvider) =>
+      asJson<{ configured: false }>(
+        await apiFetch(`/api/user/api-keys?provider=${provider}`, {
+          method: "DELETE",
+        }),
+      ),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: KEYS_QUERY_KEY });
+      qc.invalidateQueries({ queryKey: SHARES_QUERY_KEY });
+    },
+  });
+}
+
+export interface KeyShares {
+  granted: Array<{
+    granteeId: string;
+    granteeEmail: string;
+    provider: AiProvider;
+    createdAt: string;
+  }>;
+  received: Array<{
+    grantorEmail: string;
+    provider: AiProvider;
+    createdAt: string;
+  }>;
+}
+
+export function useKeyShares() {
+  return useQuery<KeyShares>({
+    queryKey: SHARES_QUERY_KEY,
+    queryFn: async () =>
+      asJson<KeyShares>(await apiFetch("/api/user/api-keys/shares")),
+  });
+}
+
+export function useGrantShare() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: async ({
+      granteeEmail,
+      provider,
+    }: {
+      granteeEmail: string;
+      provider: AiProvider;
+    }) =>
+      asJson<{ ok: true }>(
+        await apiFetch("/api/user/api-keys/shares", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ granteeEmail, provider }),
+        }),
+      ),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: SHARES_QUERY_KEY });
+    },
+  });
+}
+
+export function useRevokeShare() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: async ({
+      granteeId,
+      provider,
+    }: {
+      granteeId: string;
+      provider: AiProvider;
+    }) =>
+      asJson<{ ok: true }>(
+        await apiFetch(
+          `/api/user/api-keys/shares?granteeId=${encodeURIComponent(granteeId)}&provider=${provider}`,
+          { method: "DELETE" },
+        ),
+      ),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: SHARES_QUERY_KEY });
+    },
+  });
+}
+
+export interface AiUsage {
+  windowDays: number;
+  mine: {
+    byProvider: Array<{
+      provider: AiProvider;
+      calls: number;
+      inputTokens: number;
+      outputTokens: number;
+      cacheReadTokens: number;
+      cacheCreateTokens: number;
+      audioSeconds: number;
+    }>;
+    byRoute: Array<{
+      route: string;
+      provider: AiProvider;
+      calls: number;
+      inputTokens: number;
+      outputTokens: number;
+    }>;
+  };
+  asGrantor: {
+    byGrantee: Array<{
+      granteeId: string;
+      granteeEmail: string;
+      provider: AiProvider;
+      calls: number;
+      inputTokens: number;
+      outputTokens: number;
+      audioSeconds: number;
+    }>;
+  };
+}
+
+export function useAiUsage(days: number = 30) {
+  return useQuery<AiUsage>({
+    queryKey: [...USAGE_QUERY_KEY, days],
+    queryFn: async () =>
+      asJson<AiUsage>(await apiFetch(`/api/user/ai-usage?days=${days}`)),
+  });
+}

--- a/src/lib/__tests__/ai-key-resolver-mock-state.ts
+++ b/src/lib/__tests__/ai-key-resolver-mock-state.ts
@@ -1,0 +1,10 @@
+// Shared state for the ai-key-resolver mock. Lives outside the test file so
+// the hoisted vi.mock factory can import it without a top-level reference
+// error. Test-only helper.
+export const mockState: {
+  rowsByCall: Array<Record<string, unknown>[]>;
+  idx: number;
+} = {
+  rowsByCall: [],
+  idx: 0,
+};

--- a/src/lib/__tests__/ai-key-resolver.test.ts
+++ b/src/lib/__tests__/ai-key-resolver.test.ts
@@ -1,0 +1,180 @@
+/**
+ * Tests the priority chain in ai-key-resolver.
+ *   1. Own stored key.
+ *   2. Shared key from another user.
+ *   3. Env-var key if email is whitelisted.
+ *   4. Otherwise NoAiKeyError.
+ *
+ * Mocks `@/lib/drizzle` so no real database is touched; each test stubs the
+ * select chain to return the rows that simulate the desired DB state.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { randomBytes } from "node:crypto";
+
+// Mock drizzle. The resolver chains: .select().from().where().limit() — and
+// for shares, .select({...}).from().where().limit(). We model both with a
+// single fluent helper that returns whatever the test sets via the shared
+// `mockState` module (hoist-safe: factory references the import directly).
+
+vi.mock("@/lib/__tests__/ai-key-resolver-mock-state", () => ({
+  mockState: { rowsByCall: [] as Array<Record<string, unknown>[]>, idx: 0 },
+}));
+
+vi.mock("@/lib/drizzle", async () => {
+  const { mockState } = await import("@/lib/__tests__/ai-key-resolver-mock-state");
+  return {
+    db: {
+      select: () => ({
+        from: () => ({
+          where: () => ({
+            limit: async () => {
+              const rows = mockState.rowsByCall[mockState.idx] ?? [];
+              mockState.idx += 1;
+              return rows;
+            },
+          }),
+        }),
+      }),
+    },
+  };
+});
+
+import { mockState } from "@/lib/__tests__/ai-key-resolver-mock-state";
+import { resolveAiKey, NoAiKeyError } from "@/lib/ai-key-resolver";
+import { encryptKey } from "@/lib/key-vault";
+
+type MockRow = Record<string, unknown>;
+const mockRowsByCall = mockState.rowsByCall;
+
+const ORIGINAL_ENV = {
+  ALLOWED_EMAILS: process.env.ALLOWED_EMAILS,
+  ANTHROPIC_API_KEY: process.env.ANTHROPIC_API_KEY,
+  GROQ_API_KEY: process.env.GROQ_API_KEY,
+  API_KEY_ENCRYPTION_SECRET: process.env.API_KEY_ENCRYPTION_SECRET,
+};
+
+describe("resolveAiKey priority chain", () => {
+  beforeEach(() => {
+    mockState.rowsByCall.length = 0;
+    mockState.idx = 0;
+    process.env.API_KEY_ENCRYPTION_SECRET = randomBytes(32).toString("base64");
+    delete process.env.ALLOWED_EMAILS;
+    delete process.env.ANTHROPIC_API_KEY;
+    delete process.env.GROQ_API_KEY;
+  });
+
+  afterEach(() => {
+    for (const [k, v] of Object.entries(ORIGINAL_ENV)) {
+      if (v === undefined) delete process.env[k];
+      else process.env[k] = v;
+    }
+  });
+
+  function setOwnRow(userId: string, anthropicPlain?: string, groqPlain?: string) {
+    const row: MockRow = { userId };
+    if (anthropicPlain) {
+      row.anthropicKeyEncrypted = encryptKey(anthropicPlain, {
+        userId,
+        provider: "anthropic",
+      });
+    }
+    if (groqPlain) {
+      row.groqKeyEncrypted = encryptKey(groqPlain, { userId, provider: "groq" });
+    }
+    mockRowsByCall[0] = [row];
+  }
+
+  function setNoOwnRow() {
+    mockRowsByCall[0] = [];
+  }
+
+  function setShareRows(grantorIds: string[]) {
+    mockRowsByCall[1] = grantorIds.map((grantorId) => ({ grantorId }));
+  }
+
+  function setGrantorKey(
+    callOffset: number,
+    grantorId: string,
+    provider: "anthropic" | "groq",
+    plain?: string,
+  ) {
+    mockRowsByCall[callOffset] = plain
+      ? [{ encrypted: encryptKey(plain, { userId: grantorId, provider }) }]
+      : [];
+  }
+
+  it("returns own stored key when present", async () => {
+    setOwnRow("alice", "sk-ant-alice-key");
+    const result = await resolveAiKey("alice", "alice@example.com", "anthropic");
+    expect(result).toEqual({
+      apiKey: "sk-ant-alice-key",
+      source: "own_stored",
+      keyOwnerId: "alice",
+    });
+  });
+
+  it("returns shared key when own key is missing", async () => {
+    setNoOwnRow();
+    setShareRows(["bob"]);
+    setGrantorKey(2, "bob", "anthropic", "sk-ant-bob-shared");
+    const result = await resolveAiKey("alice", "alice@example.com", "anthropic");
+    expect(result).toEqual({
+      apiKey: "sk-ant-bob-shared",
+      source: "shared_from",
+      keyOwnerId: "bob",
+    });
+  });
+
+  it("skips a share whose grantor has no stored key, falls to next", async () => {
+    setNoOwnRow();
+    setShareRows(["bob", "carol"]);
+    setGrantorKey(2, "bob", "anthropic"); // bob has no key
+    setGrantorKey(3, "carol", "anthropic", "sk-ant-carol-key");
+    const result = await resolveAiKey("alice", "alice@example.com", "anthropic");
+    expect(result.apiKey).toBe("sk-ant-carol-key");
+    expect(result.keyOwnerId).toBe("carol");
+  });
+
+  it("falls back to env var only when email is whitelisted", async () => {
+    setNoOwnRow();
+    setShareRows([]);
+    process.env.ANTHROPIC_API_KEY = "sk-ant-env-fallback";
+    process.env.ALLOWED_EMAILS = "alice@example.com,owner@example.com";
+
+    const result = await resolveAiKey("alice", "alice@example.com", "anthropic");
+    expect(result).toEqual({
+      apiKey: "sk-ant-env-fallback",
+      source: "env_var",
+      keyOwnerId: null,
+    });
+  });
+
+  it("throws NoAiKeyError when nothing resolves", async () => {
+    setNoOwnRow();
+    setShareRows([]);
+    process.env.ANTHROPIC_API_KEY = "sk-ant-env-fallback";
+    process.env.ALLOWED_EMAILS = "other@example.com";
+
+    await expect(
+      resolveAiKey("alice", "alice@example.com", "anthropic"),
+    ).rejects.toBeInstanceOf(NoAiKeyError);
+  });
+
+  it("does not fall back to env var when ALLOWED_EMAILS is empty", async () => {
+    setNoOwnRow();
+    setShareRows([]);
+    process.env.ANTHROPIC_API_KEY = "sk-ant-env-fallback";
+    // no ALLOWED_EMAILS — must not use env-var
+
+    await expect(
+      resolveAiKey("alice", "alice@example.com", "anthropic"),
+    ).rejects.toBeInstanceOf(NoAiKeyError);
+  });
+
+  it("resolves Groq independently of Anthropic", async () => {
+    setOwnRow("alice", undefined, "gsk_alice_groq");
+    const result = await resolveAiKey("alice", "alice@example.com", "groq");
+    expect(result.apiKey).toBe("gsk_alice_groq");
+    expect(result.source).toBe("own_stored");
+  });
+});

--- a/src/lib/__tests__/ai-key-resolver.test.ts
+++ b/src/lib/__tests__/ai-key-resolver.test.ts
@@ -22,16 +22,20 @@ vi.mock("@/lib/__tests__/ai-key-resolver-mock-state", () => ({
 
 vi.mock("@/lib/drizzle", async () => {
   const { mockState } = await import("@/lib/__tests__/ai-key-resolver-mock-state");
+  const nextRows = async () => {
+    const rows = mockState.rowsByCall[mockState.idx] ?? [];
+    mockState.idx += 1;
+    return rows;
+  };
   return {
     db: {
       select: () => ({
         from: () => ({
           where: () => ({
-            limit: async () => {
-              const rows = mockState.rowsByCall[mockState.idx] ?? [];
-              mockState.idx += 1;
-              return rows;
-            },
+            // Either `.limit(...)` (own/grantor lookups) or `.orderBy(...)`
+            // (share lookup) terminates the chain and yields the queued rows.
+            limit: nextRows,
+            orderBy: nextRows,
           }),
         }),
       }),
@@ -169,6 +173,26 @@ describe("resolveAiKey priority chain", () => {
     await expect(
       resolveAiKey("alice", "alice@example.com", "anthropic"),
     ).rejects.toBeInstanceOf(NoAiKeyError);
+  });
+
+  it("traverses every share in deterministic order — picks the only grantor with a key even past five entries", async () => {
+    setNoOwnRow();
+    // 8 grantors in DB-returned order; the 7th is the only one with a key.
+    setShareRows(["g1", "g2", "g3", "g4", "g5", "g6", "g7", "g8"]);
+    setGrantorKey(2, "g1", "anthropic");
+    setGrantorKey(3, "g2", "anthropic");
+    setGrantorKey(4, "g3", "anthropic");
+    setGrantorKey(5, "g4", "anthropic");
+    setGrantorKey(6, "g5", "anthropic");
+    setGrantorKey(7, "g6", "anthropic");
+    setGrantorKey(8, "g7", "anthropic", "sk-ant-g7-wins");
+    // g8 not reached, but stub anyway to keep call indices stable.
+    setGrantorKey(9, "g8", "anthropic", "sk-ant-g8-never-used");
+
+    const result = await resolveAiKey("alice", "alice@example.com", "anthropic");
+    expect(result.apiKey).toBe("sk-ant-g7-wins");
+    expect(result.keyOwnerId).toBe("g7");
+    expect(result.source).toBe("shared_from");
   });
 
   it("resolves Groq independently of Anthropic", async () => {

--- a/src/lib/__tests__/key-vault.test.ts
+++ b/src/lib/__tests__/key-vault.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { randomBytes } from "node:crypto";
+import { encryptKey, decryptKey, lastFourOf } from "@/lib/key-vault";
+
+describe("key-vault", () => {
+  let originalSecret: string | undefined;
+
+  beforeAll(() => {
+    originalSecret = process.env.API_KEY_ENCRYPTION_SECRET;
+    process.env.API_KEY_ENCRYPTION_SECRET = randomBytes(32).toString("base64");
+  });
+
+  afterAll(() => {
+    if (originalSecret === undefined) {
+      delete process.env.API_KEY_ENCRYPTION_SECRET;
+    } else {
+      process.env.API_KEY_ENCRYPTION_SECRET = originalSecret;
+    }
+  });
+
+  it("round-trips a plaintext string", () => {
+    const plain = "sk-ant-abc123XYZ";
+    const aad = { userId: "user_42", provider: "anthropic" as const };
+    const blob = encryptKey(plain, aad);
+    expect(blob.startsWith("v1:")).toBe(true);
+    expect(decryptKey(blob, aad)).toBe(plain);
+  });
+
+  it("produces different ciphertext for the same input (random IV)", () => {
+    const aad = { userId: "u", provider: "anthropic" as const };
+    const a = encryptKey("hello", aad);
+    const b = encryptKey("hello", aad);
+    expect(a).not.toBe(b);
+    expect(decryptKey(a, aad)).toBe("hello");
+    expect(decryptKey(b, aad)).toBe("hello");
+  });
+
+  it("fails to decrypt with a different userId (AAD mismatch)", () => {
+    const blob = encryptKey("secret", { userId: "alice", provider: "groq" });
+    expect(() =>
+      decryptKey(blob, { userId: "bob", provider: "groq" }),
+    ).toThrow();
+  });
+
+  it("fails to decrypt with a different provider (AAD mismatch)", () => {
+    const blob = encryptKey("secret", { userId: "alice", provider: "anthropic" });
+    expect(() =>
+      decryptKey(blob, { userId: "alice", provider: "groq" }),
+    ).toThrow();
+  });
+
+  it("rejects malformed blobs", () => {
+    expect(() =>
+      decryptKey("v1:notenough", { userId: "u", provider: "anthropic" }),
+    ).toThrow();
+    expect(() =>
+      decryptKey("v9:foo:bar:baz", { userId: "u", provider: "anthropic" }),
+    ).toThrow(/Unknown key blob version/);
+  });
+
+  it("lastFourOf returns the trailing four chars", () => {
+    expect(lastFourOf("sk-ant-abcd1234")).toBe("1234");
+    expect(lastFourOf("ab")).toBe("ab");
+    expect(lastFourOf("")).toBe("");
+  });
+
+  it("throws when API_KEY_ENCRYPTION_SECRET is unset", () => {
+    const saved = process.env.API_KEY_ENCRYPTION_SECRET;
+    delete process.env.API_KEY_ENCRYPTION_SECRET;
+    try {
+      expect(() =>
+        encryptKey("x", { userId: "u", provider: "anthropic" }),
+      ).toThrow(/API_KEY_ENCRYPTION_SECRET/);
+    } finally {
+      process.env.API_KEY_ENCRYPTION_SECRET = saved;
+    }
+  });
+
+  it("rejects a secret of the wrong length", () => {
+    const saved = process.env.API_KEY_ENCRYPTION_SECRET;
+    process.env.API_KEY_ENCRYPTION_SECRET = "too-short";
+    try {
+      expect(() =>
+        encryptKey("x", { userId: "u", provider: "anthropic" }),
+      ).toThrow(/32 bytes/);
+    } finally {
+      process.env.API_KEY_ENCRYPTION_SECRET = saved;
+    }
+  });
+});

--- a/src/lib/ai-key-resolver.ts
+++ b/src/lib/ai-key-resolver.ts
@@ -13,7 +13,7 @@
  * into usage tracking without re-deriving them.
  */
 
-import { eq, and } from "drizzle-orm";
+import { eq, and, asc } from "drizzle-orm";
 import { db } from "@/lib/drizzle";
 import { userApiKeys, userKeyShares } from "@/db/schema";
 import { decryptKey } from "@/lib/key-vault";
@@ -85,9 +85,10 @@ export async function resolveAiKey(
     };
   }
 
-  // Look for a share granted to this user for this provider. If multiple
-  // grantors exist, pick the first deterministically (createdAt asc) — in
-  // practice a user shouldn't have many concurrent grants.
+  // Look for a share granted to this user for this provider. Ordered by
+  // createdAt asc so selection is deterministic; no LIMIT because a stale
+  // grantor (one without a stored key) would otherwise truncate away a
+  // valid grant further down the list.
   const shareRows = await db
     .select({
       grantorId: userKeyShares.grantorId,
@@ -99,7 +100,7 @@ export async function resolveAiKey(
         eq(userKeyShares.provider, provider),
       ),
     )
-    .limit(5);
+    .orderBy(asc(userKeyShares.createdAt), asc(userKeyShares.grantorId));
 
   for (const { grantorId } of shareRows) {
     const grantorRows = await db

--- a/src/lib/ai-key-resolver.ts
+++ b/src/lib/ai-key-resolver.ts
@@ -1,0 +1,134 @@
+/**
+ * Resolve which API key to use for an AI request.
+ *
+ * Priority, per provider:
+ *   1. The caller's own stored key (user_api_keys row).
+ *   2. A key shared with the caller by another user (user_key_shares row
+ *      pointing at a grantor whose user_api_keys row has the provider set).
+ *   3. The server env-var key, but only if the caller's email is on the
+ *      ALLOWED_EMAILS whitelist (interim shim — lets the owner keep using
+ *      the existing env-var setup without re-entering anything).
+ *
+ * Returns a structured result so callers can pass `keyOwnerId` + `keySource`
+ * into usage tracking without re-deriving them.
+ */
+
+import { eq, and } from "drizzle-orm";
+import { db } from "@/lib/drizzle";
+import { userApiKeys, userKeyShares } from "@/db/schema";
+import { decryptKey } from "@/lib/key-vault";
+
+export type AiProvider = "anthropic" | "groq";
+export type KeySource = "own_stored" | "shared_from" | "env_var";
+
+export interface ResolvedKey {
+  apiKey: string;
+  source: KeySource;
+  /** userId whose stored key was used (null for env-var). */
+  keyOwnerId: string | null;
+}
+
+export class NoAiKeyError extends Error {
+  constructor(public provider: AiProvider) {
+    super(`No ${provider} API key configured for user`);
+    this.name = "NoAiKeyError";
+  }
+}
+
+function getAllowedEmails(): string[] {
+  return (process.env.ALLOWED_EMAILS || "")
+    .split(",")
+    .map((e) => e.trim().toLowerCase())
+    .filter(Boolean);
+}
+
+function envKeyFor(provider: AiProvider): string | undefined {
+  return provider === "anthropic"
+    ? process.env.ANTHROPIC_API_KEY
+    : process.env.GROQ_API_KEY;
+}
+
+function encryptedColumn(provider: AiProvider) {
+  return provider === "anthropic"
+    ? userApiKeys.anthropicKeyEncrypted
+    : userApiKeys.groqKeyEncrypted;
+}
+
+function decryptStored(
+  encrypted: string,
+  ownerId: string,
+  provider: AiProvider,
+): string {
+  return decryptKey(encrypted, { userId: ownerId, provider });
+}
+
+export async function resolveAiKey(
+  userId: string,
+  email: string | undefined,
+  provider: AiProvider,
+): Promise<ResolvedKey> {
+  const ownRows = await db
+    .select()
+    .from(userApiKeys)
+    .where(eq(userApiKeys.userId, userId))
+    .limit(1);
+
+  const own = ownRows[0];
+  const ownEncrypted =
+    provider === "anthropic" ? own?.anthropicKeyEncrypted : own?.groqKeyEncrypted;
+
+  if (own && ownEncrypted) {
+    return {
+      apiKey: decryptStored(ownEncrypted, userId, provider),
+      source: "own_stored",
+      keyOwnerId: userId,
+    };
+  }
+
+  // Look for a share granted to this user for this provider. If multiple
+  // grantors exist, pick the first deterministically (createdAt asc) — in
+  // practice a user shouldn't have many concurrent grants.
+  const shareRows = await db
+    .select({
+      grantorId: userKeyShares.grantorId,
+    })
+    .from(userKeyShares)
+    .where(
+      and(
+        eq(userKeyShares.granteeId, userId),
+        eq(userKeyShares.provider, provider),
+      ),
+    )
+    .limit(5);
+
+  for (const { grantorId } of shareRows) {
+    const grantorRows = await db
+      .select({ encrypted: encryptedColumn(provider) })
+      .from(userApiKeys)
+      .where(eq(userApiKeys.userId, grantorId))
+      .limit(1);
+    const encrypted = grantorRows[0]?.encrypted;
+    if (encrypted) {
+      return {
+        apiKey: decryptStored(encrypted, grantorId, provider),
+        source: "shared_from",
+        keyOwnerId: grantorId,
+      };
+    }
+  }
+
+  // Env-var fallback for whitelisted users (interim).
+  const envKey = envKeyFor(provider);
+  if (envKey && email) {
+    const allowed = getAllowedEmails();
+    if (allowed.length > 0 && allowed.includes(email.toLowerCase())) {
+      return {
+        apiKey: envKey,
+        source: "env_var",
+        keyOwnerId: null,
+      };
+    }
+  }
+
+  throw new NoAiKeyError(provider);
+}

--- a/src/lib/drizzle.ts
+++ b/src/lib/drizzle.ts
@@ -7,7 +7,7 @@
  * via `vi.mock("@/lib/drizzle")` without touching `process.env.DATABASE_URL`.
  *
  * Phase 42 introduced src/db/schema.ts as the single source of truth for all
- * 20 Postgres tables. Phase 43 (sync engine) is the first phase that needs a
+ * 20 Postgres tables (plus 3 AI keys/usage tables added later). Phase 43 (sync engine) is the first phase that needs a
  * runtime Drizzle client — pull/push routes and the sync engine both import
  * `db` from here.
  *

--- a/src/lib/key-vault.ts
+++ b/src/lib/key-vault.ts
@@ -1,0 +1,115 @@
+/**
+ * Symmetric encryption for user-supplied API keys.
+ *
+ * Server-only. Never import from browser bundles.
+ *
+ * Blob format (versioned for future KMS swap):
+ *   v1:<iv-base64>:<tag-base64>:<ct-base64>   — AES-256-GCM, env-var key
+ *   v2:<...>                                  — reserved for KMS envelope
+ *
+ * AAD ("additional authenticated data") binds a blob to its owning user +
+ * provider, so swapping a row from one user to another (or one provider to
+ * another) within the database fails to decrypt rather than silently
+ * succeeding.
+ *
+ * Trust model:
+ *   - Master secret lives in API_KEY_ENCRYPTION_SECRET (hosting provider
+ *     secret manager, not the database).
+ *   - Compromise of Neon alone reveals only ciphertext.
+ *   - Compromise of the hosting platform exposes everything; mitigate later
+ *     by moving to KMS (v2 branch in decrypt).
+ *
+ * Rotation:
+ *   - There is no automatic re-encryption. Rotating
+ *     API_KEY_ENCRYPTION_SECRET invalidates every stored key — users
+ *     re-enter. Acceptable for this app's scale.
+ */
+
+import { createCipheriv, createDecipheriv, randomBytes } from "node:crypto";
+
+const ALGORITHM = "aes-256-gcm";
+const IV_BYTES = 12; // GCM standard
+const KEY_BYTES = 32; // AES-256
+
+function loadMasterKey(): Buffer {
+  const raw = process.env.API_KEY_ENCRYPTION_SECRET;
+  if (!raw) {
+    throw new Error(
+      "API_KEY_ENCRYPTION_SECRET is not set — cannot encrypt or decrypt user API keys",
+    );
+  }
+
+  // Accept base64 or hex; both are common ways to express 32 random bytes.
+  let buf: Buffer;
+  if (/^[0-9a-fA-F]+$/.test(raw) && raw.length === 64) {
+    buf = Buffer.from(raw, "hex");
+  } else {
+    buf = Buffer.from(raw, "base64");
+  }
+
+  if (buf.length !== KEY_BYTES) {
+    throw new Error(
+      `API_KEY_ENCRYPTION_SECRET must decode to ${KEY_BYTES} bytes (got ${buf.length}). ` +
+        `Generate with: openssl rand -base64 32`,
+    );
+  }
+  return buf;
+}
+
+export interface KeyVaultAad {
+  userId: string;
+  provider: "anthropic" | "groq";
+}
+
+function aadBytes({ userId, provider }: KeyVaultAad): Buffer {
+  return Buffer.from(`${userId}:${provider}`, "utf8");
+}
+
+export function encryptKey(plaintext: string, aad: KeyVaultAad): string {
+  if (!plaintext) throw new Error("Cannot encrypt empty plaintext");
+  const key = loadMasterKey();
+  const iv = randomBytes(IV_BYTES);
+  const cipher = createCipheriv(ALGORITHM, key, iv);
+  cipher.setAAD(aadBytes(aad));
+  const ct = Buffer.concat([
+    cipher.update(plaintext, "utf8"),
+    cipher.final(),
+  ]);
+  const tag = cipher.getAuthTag();
+  return `v1:${iv.toString("base64")}:${tag.toString("base64")}:${ct.toString("base64")}`;
+}
+
+export function decryptKey(blob: string, aad: KeyVaultAad): string {
+  if (!blob) throw new Error("Cannot decrypt empty blob");
+
+  if (blob.startsWith("v1:")) {
+    const [, ivB64, tagB64, ctB64] = blob.split(":");
+    if (!ivB64 || !tagB64 || !ctB64) {
+      throw new Error("Malformed v1 blob");
+    }
+    const key = loadMasterKey();
+    const iv = Buffer.from(ivB64, "base64");
+    const tag = Buffer.from(tagB64, "base64");
+    const ct = Buffer.from(ctB64, "base64");
+    const decipher = createDecipheriv(ALGORITHM, key, iv);
+    decipher.setAAD(aadBytes(aad));
+    decipher.setAuthTag(tag);
+    const pt = Buffer.concat([decipher.update(ct), decipher.final()]);
+    return pt.toString("utf8");
+  }
+
+  if (blob.startsWith("v2:")) {
+    throw new Error("v2 (KMS) decryption not yet implemented");
+  }
+
+  throw new Error("Unknown key blob version");
+}
+
+/**
+ * Pull the last 4 characters for UI display (e.g. "••••••AB12"). Never
+ * returns more than 4 characters; callers should never store more.
+ */
+export function lastFourOf(plaintext: string): string {
+  if (!plaintext) return "";
+  return plaintext.slice(-4);
+}


### PR DESCRIPTION
## Summary

Implements a complete system for users to supply and manage their own AI provider API keys (Anthropic, Groq), share keys with other users, and track AI usage across the application. This replaces reliance on server environment variables with a user-controlled, encrypted key vault.

## Key Changes

**Database & Schema**
- Added three new tables to `src/db/schema.ts`:
  - `userApiKeys` — stores encrypted API keys per user/provider with last-4 plaintext for UI display
  - `userKeyShares` — tracks which users have granted their keys to other users
  - `aiUsage` — logs all AI API calls with token counts, route, and key source for billing/analytics
- Added Drizzle migration `0004_regular_thundra.sql`

**Key Encryption & Resolution**
- `src/lib/key-vault.ts` — AES-256-GCM symmetric encryption for stored keys using `API_KEY_ENCRYPTION_SECRET` env var; includes AAD binding to user+provider to prevent key swapping
- `src/lib/ai-key-resolver.ts` — Priority-based key resolution: own stored key → shared key from another user → env-var key (if email whitelisted) → error
- Returns structured `ResolvedKey` with source tracking for usage logging

**API Routes**
- `GET/PUT/DELETE /api/user/api-keys` — manage user's own stored keys (validation, encryption, last-4 extraction)
- `GET/POST/DELETE /api/user/api-keys/shares` — grant/revoke key access to other users by email
- `GET /api/user/ai-usage` — retrieve usage stats (mine vs. as grantor) with configurable time window

**Usage Tracking**
- `src/app/api/ai/_shared/usage-tracker.ts` — fire-and-forget logging of AI calls (userId, keyOwnerId, keySource, provider, tokens, route)
- Integrated into all AI routes (parse, medicine-search, substance-lookup, voice-transcribe, etc.)

**UI Components**
- `src/components/settings/ai-keys-section.tsx` — settings panel for adding/removing keys, viewing status, granting/revoking shares, and viewing usage stats
- Integrated into `/settings` page with provider cards (Anthropic, Groq) showing configuration status and usage

**Client Hooks**
- `src/hooks/use-ai-keys.ts` — React Query hooks for key status, setting/deleting keys, managing shares, and fetching usage data

**Error Handling**
- `src/app/api/ai/_shared/ai-error-response.ts` — translates key resolution and provider errors into user-facing responses

**Tests**
- `src/lib/__tests__/key-vault.test.ts` — encryption/decryption round-trip and last-4 extraction
- `src/lib/__tests__/ai-key-resolver.test.ts` — priority chain resolution with mocked database state

**Modified AI Routes**
- Updated all AI endpoints (parse, medicine-search, substance-lookup, voice-transcribe, voice-parse, interaction-check, titration-warnings) to use `resolveAiKey()` and `recordUsage()` instead of direct env-var access

**Environment**
- Updated `.env.template` to document new `API_KEY_ENCRYPTION_SECRET` and deprecate direct `ANTHROPIC_API_KEY` / `GROQ_API_KEY` (still supported as fallback for whitelisted emails)

## Implementation Details

- **Encryption versioning:** Blob format `v1:<iv>:<tag>:<ciphertext>` allows future KMS migration (v2 branch)
- **AAD binding:** Prevents accidental key reuse across users/providers by including userId+provider in authenticated data
- **Fire-and-forget logging:** Usage records are logged asynchronously without blocking AI responses; lost rows on crash are acceptable
- **Backward compatibility:** Env-var keys still work for whitelisted emails during transition period
- **Share model:** Grantor's key is decrypted server-side and used on behalf of grantee; grantee never sees plaintext

https://claude.ai/code/session_01GEbcSb8FE2arwhco51vQ9U

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Users can now manage and store personal API keys for Anthropic and Groq providers.
  * Added ability to share API keys with other users.
  * New AI usage statistics dashboard showing token usage and request metrics over configurable time periods.
  * Updated settings interface with dedicated "AI features" section for key management and sharing controls.

* **Bug Fixes**
  * Improved error responses when AI provider keys are unavailable or misconfigured.

* **Chores**
  * Added database schema for encrypted key storage, sharing records, and usage tracking.
  * Updated environment configuration documentation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/RyRy79261/intake-tracker/pull/84?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->