### PR TITLE
feat: add shake gesture to open the bug report dialog

### DIFF
--- a/src/app/providers.tsx
+++ b/src/app/providers.tsx
@@ -11,6 +11,7 @@ import { queryClient } from "@/lib/query-client";
 import { SyncLifecycleMount } from "@/components/sync/sync-lifecycle-mount";
 import { SyncErrorBanner } from "@/components/sync/sync-error-banner";
 import { MigrationGuard } from "@/components/migration/migration-guard";
+import { ShakeToReport } from "@/components/shake-to-report";
 
 /**
  * Simplified provider stack (D-27). Privy wrappers and the PIN gate
@@ -82,6 +83,7 @@ export function Providers({ children }: { children: React.ReactNode }) {
             <SyncLifecycleMount />
             <SyncErrorBanner />
             <MigrationGuard />
+            <ShakeToReport />
           </TimezoneGuard>
         </ThemeProvider>
       </QueryClientProvider>

--- a/src/components/settings/report-bug-section.tsx
+++ b/src/components/settings/report-bug-section.tsx
@@ -1,18 +1,37 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { Bug, Smartphone } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Switch } from "@/components/ui/switch";
+import { Label } from "@/components/ui/label";
+import { NumericInput } from "@/components/ui/numeric-input";
 import { ReportBugDialog } from "@/components/report-bug-dialog";
 import { useSettings } from "@/hooks/use-settings";
 import { useToast } from "@/hooks/use-toast";
 import { requestMotionPermission } from "@/hooks/use-shake-gesture";
+import {
+  validateAndSave,
+  incrementSetting,
+  decrementSetting,
+} from "@/lib/settings-helpers";
 
 export function ReportBugSection() {
   const [open, setOpen] = useState(false);
   const settings = useSettings();
   const { toast } = useToast();
+
+  const [thresholdInput, setThresholdInput] = useState(
+    settings.shakeThreshold.toString(),
+  );
+  const [joltsInput, setJoltsInput] = useState(
+    settings.shakeRequiredJolts.toString(),
+  );
+
+  useEffect(() => {
+    setThresholdInput(settings.shakeThreshold.toString());
+    setJoltsInput(settings.shakeRequiredJolts.toString());
+  }, [settings.shakeThreshold, settings.shakeRequiredJolts]);
 
   const handleShakeToggle = async (checked: boolean) => {
     if (!checked) {
@@ -64,6 +83,98 @@ export function ReportBugSection() {
             onCheckedChange={handleShakeToggle}
           />
         </div>
+
+        {settings.shakeToReportEnabled && (
+          <>
+            <div className="space-y-2">
+              <Label htmlFor="shake-threshold">Shake sensitivity</Label>
+              <NumericInput
+                id="shake-threshold"
+                value={thresholdInput}
+                onChange={setThresholdInput}
+                onBlur={() =>
+                  validateAndSave(
+                    thresholdInput,
+                    8,
+                    40,
+                    settings.shakeThreshold,
+                    settings.setShakeThreshold,
+                    setThresholdInput,
+                  )
+                }
+                min={8}
+                max={40}
+                step={1}
+                onIncrement={() =>
+                  incrementSetting(
+                    settings.shakeThreshold,
+                    1,
+                    40,
+                    settings.setShakeThreshold,
+                    setThresholdInput,
+                  )
+                }
+                onDecrement={() =>
+                  decrementSetting(
+                    settings.shakeThreshold,
+                    1,
+                    8,
+                    settings.setShakeThreshold,
+                    setThresholdInput,
+                  )
+                }
+              />
+              <p className="text-xs text-muted-foreground">
+                Jolt strength needed to register a shake (8-40). Lower = more
+                sensitive.
+              </p>
+            </div>
+
+            <div className="space-y-2">
+              <Label htmlFor="shake-jolts">Jolts required</Label>
+              <NumericInput
+                id="shake-jolts"
+                value={joltsInput}
+                onChange={setJoltsInput}
+                onBlur={() =>
+                  validateAndSave(
+                    joltsInput,
+                    2,
+                    8,
+                    settings.shakeRequiredJolts,
+                    settings.setShakeRequiredJolts,
+                    setJoltsInput,
+                  )
+                }
+                min={2}
+                max={8}
+                step={1}
+                onIncrement={() =>
+                  incrementSetting(
+                    settings.shakeRequiredJolts,
+                    1,
+                    8,
+                    settings.setShakeRequiredJolts,
+                    setJoltsInput,
+                  )
+                }
+                onDecrement={() =>
+                  decrementSetting(
+                    settings.shakeRequiredJolts,
+                    1,
+                    2,
+                    settings.setShakeRequiredJolts,
+                    setJoltsInput,
+                  )
+                }
+              />
+              <p className="text-xs text-muted-foreground">
+                How many jolts within ~0.8s open the dialog (2-8). Higher =
+                fewer accidental triggers.
+              </p>
+            </div>
+          </>
+        )}
       </div>
       <ReportBugDialog open={open} onOpenChange={setOpen} />
     </div>

--- a/src/components/settings/report-bug-section.tsx
+++ b/src/components/settings/report-bug-section.tsx
@@ -1,12 +1,13 @@
 "use client";
 
 import { useState, useEffect } from "react";
-import { Bug, Smartphone } from "lucide-react";
+import { Bug, Smartphone, SlidersHorizontal } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Switch } from "@/components/ui/switch";
 import { Label } from "@/components/ui/label";
 import { NumericInput } from "@/components/ui/numeric-input";
 import { ReportBugDialog } from "@/components/report-bug-dialog";
+import { ExpandableSettingsSection } from "@/components/settings/expandable-settings-section";
 import { useSettings } from "@/hooks/use-settings";
 import { useToast } from "@/hooks/use-toast";
 import { requestMotionPermission } from "@/hooks/use-shake-gesture";
@@ -85,95 +86,101 @@ export function ReportBugSection() {
         </div>
 
         {settings.shakeToReportEnabled && (
-          <>
-            <div className="space-y-2">
-              <Label htmlFor="shake-threshold">Shake sensitivity</Label>
-              <NumericInput
-                id="shake-threshold"
-                value={thresholdInput}
-                onChange={setThresholdInput}
-                onBlur={() =>
-                  validateAndSave(
-                    thresholdInput,
-                    8,
-                    40,
-                    settings.shakeThreshold,
-                    settings.setShakeThreshold,
-                    setThresholdInput,
-                  )
-                }
-                min={8}
-                max={40}
-                step={1}
-                onIncrement={() =>
-                  incrementSetting(
-                    settings.shakeThreshold,
-                    1,
-                    40,
-                    settings.setShakeThreshold,
-                    setThresholdInput,
-                  )
-                }
-                onDecrement={() =>
-                  decrementSetting(
-                    settings.shakeThreshold,
-                    1,
-                    8,
-                    settings.setShakeThreshold,
-                    setThresholdInput,
-                  )
-                }
-              />
-              <p className="text-xs text-muted-foreground">
-                Jolt strength needed to register a shake (8-40). Lower = more
-                sensitive.
-              </p>
-            </div>
+          <ExpandableSettingsSection
+            icon={SlidersHorizontal}
+            label="Shake sensitivity"
+            iconColorClass="text-rose-600 dark:text-rose-400"
+          >
+            <div className="space-y-3">
+              <div className="space-y-2">
+                <Label htmlFor="shake-threshold">Jolt threshold</Label>
+                <NumericInput
+                  id="shake-threshold"
+                  value={thresholdInput}
+                  onChange={setThresholdInput}
+                  onBlur={() =>
+                    validateAndSave(
+                      thresholdInput,
+                      8,
+                      40,
+                      settings.shakeThreshold,
+                      settings.setShakeThreshold,
+                      setThresholdInput,
+                    )
+                  }
+                  min={8}
+                  max={40}
+                  step={1}
+                  onIncrement={() =>
+                    incrementSetting(
+                      settings.shakeThreshold,
+                      1,
+                      40,
+                      settings.setShakeThreshold,
+                      setThresholdInput,
+                    )
+                  }
+                  onDecrement={() =>
+                    decrementSetting(
+                      settings.shakeThreshold,
+                      1,
+                      8,
+                      settings.setShakeThreshold,
+                      setThresholdInput,
+                    )
+                  }
+                />
+                <p className="text-xs text-muted-foreground">
+                  Jolt strength needed to register a shake (8-40). Lower = more
+                  sensitive.
+                </p>
+              </div>
 
-            <div className="space-y-2">
-              <Label htmlFor="shake-jolts">Jolts required</Label>
-              <NumericInput
-                id="shake-jolts"
-                value={joltsInput}
-                onChange={setJoltsInput}
-                onBlur={() =>
-                  validateAndSave(
-                    joltsInput,
-                    2,
-                    8,
-                    settings.shakeRequiredJolts,
-                    settings.setShakeRequiredJolts,
-                    setJoltsInput,
-                  )
-                }
-                min={2}
-                max={8}
-                step={1}
-                onIncrement={() =>
-                  incrementSetting(
-                    settings.shakeRequiredJolts,
-                    1,
-                    8,
-                    settings.setShakeRequiredJolts,
-                    setJoltsInput,
-                  )
-                }
-                onDecrement={() =>
-                  decrementSetting(
-                    settings.shakeRequiredJolts,
-                    1,
-                    2,
-                    settings.setShakeRequiredJolts,
-                    setJoltsInput,
-                  )
-                }
-              />
-              <p className="text-xs text-muted-foreground">
-                How many jolts within ~0.8s open the dialog (2-8). Higher =
-                fewer accidental triggers.
-              </p>
+              <div className="space-y-2">
+                <Label htmlFor="shake-jolts">Jolts required</Label>
+                <NumericInput
+                  id="shake-jolts"
+                  value={joltsInput}
+                  onChange={setJoltsInput}
+                  onBlur={() =>
+                    validateAndSave(
+                      joltsInput,
+                      2,
+                      8,
+                      settings.shakeRequiredJolts,
+                      settings.setShakeRequiredJolts,
+                      setJoltsInput,
+                    )
+                  }
+                  min={2}
+                  max={8}
+                  step={1}
+                  onIncrement={() =>
+                    incrementSetting(
+                      settings.shakeRequiredJolts,
+                      1,
+                      8,
+                      settings.setShakeRequiredJolts,
+                      setJoltsInput,
+                    )
+                  }
+                  onDecrement={() =>
+                    decrementSetting(
+                      settings.shakeRequiredJolts,
+                      1,
+                      2,
+                      settings.setShakeRequiredJolts,
+                      setJoltsInput,
+                    )
+                  }
+                />
+                <p className="text-xs text-muted-foreground">
+                  How many jolts within ~0.8s open the dialog (2-8). Higher =
+                  fewer accidental triggers.
+                </p>
+              </div>
             </div>
-          </>
+          </ExpandableSettingsSection>
         )}
       </div>
       <ReportBugDialog open={open} onOpenChange={setOpen} />

--- a/src/components/settings/report-bug-section.tsx
+++ b/src/components/settings/report-bug-section.tsx
@@ -1,12 +1,36 @@
 "use client";
 
 import { useState } from "react";
-import { Bug } from "lucide-react";
+import { Bug, Smartphone } from "lucide-react";
 import { Button } from "@/components/ui/button";
+import { Switch } from "@/components/ui/switch";
 import { ReportBugDialog } from "@/components/report-bug-dialog";
+import { useSettings } from "@/hooks/use-settings";
+import { useToast } from "@/hooks/use-toast";
+import { requestMotionPermission } from "@/hooks/use-shake-gesture";
 
 export function ReportBugSection() {
   const [open, setOpen] = useState(false);
+  const settings = useSettings();
+  const { toast } = useToast();
+
+  const handleShakeToggle = async (checked: boolean) => {
+    if (!checked) {
+      settings.setShakeToReportEnabled(false);
+      return;
+    }
+    const result = await requestMotionPermission();
+    if (result === "denied") {
+      toast({
+        title: "Motion access blocked",
+        description:
+          "Allow motion & orientation access for this site to use shake-to-report.",
+        variant: "destructive",
+      });
+      return;
+    }
+    settings.setShakeToReportEnabled(true);
+  };
 
   return (
     <div className="space-y-4">
@@ -24,6 +48,22 @@ export function ReportBugSection() {
           <Bug className="h-4 w-4" />
           Report a bug
         </Button>
+
+        <div className="flex items-center justify-between gap-3 pt-1">
+          <div className="space-y-0.5">
+            <p className="flex items-center gap-1.5 text-sm font-medium">
+              <Smartphone className="h-3.5 w-3.5" />
+              Shake to report
+            </p>
+            <p className="text-xs text-muted-foreground">
+              Give your device a shake to open this dialog from anywhere.
+            </p>
+          </div>
+          <Switch
+            checked={settings.shakeToReportEnabled}
+            onCheckedChange={handleShakeToggle}
+          />
+        </div>
       </div>
       <ReportBugDialog open={open} onOpenChange={setOpen} />
     </div>

--- a/src/components/settings/report-bug-section.tsx
+++ b/src/components/settings/report-bug-section.tsx
@@ -101,21 +101,21 @@ export function ReportBugSection() {
                   onBlur={() =>
                     validateAndSave(
                       thresholdInput,
-                      8,
-                      40,
+                      4,
+                      20,
                       settings.shakeThreshold,
                       settings.setShakeThreshold,
                       setThresholdInput,
                     )
                   }
-                  min={8}
-                  max={40}
+                  min={4}
+                  max={20}
                   step={1}
                   onIncrement={() =>
                     incrementSetting(
                       settings.shakeThreshold,
                       1,
-                      40,
+                      20,
                       settings.setShakeThreshold,
                       setThresholdInput,
                     )
@@ -124,15 +124,15 @@ export function ReportBugSection() {
                     decrementSetting(
                       settings.shakeThreshold,
                       1,
-                      8,
+                      4,
                       settings.setShakeThreshold,
                       setThresholdInput,
                     )
                   }
                 />
                 <p className="text-xs text-muted-foreground">
-                  Jolt strength needed to register a shake (8-40). Lower = more
-                  sensitive.
+                  Movement strength needed to register a shake (4-20). Lower =
+                  more sensitive.
                 </p>
               </div>
 

--- a/src/components/shake-to-report.tsx
+++ b/src/components/shake-to-report.tsx
@@ -11,11 +11,15 @@ import { ReportBugDialog } from "@/components/report-bug-dialog";
  */
 export function ShakeToReport() {
   const enabled = useSettingsStore((s) => s.shakeToReportEnabled);
+  const threshold = useSettingsStore((s) => s.shakeThreshold);
+  const requiredJolts = useSettingsStore((s) => s.shakeRequiredJolts);
   const [open, setOpen] = useState(false);
 
   useShakeGesture({
     enabled: enabled && !open,
     onShake: () => setOpen(true),
+    threshold,
+    requiredJolts,
   });
 
   if (!enabled && !open) return null;

--- a/src/components/shake-to-report.tsx
+++ b/src/components/shake-to-report.tsx
@@ -1,0 +1,24 @@
+"use client";
+
+import { useState } from "react";
+import { useSettingsStore } from "@/stores/settings-store";
+import { useShakeGesture } from "@/hooks/use-shake-gesture";
+import { ReportBugDialog } from "@/components/report-bug-dialog";
+
+/**
+ * Mounted once globally. Shaking the device opens the bug-report / feature-
+ * request dialog. Shake detection pauses while the dialog is already open.
+ */
+export function ShakeToReport() {
+  const enabled = useSettingsStore((s) => s.shakeToReportEnabled);
+  const [open, setOpen] = useState(false);
+
+  useShakeGesture({
+    enabled: enabled && !open,
+    onShake: () => setOpen(true),
+  });
+
+  if (!enabled && !open) return null;
+
+  return <ReportBugDialog open={open} onOpenChange={setOpen} defaultType="bug" />;
+}

--- a/src/components/shake-to-report.tsx
+++ b/src/components/shake-to-report.tsx
@@ -1,8 +1,12 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { useSettingsStore } from "@/stores/settings-store";
-import { useShakeGesture } from "@/hooks/use-shake-gesture";
+import {
+  useShakeGesture,
+  requestMotionPermission,
+  motionPermissionNeeded,
+} from "@/hooks/use-shake-gesture";
 import { ReportBugDialog } from "@/components/report-bug-dialog";
 
 /**
@@ -21,6 +25,19 @@ export function ShakeToReport() {
     threshold,
     requiredJolts,
   });
+
+  // iOS 13+ gates `devicemotion` behind a permission prompt that must be
+  // triggered by a user gesture. The settings toggle requests it on an
+  // explicit opt-in, but the feature also ships enabled by default — so on
+  // iOS we request it once on the first interaction after the app loads.
+  useEffect(() => {
+    if (!enabled || !motionPermissionNeeded()) return;
+    const onFirstGesture = () => {
+      void requestMotionPermission();
+    };
+    window.addEventListener("pointerdown", onFirstGesture, { once: true });
+    return () => window.removeEventListener("pointerdown", onFirstGesture);
+  }, [enabled]);
 
   if (!enabled && !open) return null;
 

--- a/src/hooks/use-shake-gesture.test.ts
+++ b/src/hooks/use-shake-gesture.test.ts
@@ -6,17 +6,17 @@ import {
 } from "@/hooks/use-shake-gesture";
 
 const BASE: ShakeDetectorConfig = {
-  threshold: 15,
+  threshold: 8,
   requiredJolts: 3,
   windowMs: 800,
   cooldownMs: 3000,
 };
 
 /**
- * Feed the detector an alternating sample at each timestamp. Consecutive
- * samples differ by `delta` on the x-axis, so every transition registers a
- * jolt when `delta` exceeds the configured threshold. Returns the timestamps
- * at which a shake was detected.
+ * Feed the detector an alternating sample at each timestamp. Samples alternate
+ * between magnitude 0 and magnitude `delta` on the x-axis, so every transition
+ * changes the acceleration magnitude by `delta` and registers a jolt when that
+ * exceeds the threshold. Returns the timestamps at which a shake was detected.
  */
 function run(
   config: ShakeDetectorConfig,
@@ -73,5 +73,28 @@ describe("createShakeDetector", () => {
       3200, 3260, 3320, // cooldown elapsed -> fires again
     ]);
     expect(triggers).toEqual([180, 3320]);
+  });
+
+  it("ignores reorientation that keeps total acceleration constant", () => {
+    // Gravity (~9.8 m/s²) redistributing across the axes as the device is
+    // tilted: every sample has the same magnitude but different per-axis
+    // values. A per-axis delta would read this as a violent shake; the
+    // magnitude-based detector correctly sees no movement.
+    const detector = createShakeDetector({ ...BASE, threshold: 4 });
+    const G = 9.8;
+    const D = G / Math.SQRT2; // ~6.93 — keeps magnitude at G
+    const rotations: ShakeSample[] = [
+      { x: G, y: 0, z: 0 },
+      { x: 0, y: G, z: 0 },
+      { x: 0, y: 0, z: G },
+      { x: D, y: D, z: 0 },
+      { x: 0, y: D, z: D },
+      { x: D, y: 0, z: D },
+    ];
+    let fired = false;
+    rotations.forEach((sample, i) => {
+      if (detector.process(sample, i * 60)) fired = true;
+    });
+    expect(fired).toBe(false);
   });
 });

--- a/src/hooks/use-shake-gesture.test.ts
+++ b/src/hooks/use-shake-gesture.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect } from "vitest";
+import {
+  createShakeDetector,
+  type ShakeDetectorConfig,
+  type ShakeSample,
+} from "@/hooks/use-shake-gesture";
+
+const BASE: ShakeDetectorConfig = {
+  threshold: 15,
+  requiredJolts: 3,
+  windowMs: 800,
+  cooldownMs: 3000,
+};
+
+/**
+ * Feed the detector an alternating sample at each timestamp. Consecutive
+ * samples differ by `delta` on the x-axis, so every transition registers a
+ * jolt when `delta` exceeds the configured threshold. Returns the timestamps
+ * at which a shake was detected.
+ */
+function run(
+  config: ShakeDetectorConfig,
+  times: number[],
+  delta = 100,
+): number[] {
+  const detector = createShakeDetector(config);
+  const triggers: number[] = [];
+  times.forEach((t, i) => {
+    const sample: ShakeSample = { x: i % 2 === 0 ? 0 : delta, y: 0, z: 0 };
+    if (detector.process(sample, t)) triggers.push(t);
+  });
+  return triggers;
+}
+
+describe("createShakeDetector", () => {
+  it("fires once enough jolts land within the window", () => {
+    expect(run(BASE, [0, 60, 120, 180])).toEqual([180]);
+  });
+
+  it("does not fire when jolt deltas stay below the threshold", () => {
+    // delta 100 < threshold 200 — no jolts register at all.
+    expect(run({ ...BASE, threshold: 200 }, [0, 60, 120, 180], 100)).toEqual(
+      [],
+    );
+    // Lowering the threshold below the same delta makes it fire — proving
+    // the sensitivity setting changes behaviour.
+    expect(run({ ...BASE, threshold: 50 }, [0, 60, 120, 180], 100)).toEqual([
+      180,
+    ]);
+  });
+
+  it("respects the required-jolts setting", () => {
+    // Three jolts: fires at requiredJolts 3, silent at requiredJolts 5.
+    expect(run({ ...BASE, requiredJolts: 3 }, [0, 60, 120, 180])).toEqual([
+      180,
+    ]);
+    expect(run({ ...BASE, requiredJolts: 5 }, [0, 60, 120, 180])).toEqual([]);
+    // Five jolts clears the higher bar.
+    expect(
+      run({ ...BASE, requiredJolts: 5 }, [0, 60, 120, 180, 240, 300]),
+    ).toEqual([300]);
+  });
+
+  it("ignores jolts spaced beyond the rolling window", () => {
+    // 500ms spacing with an 800ms window: at most two jolts ever coexist.
+    expect(run(BASE, [0, 500, 1000, 1500, 2000])).toEqual([]);
+  });
+
+  it("enforces the cooldown between consecutive detections", () => {
+    const triggers = run(BASE, [
+      0, 60, 120, 180, // first shake -> fires at 180
+      240, 300, 360, // within 3000ms cooldown -> suppressed
+      3200, 3260, 3320, // cooldown elapsed -> fires again
+    ]);
+    expect(triggers).toEqual([180, 3320]);
+  });
+});

--- a/src/hooks/use-shake-gesture.ts
+++ b/src/hooks/use-shake-gesture.ts
@@ -13,6 +13,17 @@ type DeviceMotionEventWithPermission = typeof DeviceMotionEvent & {
   requestPermission?: () => Promise<"granted" | "denied">;
 };
 
+/** True on browsers (iOS 13+) that gate motion events behind a permission prompt. */
+export function motionPermissionNeeded(): boolean {
+  if (typeof window === "undefined" || typeof DeviceMotionEvent === "undefined") {
+    return false;
+  }
+  return (
+    typeof (DeviceMotionEvent as DeviceMotionEventWithPermission)
+      .requestPermission === "function"
+  );
+}
+
 export async function requestMotionPermission(): Promise<MotionPermissionResult> {
   if (typeof window === "undefined" || typeof DeviceMotionEvent === "undefined") {
     return "unsupported";
@@ -30,16 +41,64 @@ export async function requestMotionPermission(): Promise<MotionPermissionResult>
   }
 }
 
+export interface ShakeSample {
+  x: number;
+  y: number;
+  z: number;
+}
+
+export interface ShakeDetectorConfig {
+  /** Sum-of-axes acceleration delta (m/s²) that counts as a jolt. */
+  threshold: number;
+  /** Number of jolts within the rolling window required to fire. */
+  requiredJolts: number;
+  /** Rolling window the jolts must fall within. */
+  windowMs: number;
+  /** Minimum gap between two consecutive detections. */
+  cooldownMs: number;
+}
+
+/**
+ * Pure shake-detection state machine. Feed it accelerometer samples via
+ * `process` and it returns `true` on the sample that completes a shake.
+ * Kept free of React/DOM so the algorithm can be unit-tested directly.
+ */
+export function createShakeDetector(config: ShakeDetectorConfig) {
+  let last: ShakeSample | null = null;
+  let lastShakeAt = Number.NEGATIVE_INFINITY;
+  let jolts: number[] = [];
+
+  return {
+    process(sample: ShakeSample, now: number): boolean {
+      if (last) {
+        const delta =
+          Math.abs(sample.x - last.x) +
+          Math.abs(sample.y - last.y) +
+          Math.abs(sample.z - last.z);
+        if (delta > config.threshold) jolts.push(now);
+      }
+      last = sample;
+
+      jolts = jolts.filter((t) => now - t <= config.windowMs);
+      if (
+        jolts.length >= config.requiredJolts &&
+        now - lastShakeAt > config.cooldownMs
+      ) {
+        lastShakeAt = now;
+        jolts = [];
+        return true;
+      }
+      return false;
+    },
+  };
+}
+
 interface UseShakeGestureOptions {
   enabled: boolean;
   onShake: () => void;
-  /** Sum-of-axes acceleration delta (m/s²) that counts as a jolt. */
   threshold?: number;
-  /** Number of jolts within the rolling window required to fire. */
   requiredJolts?: number;
-  /** Rolling window the jolts must fall within. */
   windowMs?: number;
-  /** Minimum gap between two consecutive `onShake` calls. */
   cooldownMs?: number;
 }
 
@@ -60,14 +119,16 @@ export function useShakeGesture({
   onShakeRef.current = onShake;
 
   useEffect(() => {
-    if (!enabled) return;
-    if (typeof window === "undefined" || !("ondevicemotion" in window)) return;
+    if (!enabled || typeof window === "undefined") return;
 
+    const detector = createShakeDetector({
+      threshold,
+      requiredJolts,
+      windowMs,
+      cooldownMs,
+    });
     const SAMPLE_THROTTLE_MS = 60;
-    let last: { x: number; y: number; z: number } | null = null;
     let lastSampleAt = 0;
-    let lastShakeAt = 0;
-    let jolts: number[] = [];
 
     const handleMotion = (event: DeviceMotionEvent) => {
       const acc = event.accelerationIncludingGravity;
@@ -77,20 +138,7 @@ export function useShakeGesture({
       if (now - lastSampleAt < SAMPLE_THROTTLE_MS) return;
       lastSampleAt = now;
 
-      const current = { x: acc.x, y: acc.y, z: acc.z };
-      if (last) {
-        const delta =
-          Math.abs(current.x - last.x) +
-          Math.abs(current.y - last.y) +
-          Math.abs(current.z - last.z);
-        if (delta > threshold) jolts.push(now);
-      }
-      last = current;
-
-      jolts = jolts.filter((t) => now - t <= windowMs);
-      if (jolts.length >= requiredJolts && now - lastShakeAt > cooldownMs) {
-        lastShakeAt = now;
-        jolts = [];
+      if (detector.process({ x: acc.x, y: acc.y, z: acc.z }, now)) {
         onShakeRef.current();
       }
     };

--- a/src/hooks/use-shake-gesture.ts
+++ b/src/hooks/use-shake-gesture.ts
@@ -1,0 +1,101 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+
+/**
+ * iOS 13+ Safari requires a user-gesture-initiated permission grant before
+ * `devicemotion` events fire. `DeviceMotionEvent.requestPermission` only
+ * exists on those browsers — elsewhere motion works without a prompt.
+ */
+type MotionPermissionResult = "granted" | "denied" | "unsupported";
+
+type DeviceMotionEventWithPermission = typeof DeviceMotionEvent & {
+  requestPermission?: () => Promise<"granted" | "denied">;
+};
+
+export async function requestMotionPermission(): Promise<MotionPermissionResult> {
+  if (typeof window === "undefined" || typeof DeviceMotionEvent === "undefined") {
+    return "unsupported";
+  }
+  const request = (DeviceMotionEvent as DeviceMotionEventWithPermission)
+    .requestPermission;
+  if (typeof request !== "function") {
+    // Non-iOS browsers: motion events fire without an explicit grant.
+    return "granted";
+  }
+  try {
+    return await request();
+  } catch {
+    return "denied";
+  }
+}
+
+interface UseShakeGestureOptions {
+  enabled: boolean;
+  onShake: () => void;
+  /** Sum-of-axes acceleration delta (m/s²) that counts as a jolt. */
+  threshold?: number;
+  /** Number of jolts within the rolling window required to fire. */
+  requiredJolts?: number;
+  /** Rolling window the jolts must fall within. */
+  windowMs?: number;
+  /** Minimum gap between two consecutive `onShake` calls. */
+  cooldownMs?: number;
+}
+
+/**
+ * Fires `onShake` when the device is physically shaken. Requires several
+ * acceleration jolts within a short window so a single bump or a phone
+ * settling into a pocket does not trigger it.
+ */
+export function useShakeGesture({
+  enabled,
+  onShake,
+  threshold = 15,
+  requiredJolts = 3,
+  windowMs = 800,
+  cooldownMs = 3000,
+}: UseShakeGestureOptions) {
+  const onShakeRef = useRef(onShake);
+  onShakeRef.current = onShake;
+
+  useEffect(() => {
+    if (!enabled) return;
+    if (typeof window === "undefined" || !("ondevicemotion" in window)) return;
+
+    const SAMPLE_THROTTLE_MS = 60;
+    let last: { x: number; y: number; z: number } | null = null;
+    let lastSampleAt = 0;
+    let lastShakeAt = 0;
+    let jolts: number[] = [];
+
+    const handleMotion = (event: DeviceMotionEvent) => {
+      const acc = event.accelerationIncludingGravity;
+      if (!acc || acc.x == null || acc.y == null || acc.z == null) return;
+
+      const now = Date.now();
+      if (now - lastSampleAt < SAMPLE_THROTTLE_MS) return;
+      lastSampleAt = now;
+
+      const current = { x: acc.x, y: acc.y, z: acc.z };
+      if (last) {
+        const delta =
+          Math.abs(current.x - last.x) +
+          Math.abs(current.y - last.y) +
+          Math.abs(current.z - last.z);
+        if (delta > threshold) jolts.push(now);
+      }
+      last = current;
+
+      jolts = jolts.filter((t) => now - t <= windowMs);
+      if (jolts.length >= requiredJolts && now - lastShakeAt > cooldownMs) {
+        lastShakeAt = now;
+        jolts = [];
+        onShakeRef.current();
+      }
+    };
+
+    window.addEventListener("devicemotion", handleMotion);
+    return () => window.removeEventListener("devicemotion", handleMotion);
+  }, [enabled, threshold, requiredJolts, windowMs, cooldownMs]);
+}

--- a/src/hooks/use-shake-gesture.ts
+++ b/src/hooks/use-shake-gesture.ts
@@ -48,7 +48,12 @@ export interface ShakeSample {
 }
 
 export interface ShakeDetectorConfig {
-  /** Sum-of-axes acceleration delta (m/s²) that counts as a jolt. */
+  /**
+   * Change in total acceleration magnitude (m/s²) between samples that
+   * counts as a jolt. Magnitude is rotation-invariant: tilting the device
+   * redistributes gravity across the axes but leaves the magnitude near
+   * 9.8, so only real movement — not reorientation — registers.
+   */
   threshold: number;
   /** Number of jolts within the rolling window required to fire. */
   requiredJolts: number;
@@ -58,26 +63,30 @@ export interface ShakeDetectorConfig {
   cooldownMs: number;
 }
 
+function magnitude(sample: ShakeSample): number {
+  return Math.sqrt(
+    sample.x * sample.x + sample.y * sample.y + sample.z * sample.z,
+  );
+}
+
 /**
  * Pure shake-detection state machine. Feed it accelerometer samples via
  * `process` and it returns `true` on the sample that completes a shake.
  * Kept free of React/DOM so the algorithm can be unit-tested directly.
  */
 export function createShakeDetector(config: ShakeDetectorConfig) {
-  let last: ShakeSample | null = null;
+  let lastMagnitude: number | null = null;
   let lastShakeAt = Number.NEGATIVE_INFINITY;
   let jolts: number[] = [];
 
   return {
     process(sample: ShakeSample, now: number): boolean {
-      if (last) {
-        const delta =
-          Math.abs(sample.x - last.x) +
-          Math.abs(sample.y - last.y) +
-          Math.abs(sample.z - last.z);
+      const mag = magnitude(sample);
+      if (lastMagnitude !== null) {
+        const delta = Math.abs(mag - lastMagnitude);
         if (delta > config.threshold) jolts.push(now);
       }
-      last = sample;
+      lastMagnitude = mag;
 
       jolts = jolts.filter((t) => now - t <= config.windowMs);
       if (
@@ -110,7 +119,7 @@ interface UseShakeGestureOptions {
 export function useShakeGesture({
   enabled,
   onShake,
-  threshold = 15,
+  threshold = 8,
   requiredJolts = 3,
   windowMs = 800,
   cooldownMs = 3000,

--- a/src/stores/settings-store.ts
+++ b/src/stores/settings-store.ts
@@ -95,7 +95,7 @@ export interface Settings {
 
   // Shake the device to open the bug report / feature request dialog
   shakeToReportEnabled: boolean;
-  shakeThreshold: number; // sum-of-axes jolt delta (m/s²) — lower = more sensitive
+  shakeThreshold: number; // acceleration-magnitude jolt delta (m/s²) — lower = more sensitive
   shakeRequiredJolts: number; // jolts within the detection window required to fire
 
   // Substance tracking configuration
@@ -181,7 +181,7 @@ const defaultSettings: Settings = {
   weightIncrement: 0.05,
   storageMode: "local" as const,
   shakeToReportEnabled: true,
-  shakeThreshold: 15,
+  shakeThreshold: 8,
   shakeRequiredJolts: 3,
   dismissedInsights: {},
   primaryRegion: "",
@@ -294,7 +294,7 @@ export const useSettingsStore = create<Settings & SettingsActions>()(
       // Shake to report
       setShakeToReportEnabled: (value) => set({ shakeToReportEnabled: value }),
       setShakeThreshold: (value) =>
-        set({ shakeThreshold: sanitizeNumericInput(value, 8, 40) }),
+        set({ shakeThreshold: sanitizeNumericInput(value, 4, 20) }),
       setShakeRequiredJolts: (value) =>
         set({ shakeRequiredJolts: sanitizeNumericInput(value, 2, 8) }),
 
@@ -327,7 +327,7 @@ export const useSettingsStore = create<Settings & SettingsActions>()(
     {
       name: "intake-tracker-settings",
       storage: createJSONStorage(() => localStorage),
-      version: 11,
+      version: 12,
       migrate: (persisted, version) => {
         const state = persisted as Record<string, unknown>;
         if (version === 0) {
@@ -385,6 +385,12 @@ export const useSettingsStore = create<Settings & SettingsActions>()(
         if (version < 11) {
           state.shakeThreshold = 15;
           state.shakeRequiredJolts = 3;
+        }
+        if (version < 12) {
+          // Shake detection switched from a per-axis delta to a rotation-
+          // invariant magnitude delta; the old threshold scale no longer
+          // applies, so reset it to the recalibrated default.
+          state.shakeThreshold = 8;
         }
         return state as unknown as Settings & SettingsActions;
       },

--- a/src/stores/settings-store.ts
+++ b/src/stores/settings-store.ts
@@ -93,6 +93,9 @@ export interface Settings {
   // Storage mode: local-only or cloud-sync
   storageMode: "local" | "cloud-sync";
 
+  // Shake the device to open the bug report / feature request dialog
+  shakeToReportEnabled: boolean;
+
   // Substance tracking configuration
   substanceConfig: SubstanceConfig;
 }
@@ -140,6 +143,8 @@ interface SettingsActions {
   setWeightIncrement: (value: number) => void;
   // Storage mode
   setStorageMode: (mode: "local" | "cloud-sync") => void;
+  // Shake to report
+  setShakeToReportEnabled: (value: boolean) => void;
   // Substance config
   setSubstanceConfig: (config: SubstanceConfig) => void;
   resetToDefaults: () => void;
@@ -171,6 +176,7 @@ const defaultSettings: Settings = {
   liquidPresets: DEFAULT_LIQUID_PRESETS,
   weightIncrement: 0.05,
   storageMode: "local" as const,
+  shakeToReportEnabled: true,
   dismissedInsights: {},
   primaryRegion: "",
   secondaryRegion: "",
@@ -279,6 +285,9 @@ export const useSettingsStore = create<Settings & SettingsActions>()(
       // Storage mode
       setStorageMode: (mode) => set({ storageMode: mode }),
 
+      // Shake to report
+      setShakeToReportEnabled: (value) => set({ shakeToReportEnabled: value }),
+
       // Substance config
       setSubstanceConfig: (config) => set({ substanceConfig: config }),
 
@@ -308,7 +317,7 @@ export const useSettingsStore = create<Settings & SettingsActions>()(
     {
       name: "intake-tracker-settings",
       storage: createJSONStorage(() => localStorage),
-      version: 9,
+      version: 10,
       migrate: (persisted, version) => {
         const state = persisted as Record<string, unknown>;
         if (version === 0) {
@@ -359,6 +368,9 @@ export const useSettingsStore = create<Settings & SettingsActions>()(
         if (version < 9) {
           state.swipeNavDistanceThresholdPct = 28;
           state.swipeNavVelocityThreshold = 500;
+        }
+        if (version < 10) {
+          state.shakeToReportEnabled = true;
         }
         return state as unknown as Settings & SettingsActions;
       },

--- a/src/stores/settings-store.ts
+++ b/src/stores/settings-store.ts
@@ -95,6 +95,8 @@ export interface Settings {
 
   // Shake the device to open the bug report / feature request dialog
   shakeToReportEnabled: boolean;
+  shakeThreshold: number; // sum-of-axes jolt delta (m/s²) — lower = more sensitive
+  shakeRequiredJolts: number; // jolts within the detection window required to fire
 
   // Substance tracking configuration
   substanceConfig: SubstanceConfig;
@@ -145,6 +147,8 @@ interface SettingsActions {
   setStorageMode: (mode: "local" | "cloud-sync") => void;
   // Shake to report
   setShakeToReportEnabled: (value: boolean) => void;
+  setShakeThreshold: (value: number) => void;
+  setShakeRequiredJolts: (value: number) => void;
   // Substance config
   setSubstanceConfig: (config: SubstanceConfig) => void;
   resetToDefaults: () => void;
@@ -177,6 +181,8 @@ const defaultSettings: Settings = {
   weightIncrement: 0.05,
   storageMode: "local" as const,
   shakeToReportEnabled: true,
+  shakeThreshold: 15,
+  shakeRequiredJolts: 3,
   dismissedInsights: {},
   primaryRegion: "",
   secondaryRegion: "",
@@ -287,6 +293,10 @@ export const useSettingsStore = create<Settings & SettingsActions>()(
 
       // Shake to report
       setShakeToReportEnabled: (value) => set({ shakeToReportEnabled: value }),
+      setShakeThreshold: (value) =>
+        set({ shakeThreshold: sanitizeNumericInput(value, 8, 40) }),
+      setShakeRequiredJolts: (value) =>
+        set({ shakeRequiredJolts: sanitizeNumericInput(value, 2, 8) }),
 
       // Substance config
       setSubstanceConfig: (config) => set({ substanceConfig: config }),
@@ -317,7 +327,7 @@ export const useSettingsStore = create<Settings & SettingsActions>()(
     {
       name: "intake-tracker-settings",
       storage: createJSONStorage(() => localStorage),
-      version: 10,
+      version: 11,
       migrate: (persisted, version) => {
         const state = persisted as Record<string, unknown>;
         if (version === 0) {
@@ -371,6 +381,10 @@ export const useSettingsStore = create<Settings & SettingsActions>()(
         }
         if (version < 10) {
           state.shakeToReportEnabled = true;
+        }
+        if (version < 11) {
+          state.shakeThreshold = 15;
+          state.shakeRequiredJolts = 3;
         }
         return state as unknown as Settings & SettingsActions;
       },


### PR DESCRIPTION
Shaking the device opens the bug-report / feature-request dialog from
anywhere in the app. Detection requires several acceleration jolts within
a short rolling window so a single bump does not trigger it, and a new
settings toggle (on by default) lets users disable it and handles the
iOS motion-permission prompt.

Closes #96

https://claude.ai/code/session_01DyKjZFgRGrj7MBWjdL9YmN