### PR TITLE
feat(medications): improve dose-marking time flow

### DIFF
--- a/src/components/medications/bulk-dose-edit-dialog.tsx
+++ b/src/components/medications/bulk-dose-edit-dialog.tsx
@@ -1,0 +1,203 @@
+"use client";
+
+import { useState } from "react";
+import { Drawer, DrawerContent } from "@/components/ui/drawer";
+import { PillIconWithBadge } from "./pill-icon";
+import { useUntakeDose, useSkipAllDoses, useEditAllDoseTimes } from "@/hooks/use-medication-queries";
+import { hapticTake, hapticSkip, formatPillCount, getCurrentTimeHHMM } from "@/lib/medication-ui-utils";
+import { toast } from "@/hooks/use-toast";
+import { X, RotateCcw, Clock } from "lucide-react";
+import { RetroactiveTimePicker } from "./retroactive-time-picker";
+import type { DoseSlot } from "@/hooks/use-medication-queries";
+
+interface BulkDoseEditDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  time: string;
+  slots: DoseSlot[];
+  date: string;
+}
+
+function formatTime12(time24: string): string {
+  const parts = time24.split(":").map(Number);
+  const h = parts[0] ?? 0;
+  const m = parts[1] ?? 0;
+  const ampm = h >= 12 ? "PM" : "AM";
+  const h12 = h === 0 ? 12 : h > 12 ? h - 12 : h;
+  return `${h12}:${String(m).padStart(2, "0")} ${ampm}`;
+}
+
+function formatClock(ts: number): string {
+  const d = new Date(ts);
+  return `${String(d.getHours()).padStart(2, "0")}:${String(d.getMinutes()).padStart(2, "0")}`;
+}
+
+function formatLoggedTime(ts: number): string {
+  const d = new Date(ts);
+  const dateStr = d.toLocaleDateString("en-US", { month: "short", day: "numeric" });
+  return `${formatClock(ts)}, ${dateStr}`;
+}
+
+export function BulkDoseEditDialog({ open, onOpenChange, time, slots, date }: BulkDoseEditDialogProps) {
+  const [editPickerOpen, setEditPickerOpen] = useState(false);
+
+  const untakeMut = useUntakeDose();
+  const skipAllMut = useSkipAllDoses();
+  const editAllMut = useEditAllDoseTimes();
+
+  if (slots.length === 0) return null;
+
+  const takenSlots = slots.filter((s) => s.status === "taken");
+  const hasTaken = takenSlots.length > 0;
+
+  // Default the Edit Record picker to the time the batch was logged at.
+  const firstLog = takenSlots[0]?.existingLog?.actionTimestamp;
+  const batchLoggedTime = firstLog ? formatClock(firstLog) : getCurrentTimeHHMM();
+
+  const handleSkipAll = async () => {
+    hapticSkip();
+    const target = slots.filter((s) => s.status !== "skipped");
+    await skipAllMut.mutateAsync({
+      entries: target.map((s) => ({
+        prescriptionId: s.prescriptionId,
+        phaseId: s.phaseId,
+        scheduleId: s.scheduleId,
+        dosageMg: s.dosageMg,
+      })),
+      date,
+      time,
+    });
+    toast({ title: `All ${formatTime12(time)} doses skipped` });
+    onOpenChange(false);
+  };
+
+  const handleUntakeAll = async () => {
+    hapticSkip();
+    for (const s of takenSlots) {
+      await untakeMut.mutateAsync({
+        prescriptionId: s.prescriptionId,
+        phaseId: s.phaseId,
+        scheduleId: s.scheduleId,
+        date: s.scheduledDate,
+        time: s.localTime,
+        dosageMg: s.dosageMg,
+      });
+    }
+    toast({ title: `All ${formatTime12(time)} doses reversed` });
+    onOpenChange(false);
+  };
+
+  const handleEditRecordConfirm = async (newTime: string) => {
+    hapticTake();
+    await editAllMut.mutateAsync({
+      entries: takenSlots.map((s) => ({
+        prescriptionId: s.prescriptionId,
+        phaseId: s.phaseId,
+        scheduleId: s.scheduleId,
+      })),
+      date,
+      time,
+      newTime,
+    });
+    toast({ title: `${formatTime12(time)} dose time updated` });
+    onOpenChange(false);
+  };
+
+  return (
+    <>
+      <Drawer open={open} onOpenChange={onOpenChange}>
+        <DrawerContent className="max-h-[85vh]">
+          <div className="p-6">
+            {/* Header */}
+            <div className="flex items-center justify-between mb-4">
+              <div className="w-8" />
+              <h2 className="text-lg font-bold">{formatTime12(time)}</h2>
+              <button
+                onClick={() => onOpenChange(false)}
+                className="w-8 h-8 flex items-center justify-center text-muted-foreground"
+                aria-label="Close"
+              >
+                <X className="w-5 h-5" />
+              </button>
+            </div>
+
+            {/* Dose list */}
+            <div className="space-y-3 mb-6 max-h-[50vh] overflow-y-auto">
+              {slots.map((slot) => {
+                const doseLabel = slot.pillsPerDose != null
+                  ? `${slot.dosageMg}${slot.unit}, take ${formatPillCount(slot.pillsPerDose)}`
+                  : `${slot.dosageMg}${slot.unit}`;
+                return (
+                  <div key={`${slot.scheduleId}-${slot.localTime}`} className="flex items-center gap-3">
+                    <PillIconWithBadge
+                      shape={slot.inventory?.pillShape || "round"}
+                      color={slot.inventory?.pillColor || "#ccc"}
+                      size={36}
+                      status={slot.status === "missed" ? "pending" : slot.status}
+                    />
+                    <div className="flex-1 min-w-0">
+                      <p className="font-semibold text-sm leading-tight">
+                        {slot.prescription.genericName}
+                      </p>
+                      <p className="text-xs text-muted-foreground mt-0.5">{doseLabel}</p>
+                      {slot.status === "taken" && slot.existingLog?.actionTimestamp && (
+                        <p className="text-xs text-emerald-600 dark:text-emerald-400 mt-0.5">
+                          Taken at {formatLoggedTime(slot.existingLog.actionTimestamp)}
+                        </p>
+                      )}
+                      {slot.status === "skipped" && (
+                        <p className="text-xs text-muted-foreground mt-0.5">
+                          {slot.existingLog?.skipReason || "Skipped"}
+                        </p>
+                      )}
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+
+            {/* Action buttons */}
+            <div className="flex justify-center gap-6">
+              <button onClick={handleSkipAll} className="flex flex-col items-center gap-1.5">
+                <div className="w-12 h-12 rounded-full border-2 border-teal-600 dark:border-teal-400 flex items-center justify-center">
+                  <X className="w-5 h-5 text-teal-600 dark:text-teal-400" />
+                </div>
+                <span className="text-xs font-medium text-teal-600 dark:text-teal-400">SKIP ALL</span>
+              </button>
+
+              <button
+                onClick={handleUntakeAll}
+                disabled={!hasTaken}
+                className="flex flex-col items-center gap-1.5 disabled:opacity-40"
+              >
+                <div className="w-12 h-12 rounded-full border-2 border-red-500 dark:border-red-400 bg-red-500 dark:bg-red-500 flex items-center justify-center">
+                  <RotateCcw className="w-5 h-5 text-white" />
+                </div>
+                <span className="text-xs font-medium text-red-500 dark:text-red-400">UN-TAKE</span>
+              </button>
+
+              <button
+                onClick={() => setEditPickerOpen(true)}
+                disabled={!hasTaken}
+                className="flex flex-col items-center gap-1.5 disabled:opacity-40"
+              >
+                <div className="w-12 h-12 rounded-full border-2 border-gray-400 flex items-center justify-center">
+                  <Clock className="w-5 h-5 text-gray-400" />
+                </div>
+                <span className="text-xs font-medium text-muted-foreground">EDIT RECORD</span>
+              </button>
+            </div>
+          </div>
+        </DrawerContent>
+      </Drawer>
+
+      <RetroactiveTimePicker
+        open={editPickerOpen}
+        onOpenChange={setEditPickerOpen}
+        defaultTime={batchLoggedTime}
+        compoundName="all doses"
+        onConfirm={handleEditRecordConfirm}
+      />
+    </>
+  );
+}

--- a/src/components/medications/dose-row.tsx
+++ b/src/components/medications/dose-row.tsx
@@ -5,7 +5,7 @@ import { PillIconWithBadge } from "./pill-icon";
 import { Button } from "@/components/ui/button";
 import { Check } from "lucide-react";
 import { cn } from "@/lib/utils";
-import { formatPillCount } from "@/lib/medication-ui-utils";
+import { formatPillCount, getCurrentTimeHHMM } from "@/lib/medication-ui-utils";
 import { RetroactiveTimePicker } from "./retroactive-time-picker";
 import type { DoseSlot } from "@/hooks/use-medication-queries";
 
@@ -17,6 +17,7 @@ interface DoseRowProps {
   onRetroactiveTake: (slot: DoseSlot, time: string) => void;
   onSkip: (slot: DoseSlot) => void;
   onDoseClick: (slot: DoseSlot) => void;
+  onEditTime: (slot: DoseSlot, time: string) => void;
 }
 
 const LATE_THRESHOLD_MINUTES = 30;
@@ -34,9 +35,10 @@ function formatTimestamp(ts: number): string {
   return `${String(d.getHours()).padStart(2, "0")}:${String(d.getMinutes()).padStart(2, "0")}`;
 }
 
-export function DoseRow({ slot, isToday, isFuture, onTake, onRetroactiveTake, onSkip, onDoseClick }: DoseRowProps) {
+export function DoseRow({ slot, isToday, isFuture, onTake, onRetroactiveTake, onSkip, onDoseClick, onEditTime }: DoseRowProps) {
   const { status, prescription, phase, inventory, pillsPerDose } = slot;
   const [timePickerOpen, setTimePickerOpen] = useState(false);
+  const [editPickerOpen, setEditPickerOpen] = useState(false);
 
   const isActionable = !isFuture && (status === "pending" || status === "missed");
 
@@ -139,15 +141,39 @@ export function DoseRow({ slot, isToday, isFuture, onTake, onRetroactiveTake, on
               </Button>
             </div>
           )}
+
+          {status === "taken" && (
+            <div className="flex items-center shrink-0">
+              <Button
+                size="sm"
+                variant="ghost"
+                className="h-8 px-3 text-xs text-muted-foreground"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  setEditPickerOpen(true);
+                }}
+              >
+                Edit
+              </Button>
+            </div>
+          )}
         </div>
       </div>
 
       <RetroactiveTimePicker
         open={timePickerOpen}
         onOpenChange={setTimePickerOpen}
-        defaultTime={slot.localTime}
+        defaultTime={getCurrentTimeHHMM()}
         compoundName={prescription.genericName}
         onConfirm={handleRetroactiveConfirm}
+      />
+
+      <RetroactiveTimePicker
+        open={editPickerOpen}
+        onOpenChange={setEditPickerOpen}
+        defaultTime={takenAtDisplay}
+        compoundName={prescription.genericName}
+        onConfirm={(time) => onEditTime(slot, time)}
       />
     </>
   );

--- a/src/components/medications/retroactive-time-picker.tsx
+++ b/src/components/medications/retroactive-time-picker.tsx
@@ -8,7 +8,7 @@ import {
   DialogFooter,
 } from "@/components/ui/dialog";
 import { Button } from "@/components/ui/button";
-import { useState } from "react";
+import { useState, useEffect } from "react";
 
 interface RetroactiveTimePickerProps {
   open: boolean;
@@ -27,16 +27,18 @@ export function RetroactiveTimePicker({
 }: RetroactiveTimePickerProps) {
   const [selectedTime, setSelectedTime] = useState(defaultTime);
 
-  // Reset time when dialog opens with new default
-  const handleOpenChange = (newOpen: boolean) => {
-    if (newOpen) {
+  // Reset the input to the default every time the dialog opens, so a stale
+  // value from a previous dose never carries over. Radix only fires
+  // onOpenChange for its own events, not for controlled `open` prop changes,
+  // so the reset must key off `open` directly.
+  useEffect(() => {
+    if (open) {
       setSelectedTime(defaultTime);
     }
-    onOpenChange(newOpen);
-  };
+  }, [open, defaultTime]);
 
   return (
-    <Dialog open={open} onOpenChange={handleOpenChange}>
+    <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent className="max-w-xs">
         <DialogHeader>
           <DialogTitle className="text-center">

--- a/src/components/medications/schedule-view.tsx
+++ b/src/components/medications/schedule-view.tsx
@@ -1,15 +1,17 @@
 "use client";
 
 import { useMemo, useEffect, useState, useCallback } from "react";
-import { useDailyDoseSchedule, useTakeDose, useUntakeDose, useSkipDose, useTakeAllDoses } from "@/hooks/use-medication-queries";
+import { useDailyDoseSchedule, useTakeDose, useUntakeDose, useSkipDose, useTakeAllDoses, useEditDoseTime } from "@/hooks/use-medication-queries";
 import type { DoseSlot } from "@/hooks/use-medication-queries";
-import { hapticTake, hapticSkip } from "@/lib/medication-ui-utils";
+import { hapticTake, hapticSkip, getCurrentTimeHHMM } from "@/lib/medication-ui-utils";
+import { toast } from "@/hooks/use-toast";
 import { showUndoToast } from "./undo-toast";
 import { DoseProgressSummary } from "./dose-progress-summary";
 import { TimeSlotGroup } from "./time-slot-group";
 import { SkipReasonPicker } from "./skip-reason-picker";
 import { EmptySchedule } from "./empty-schedule";
 import { RetroactiveTimePicker } from "./retroactive-time-picker";
+import { BulkDoseEditDialog } from "./bulk-dose-edit-dialog";
 
 interface ScheduleViewProps {
   selectedDate: Date;
@@ -35,6 +37,7 @@ export function ScheduleView({ selectedDate, onDoseClick, onAddMed }: ScheduleVi
   const untakeDoseMut = useUntakeDose();
   const skipDoseMut = useSkipDose();
   const takeAllDosesMut = useTakeAllDoses();
+  const editDoseTimeMut = useEditDoseTime();
 
   // Skip reason picker state
   const [skipPickerOpen, setSkipPickerOpen] = useState(false);
@@ -43,6 +46,10 @@ export function ScheduleView({ selectedDate, onDoseClick, onAddMed }: ScheduleVi
   // Mark All time picker state (for late doses)
   const [markAllPickerOpen, setMarkAllPickerOpen] = useState(false);
   const [markAllTarget, setMarkAllTarget] = useState<{ time: string; slots: DoseSlot[] } | null>(null);
+
+  // Bulk edit drawer state (for already-logged time slots)
+  const [bulkEditOpen, setBulkEditOpen] = useState(false);
+  const [bulkEditTarget, setBulkEditTarget] = useState<{ time: string; slots: DoseSlot[] } | null>(null);
 
   const today = new Date();
   const isToday = selectedDate.toDateString() === today.toDateString();
@@ -280,6 +287,29 @@ export function ScheduleView({ selectedDate, onDoseClick, onAddMed }: ScheduleVi
     [markAllTarget, executeMarkAll],
   );
 
+  // Handle editing the recorded time of a single taken dose
+  const handleEditTime = useCallback(
+    async (slot: DoseSlot, takenAtTime: string) => {
+      hapticTake();
+      await editDoseTimeMut.mutateAsync({
+        prescriptionId: slot.prescriptionId,
+        phaseId: slot.phaseId,
+        scheduleId: slot.scheduleId,
+        date: slot.scheduledDate,
+        time: slot.localTime,
+        newTime: takenAtTime,
+      });
+      toast({ title: `${slot.prescription.genericName} time updated` });
+    },
+    [editDoseTimeMut],
+  );
+
+  // Handle Edit All — open the bulk edit drawer for a logged time slot
+  const handleEditAll = useCallback((time: string, groupSlots: DoseSlot[]) => {
+    setBulkEditTarget({ time, slots: groupSlots });
+    setBulkEditOpen(true);
+  }, []);
+
   if (!slots || slots.length === 0) {
     return <EmptySchedule onAddMed={onAddMed} />;
   }
@@ -303,6 +333,8 @@ export function ScheduleView({ selectedDate, onDoseClick, onAddMed }: ScheduleVi
           onSkip={handleSkipStart}
           onDoseClick={onDoseClick}
           onMarkAll={handleMarkAll}
+          onEditAll={handleEditAll}
+          onEditTime={handleEditTime}
         />
       ))}
 
@@ -319,9 +351,17 @@ export function ScheduleView({ selectedDate, onDoseClick, onAddMed }: ScheduleVi
       <RetroactiveTimePicker
         open={markAllPickerOpen}
         onOpenChange={setMarkAllPickerOpen}
-        defaultTime={markAllTarget?.time ?? "08:00"}
+        defaultTime={getCurrentTimeHHMM()}
         compoundName="all doses"
         onConfirm={handleMarkAllTimeConfirm}
+      />
+
+      <BulkDoseEditDialog
+        open={bulkEditOpen}
+        onOpenChange={setBulkEditOpen}
+        time={bulkEditTarget?.time ?? ""}
+        slots={bulkEditTarget?.slots ?? []}
+        date={dateStr}
       />
     </div>
   );

--- a/src/components/medications/time-slot-group.tsx
+++ b/src/components/medications/time-slot-group.tsx
@@ -16,6 +16,8 @@ interface TimeSlotGroupProps {
   onSkip: (slot: DoseSlot) => void;
   onDoseClick: (slot: DoseSlot) => void;
   onMarkAll: (time: string, slots: DoseSlot[]) => void;
+  onEditAll: (time: string, slots: DoseSlot[]) => void;
+  onEditTime: (slot: DoseSlot, time: string) => void;
 }
 
 function formatTime12(time24: string): string {
@@ -46,8 +48,11 @@ export function TimeSlotGroup({
   onSkip,
   onDoseClick,
   onMarkAll,
+  onEditAll,
+  onEditTime,
 }: TimeSlotGroupProps) {
   const hasPending = slots.some((s) => s.status === "pending" || s.status === "missed");
+  const hasTaken = slots.some((s) => s.status === "taken");
   const allDone = slots.every((s) => s.status === "taken" || s.status === "skipped");
   const overdue = isToday && isTimeOverdue(time) && hasPending;
 
@@ -79,6 +84,16 @@ export function TimeSlotGroup({
             Mark All
           </Button>
         )}
+        {!isFuture && !hasPending && hasTaken && (
+          <Button
+            variant="ghost"
+            size="sm"
+            className="text-xs text-muted-foreground h-7"
+            onClick={() => onEditAll(time, slots)}
+          >
+            Edit All
+          </Button>
+        )}
       </div>
 
       <div className="space-y-2">
@@ -92,6 +107,7 @@ export function TimeSlotGroup({
             onRetroactiveTake={onRetroactiveTake}
             onSkip={onSkip}
             onDoseClick={onDoseClick}
+            onEditTime={onEditTime}
           />
         ))}
       </div>

--- a/src/hooks/use-medication-queries.ts
+++ b/src/hooks/use-medication-queries.ts
@@ -45,11 +45,14 @@ import {
   rescheduleDose,
   takeAllDoses,
   skipAllDoses,
+  editDoseTime,
+  editAllDoseTimes,
   type DoseLogWithDetails,
   type TakeDoseInput,
   type UntakeDoseInput,
   type SkipDoseInput,
   type RescheduleDoseInput,
+  type EditDoseTimeInput,
 } from "@/lib/dose-log-service";
 import {
   getDailyDoseSchedule,
@@ -242,6 +245,19 @@ export function useSkipAllDoses() {
   return useMutation({
     mutationFn: async (args: { entries: { prescriptionId: string; phaseId: string; scheduleId: string; dosageMg: number }[]; date: string; time: string; reason?: string }) =>
       unwrap(await skipAllDoses(args.entries, args.date, args.time, args.reason)),
+  });
+}
+
+export function useEditDoseTime() {
+  return useMutation({
+    mutationFn: async (input: EditDoseTimeInput) => unwrap(await editDoseTime(input)),
+  });
+}
+
+export function useEditAllDoseTimes() {
+  return useMutation({
+    mutationFn: async (args: { entries: { prescriptionId: string; phaseId: string; scheduleId: string }[]; date: string; time: string; newTime: string }) =>
+      unwrap(await editAllDoseTimes(args.entries, args.date, args.time, args.newTime)),
   });
 }
 

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -37,6 +37,7 @@ export type AuditAction =
   | "dose_taken"
   | "dose_skipped"
   | "dose_rescheduled"
+  | "dose_time_edited"
   | "prescription_added"
   | "prescription_updated"
   | "inventory_adjusted"

--- a/src/lib/dose-log-service.ts
+++ b/src/lib/dose-log-service.ts
@@ -57,6 +57,15 @@ export interface RescheduleDoseInput {
   dosageMg: number;
 }
 
+export interface EditDoseTimeInput {
+  prescriptionId: string;
+  phaseId: string;
+  scheduleId: string;
+  date: string;
+  time: string;
+  newTime: string; // "HH:MM" — actual time the dose was taken
+}
+
 // ---------------------------------------------------------------------------
 // Fractional pill math helpers (exported for reuse)
 // ---------------------------------------------------------------------------
@@ -606,6 +615,74 @@ export async function skipAllDoses(
 
   if (errors.length > 0) {
     return err(`Failed to skip ${errors.length} dose(s): ${errors.join("; ")}`);
+  }
+  return ok(undefined);
+}
+
+/**
+ * Edit the recorded time of an already-taken dose. Only `actionTimestamp` is
+ * updated — inventory is untouched since the dose itself is unchanged.
+ */
+export async function editDoseTime(input: EditDoseTimeInput): Promise<ServiceResult<DoseLog>> {
+  try {
+    const { prescriptionId, phaseId, scheduleId, date, time, newTime } = input;
+
+    const [h, m] = newTime.split(":").map(Number);
+    const d = new Date(date + "T00:00:00");
+    d.setHours(h ?? 0, m ?? 0, 0, 0);
+    const newTimestamp = d.getTime();
+
+    const log = await db.transaction(
+      "rw",
+      [db.doseLogs, db.auditLogs, db._syncQueue],
+      async () => {
+        const prev = await getDoseLogRaw(prescriptionId, phaseId, scheduleId, date, time);
+        if (!prev || prev.status !== "taken") {
+          throw new Error("Dose is not logged as taken");
+        }
+
+        const now = Date.now();
+        await db.doseLogs.update(prev.id, { actionTimestamp: newTimestamp, updatedAt: now });
+        await enqueueInsideTx("doseLogs", prev.id, "upsert");
+
+        const auditEntry = buildAuditEntry("dose_time_edited", {
+          prescriptionId, date, time, newTime,
+        });
+        await db.auditLogs.add(auditEntry);
+        await enqueueInsideTx("auditLogs", auditEntry.id, "upsert");
+
+        return { ...prev, actionTimestamp: newTimestamp, updatedAt: now };
+      },
+    );
+    schedulePush();
+
+    return ok(log);
+  } catch (e) {
+    return err("Failed to edit dose time", e);
+  }
+}
+
+/**
+ * Edit the recorded time for a list of taken doses. Each dose gets its own
+ * transaction — one failure does not block others.
+ */
+export async function editAllDoseTimes(
+  entries: { prescriptionId: string; phaseId: string; scheduleId: string }[],
+  date: string,
+  time: string,
+  newTime: string,
+): Promise<ServiceResult<void>> {
+  const errors: string[] = [];
+
+  for (const entry of entries) {
+    const result = await editDoseTime({ ...entry, date, time, newTime });
+    if (!result.success) {
+      errors.push(result.error);
+    }
+  }
+
+  if (errors.length > 0) {
+    return err(`Failed to edit ${errors.length} dose(s): ${errors.join("; ")}`);
   }
   return ok(undefined);
 }

--- a/src/lib/dose-log-service.ts
+++ b/src/lib/dose-log-service.ts
@@ -627,9 +627,14 @@ export async function editDoseTime(input: EditDoseTimeInput): Promise<ServiceRes
   try {
     const { prescriptionId, phaseId, scheduleId, date, time, newTime } = input;
 
-    const [h, m] = newTime.split(":").map(Number);
+    const match = /^(\d{1,2}):(\d{2})$/.exec(newTime);
+    const h = match ? Number(match[1]) : NaN;
+    const m = match ? Number(match[2]) : NaN;
+    if (!Number.isInteger(h) || !Number.isInteger(m) || h < 0 || h > 23 || m < 0 || m > 59) {
+      return err(`Invalid time "${newTime}"`);
+    }
     const d = new Date(date + "T00:00:00");
-    d.setHours(h ?? 0, m ?? 0, 0, 0);
+    d.setHours(h, m, 0, 0);
     const newTimestamp = d.getTime();
 
     const log = await db.transaction(

--- a/src/lib/medication-ui-utils.ts
+++ b/src/lib/medication-ui-utils.ts
@@ -77,6 +77,12 @@ export function formatPillCount(pills: number): string {
   return `${combined} tablets`;
 }
 
+/** Current wall-clock time as a zero-padded 24-hour "HH:MM" string. */
+export function getCurrentTimeHHMM(): string {
+  const now = new Date();
+  return `${String(now.getHours()).padStart(2, "0")}:${String(now.getMinutes()).padStart(2, "0")}`;
+}
+
 /**
  * Haptic feedback for taking a dose.
  */


### PR DESCRIPTION
The retroactive time picker defaulted to the scheduled time and never
reset between uses, so marking a late morning dose then a late evening
dose left a stale morning time selected. The picker now defaults to the
current time and resets every time it opens.

A fully-logged time slot now shows "Edit All" in place of "Mark All",
opening a bulk edit drawer (skip all / un-take / edit record) so the
recorded time of a whole batch can be corrected. Taken single-dose rows
gain an inline "Edit" button for the same correction on one dose.

https://claude.ai/code/session_01XCGLaCAxtws9rD1GDYvtCq

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Edit the recorded time of individual taken medication doses retroactively.
  * New bulk dose editor to manage multiple medications at once, including skip and untake actions.
  * "Edit All" button in time slots to quickly adjust times for multiple doses simultaneously.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/RyRy79261/intake-tracker/pull/117?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->