### PR TITLE
Align blood pressure classification with AHA/ACC 2025 guideline

### DIFF
--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -43,22 +43,25 @@ export interface BPCategory {
 }
 
 /**
- * Classify a blood-pressure reading per the AHA/ACC 2025 guideline.
- * Categories are evaluated highest-first; each threshold is OR-based, so the
- * worse of the two numbers determines the category (a normal systolic does
- * not cancel out a high diastolic).
+ * Classify a blood-pressure reading per the ESH 2023 / 2018 ESC-ESH office BP
+ * classification — the same scale Withings BPM devices use in Europe.
+ * Categories are evaluated highest-first; each threshold is OR-based, so
+ * whichever of systolic/diastolic falls in the higher band sets the category
+ * (a normal systolic does not cancel out a high diastolic).
  */
 export function getBPCategory(systolic: number, diastolic: number): BPCategory {
-  if (systolic > 180 || diastolic > 120) {
-    return { label: "Hypertensive Crisis", color: "text-red-700 dark:text-red-300" };
+  if (systolic >= 180 || diastolic >= 110) {
+    return { label: "Grade 3 hypertension", color: "text-red-700 dark:text-red-300" };
+  } else if (systolic >= 160 || diastolic >= 100) {
+    return { label: "Grade 2 hypertension", color: "text-red-600 dark:text-red-400" };
   } else if (systolic >= 140 || diastolic >= 90) {
-    return { label: "Hypertension Stage 2", color: "text-red-600 dark:text-red-400" };
-  } else if (systolic >= 130 || diastolic >= 80) {
-    return { label: "Hypertension Stage 1", color: "text-orange-600 dark:text-orange-400" };
-  } else if (systolic >= 120) {
-    return { label: "Elevated", color: "text-yellow-600 dark:text-yellow-400" };
+    return { label: "Grade 1 hypertension", color: "text-orange-600 dark:text-orange-400" };
+  } else if (systolic >= 130 || diastolic >= 85) {
+    return { label: "High normal", color: "text-yellow-600 dark:text-yellow-400" };
+  } else if (systolic >= 120 || diastolic >= 80) {
+    return { label: "Normal", color: "text-lime-600 dark:text-lime-400" };
   } else {
-    return { label: "Normal", color: "text-green-600 dark:text-green-400" };
+    return { label: "Optimal", color: "text-green-600 dark:text-green-400" };
   }
 }
 

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -43,17 +43,22 @@ export interface BPCategory {
 }
 
 /**
- * Classify a blood-pressure reading according to AHA guidelines.
+ * Classify a blood-pressure reading per the AHA/ACC 2025 guideline.
+ * Categories are evaluated highest-first; each threshold is OR-based, so the
+ * worse of the two numbers determines the category (a normal systolic does
+ * not cancel out a high diastolic).
  */
 export function getBPCategory(systolic: number, diastolic: number): BPCategory {
-  if (systolic < 120 && diastolic < 80) {
-    return { label: "Normal", color: "text-green-600 dark:text-green-400" };
-  } else if (systolic < 130 && diastolic < 80) {
+  if (systolic > 180 || diastolic > 120) {
+    return { label: "Hypertensive Crisis", color: "text-red-700 dark:text-red-300" };
+  } else if (systolic >= 140 || diastolic >= 90) {
+    return { label: "Hypertension Stage 2", color: "text-red-600 dark:text-red-400" };
+  } else if (systolic >= 130 || diastolic >= 80) {
+    return { label: "Hypertension Stage 1", color: "text-orange-600 dark:text-orange-400" };
+  } else if (systolic >= 120) {
     return { label: "Elevated", color: "text-yellow-600 dark:text-yellow-400" };
-  } else if (systolic < 140 && diastolic < 90) {
-    return { label: "High Stage 1", color: "text-orange-600 dark:text-orange-400" };
   } else {
-    return { label: "High Stage 2", color: "text-red-600 dark:text-red-400" };
+    return { label: "Normal", color: "text-green-600 dark:text-green-400" };
   }
 }
 


### PR DESCRIPTION
Use standard category names (Hypertension Stage 1/2) and add the
Hypertensive Crisis category for readings above 180/120. Switch the
threshold checks to OR-based logic so the higher of systolic/diastolic
determines the category, matching how home and clinical BP devices label
the same readings.

https://claude.ai/code/session_019eEQB98eNbuRK3G2ZvnE4m

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**Enhancement**
* Updated blood pressure classification to use the ESH 2023/2018 ESC-ESH office BP classification standard. Blood pressure readings are now categorized into six levels—Optimal, Normal, High Normal, and three Grade levels—aligned with Withings BPM device classifications for consistent results.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/RyRy79261/intake-tracker/pull/91?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->