### PR TITLE
fix: dose counter shows full daily total regardless of time

### DIFF
--- a/src/lib/medication-ui-utils.ts
+++ b/src/lib/medication-ui-utils.ts
@@ -48,7 +48,8 @@ export function hapticSkip(): void {
 
 /**
  * Compute progress from a DoseSlot array.
- * Only counts slots up to the current time (plus any future slots already actioned).
+ * Counts every scheduled slot for the day so the total reflects the full
+ * daily dose count regardless of notification batching or time of day.
  */
 export function computeProgress(slots: DoseSlot[]): {
   total: number;
@@ -58,26 +59,16 @@ export function computeProgress(slots: DoseSlot[]): {
   pct: number;
   allDone: boolean;
 } {
-  const now = new Date();
-  const nowMinutes = now.getHours() * 60 + now.getMinutes();
-
   let total = 0;
   let taken = 0;
   let skipped = 0;
   let pending = 0;
 
   for (const slot of slots) {
-    const parts = slot.localTime.split(":").map(Number);
-    const slotMinutes = (parts[0] ?? 0) * 60 + (parts[1] ?? 0);
-    const isFutureSlot = slotMinutes > nowMinutes;
-
-    // Count if slot is in the past/now, OR if a future slot was already actioned
-    if (!isFutureSlot || slot.status === "taken" || slot.status === "skipped") {
-      total++;
-      if (slot.status === "taken") taken++;
-      else if (slot.status === "skipped") skipped++;
-      else pending++;
-    }
+    total++;
+    if (slot.status === "taken") taken++;
+    else if (slot.status === "skipped") skipped++;
+    else pending++;
   }
 
   const handled = taken + skipped;


### PR DESCRIPTION
The dose progress counter only counted slots up to the current time
(plus future slots already actioned), causing the total to step up as
notification batches arrived (0/0 → 6/6 → 10/10) instead of reflecting
all scheduled doses for the day. computeProgress now counts every slot
returned by getDailyDoseSchedule, which already scopes to the given day.

Fixes #95

https://claude.ai/code/session_01PapHJBC8ArUWhzA5LMRh9d

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * Modified medication progress tracking to count all scheduled doses for the day, removing time-based filtering from progress calculations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/RyRy79261/intake-tracker/pull/97?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->