### PR TITLE
Fix swipe navigation race condition during rapid gestures

### DIFF
--- a/src/components/swipe-nav.tsx
+++ b/src/components/swipe-nav.tsx
@@ -121,7 +121,14 @@ export function SwipeNav({ children }: { children: React.ReactNode }) {
       startedRef.current = false;
       lockRef.current = null;
 
-      if (!wasHorizontal || navigatingRef.current) {
+      // While a navigation commit is in flight it owns the `x` motion value
+      // until the route changes. Starting another animation here (from a
+      // stray gesture during a rapid swipe) would cancel the commit
+      // animation, dropping its queued router.push() and leaving the
+      // skeleton overlay and page content desynced.
+      if (navigatingRef.current) return;
+
+      if (!wasHorizontal) {
         animate(x, 0, { type: "spring", stiffness: 400, damping: 40 });
         return;
       }


### PR DESCRIPTION
## Summary

Fixes a race condition in the swipe navigation component where rapid consecutive swipes could cancel an in-flight route navigation, causing the skeleton overlay and page content to become desynced.

## Key Changes

- **Reordered navigation guards**: Moved the `navigatingRef.current` check before the `wasHorizontal` check to prevent starting new animations while a route change is in progress
- **Added early return**: When a navigation is already in flight, the gesture handler now returns immediately instead of proceeding to animate the x position
- **Improved code clarity**: Added detailed comment explaining why the navigation state must be checked first—the motion value is "owned" by the commit animation until the route changes, and starting a competing animation would cancel the queued `router.push()` call

## Implementation Details

The fix ensures that while a navigation commit is in flight (indicated by `navigatingRef.current` being true), any stray gestures from rapid swiping are ignored rather than triggering a competing animation. This prevents the skeleton overlay and page content from becoming desynced when the router.push() gets dropped due to animation cancellation.

https://claude.ai/code/session_01DvCzWcSJBGELvE3AxXFMEH

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed swipe navigation to prevent animation conflicts when multiple gestures overlap during navigation transitions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/RyRy79261/intake-tracker/pull/104?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->