### PR TITLE
feat: add sugar entry to drink logging and standardize sodium bar label

### DIFF
--- a/e2e/dashboard.spec.ts
+++ b/e2e/dashboard.spec.ts
@@ -29,16 +29,17 @@ test.describe('Dashboard', () => {
   });
 
   test('should create composable food entry via AI parse', async ({ page }) => {
-    // Mock the AI parse endpoint. Response schema is
-    // { water, value_mg, measurement_type, reasoning }; client does the
-    // salt→sodium conversion when measurement_type === "salt" (see
-    // src/app/api/ai/parse/route.ts). Returning measurement_type: "sodium"
-    // means value_mg lands in #eating-sodium unchanged.
+    // Mock the AI parse endpoint. The route responds with
+    // { water, salt, measurement_type, sugar, reasoning } — `salt` always
+    // carries sodium in mg regardless of measurement_type (see
+    // src/app/api/ai/parse/route.ts). The client maps `salt` straight into
+    // #eating-sodium and `water` into #eating-water.
     await page.route('/api/ai/parse', async route => {
       const json = {
         water: 200,
-        value_mg: 450,
+        salt: 450,
         measurement_type: 'sodium',
+        sugar: null,
         reasoning: 'Bowl of soup estimated at 200ml water, 450mg sodium',
       };
       await route.fulfill({ json });

--- a/src/components/food-salt-card.tsx
+++ b/src/components/food-salt-card.tsx
@@ -36,39 +36,37 @@ export function FoodSaltCard() {
     >
       <CardContent className="p-6">
         {/* Card header */}
-        <div className="flex items-center gap-2 mb-4">
-          <div className={cn("p-2 rounded-lg", CARD_THEMES.eating.iconBg)}>
-            <Utensils
-              className={cn("w-5 h-5", CARD_THEMES.eating.iconColor)}
-            />
+        <div className="flex items-center justify-between mb-4">
+          <div className="flex items-center gap-2">
+            <div className={cn("p-2 rounded-lg", CARD_THEMES.eating.iconBg)}>
+              <Utensils
+                className={cn("w-5 h-5", CARD_THEMES.eating.iconColor)}
+              />
+            </div>
+            <span className="font-semibold text-lg uppercase tracking-wide">
+              Food
+            </span>
           </div>
-          <span className="font-semibold text-lg uppercase tracking-wide">
-            Food
-          </span>
+          <div className="text-right">
+            <p
+              className={cn(
+                "text-sm font-medium",
+                isOverLimit
+                  ? "text-red-600 dark:text-red-400"
+                  : "text-foreground"
+              )}
+            >
+              {formatAmount(dailyTotal, "mg")} / {formatAmount(limit, "mg")}
+            </p>
+            <p className="text-xs text-muted-foreground">today (sodium)</p>
+            <p className="text-xs text-muted-foreground/70">
+              24h: {formatAmount(rollingTotal, "mg")}
+            </p>
+          </div>
         </div>
 
-        {/* Sodium total + progress bar */}
-        <div className="mb-3">
-          <div className="flex items-center justify-between mb-1.5">
-            <span className="text-xs font-medium text-muted-foreground uppercase tracking-wide">
-              Sodium
-            </span>
-            <div className="text-right">
-              <span
-                className={cn(
-                  "text-sm font-medium",
-                  isOverLimit
-                    ? "text-red-600 dark:text-red-400"
-                    : "text-foreground"
-                )}
-              >
-                {formatAmount(dailyTotal, "mg")} / {formatAmount(limit, "mg")}
-              </span>
-              <span className="text-xs text-muted-foreground/70 ml-2">
-                24h: {formatAmount(rollingTotal, "mg")}
-              </span>
-            </div>
-          </div>
+        {/* Sodium progress bar */}
+        <div className="mb-4">
           <Progress
             value={progressPercent}
             className="h-3"
@@ -80,12 +78,9 @@ export function FoodSaltCard() {
 
         {/* Sugar total + progress bar */}
         <div className="mb-4">
-          <div className="flex items-center justify-between mb-1.5">
-            <span className="text-xs font-medium text-muted-foreground uppercase tracking-wide">
-              Sugar
-            </span>
+          <div className="flex justify-end mb-1.5">
             <div className="text-right">
-              <span
+              <p
                 className={cn(
                   "text-sm font-medium",
                   isOverSugarLimit
@@ -94,10 +89,11 @@ export function FoodSaltCard() {
                 )}
               >
                 {formatAmount(sugarDaily, "g")} / {formatAmount(sugarLimit, "g")}
-              </span>
-              <span className="text-xs text-muted-foreground/70 ml-2">
+              </p>
+              <p className="text-xs text-muted-foreground">today</p>
+              <p className="text-xs text-muted-foreground/70">
                 24h: {formatAmount(sugarRolling, "g")}
-              </span>
+              </p>
             </div>
           </div>
           <Progress

--- a/src/components/food-salt-card.tsx
+++ b/src/components/food-salt-card.tsx
@@ -64,7 +64,6 @@ export function FoodSaltCard() {
               >
                 {formatAmount(dailyTotal, "mg")} / {formatAmount(limit, "mg")}
               </p>
-              <p className="text-xs text-muted-foreground">today (sodium)</p>
               <p className="text-xs text-muted-foreground/70">
                 24h: {formatAmount(rollingTotal, "mg")}
               </p>
@@ -96,7 +95,6 @@ export function FoodSaltCard() {
               >
                 {formatAmount(sugarDaily, "g")} / {formatAmount(sugarLimit, "g")}
               </p>
-              <p className="text-xs text-muted-foreground">today</p>
               <p className="text-xs text-muted-foreground/70">
                 24h: {formatAmount(sugarRolling, "g")}
               </p>

--- a/src/components/food-salt-card.tsx
+++ b/src/components/food-salt-card.tsx
@@ -36,37 +36,40 @@ export function FoodSaltCard() {
     >
       <CardContent className="p-6">
         {/* Card header */}
-        <div className="flex items-center justify-between mb-4">
-          <div className="flex items-center gap-2">
-            <div className={cn("p-2 rounded-lg", CARD_THEMES.eating.iconBg)}>
-              <Utensils
-                className={cn("w-5 h-5", CARD_THEMES.eating.iconColor)}
-              />
-            </div>
-            <span className="font-semibold text-lg uppercase tracking-wide">
-              Food
-            </span>
+        <div className="flex items-center gap-2 mb-4">
+          <div className={cn("p-2 rounded-lg", CARD_THEMES.eating.iconBg)}>
+            <Utensils
+              className={cn("w-5 h-5", CARD_THEMES.eating.iconColor)}
+            />
           </div>
-          <div className="text-right">
-            <p
-              className={cn(
-                "text-sm font-medium",
-                isOverLimit
-                  ? "text-red-600 dark:text-red-400"
-                  : "text-foreground"
-              )}
-            >
-              {formatAmount(dailyTotal, "mg")} / {formatAmount(limit, "mg")}
-            </p>
-            <p className="text-xs text-muted-foreground">today (sodium)</p>
-            <p className="text-xs text-muted-foreground/70">
-              24h: {formatAmount(rollingTotal, "mg")}
-            </p>
-          </div>
+          <span className="font-semibold text-lg uppercase tracking-wide">
+            Food
+          </span>
         </div>
 
-        {/* Sodium progress bar */}
+        {/* Sodium total + progress bar */}
         <div className="mb-4">
+          <div className="flex items-center justify-between mb-1.5">
+            <span className="text-sm font-medium text-muted-foreground">
+              Sodium
+            </span>
+            <div className="text-right">
+              <p
+                className={cn(
+                  "text-sm font-medium",
+                  isOverLimit
+                    ? "text-red-600 dark:text-red-400"
+                    : "text-foreground"
+                )}
+              >
+                {formatAmount(dailyTotal, "mg")} / {formatAmount(limit, "mg")}
+              </p>
+              <p className="text-xs text-muted-foreground">today (sodium)</p>
+              <p className="text-xs text-muted-foreground/70">
+                24h: {formatAmount(rollingTotal, "mg")}
+              </p>
+            </div>
+          </div>
           <Progress
             value={progressPercent}
             className="h-3"
@@ -78,7 +81,10 @@ export function FoodSaltCard() {
 
         {/* Sugar total + progress bar */}
         <div className="mb-4">
-          <div className="flex justify-end mb-1.5">
+          <div className="flex items-center justify-between mb-1.5">
+            <span className="text-sm font-medium text-muted-foreground">
+              Sugar
+            </span>
             <div className="text-right">
               <p
                 className={cn(

--- a/src/components/food-salt-card.tsx
+++ b/src/components/food-salt-card.tsx
@@ -36,37 +36,39 @@ export function FoodSaltCard() {
     >
       <CardContent className="p-6">
         {/* Card header */}
-        <div className="flex items-center justify-between mb-4">
-          <div className="flex items-center gap-2">
-            <div className={cn("p-2 rounded-lg", CARD_THEMES.eating.iconBg)}>
-              <Utensils
-                className={cn("w-5 h-5", CARD_THEMES.eating.iconColor)}
-              />
-            </div>
-            <span className="font-semibold text-lg uppercase tracking-wide">
-              Food
-            </span>
+        <div className="flex items-center gap-2 mb-4">
+          <div className={cn("p-2 rounded-lg", CARD_THEMES.eating.iconBg)}>
+            <Utensils
+              className={cn("w-5 h-5", CARD_THEMES.eating.iconColor)}
+            />
           </div>
-          <div className="text-right">
-            <p
-              className={cn(
-                "text-sm font-medium",
-                isOverLimit
-                  ? "text-red-600 dark:text-red-400"
-                  : "text-foreground"
-              )}
-            >
-              {formatAmount(dailyTotal, "mg")} / {formatAmount(limit, "mg")}
-            </p>
-            <p className="text-xs text-muted-foreground">today (sodium)</p>
-            <p className="text-xs text-muted-foreground/70">
-              24h: {formatAmount(rollingTotal, "mg")}
-            </p>
-          </div>
+          <span className="font-semibold text-lg uppercase tracking-wide">
+            Food
+          </span>
         </div>
 
-        {/* Sodium progress bar */}
+        {/* Sodium total + progress bar */}
         <div className="mb-3">
+          <div className="flex items-center justify-between mb-1.5">
+            <span className="text-xs font-medium text-muted-foreground uppercase tracking-wide">
+              Sodium
+            </span>
+            <div className="text-right">
+              <span
+                className={cn(
+                  "text-sm font-medium",
+                  isOverLimit
+                    ? "text-red-600 dark:text-red-400"
+                    : "text-foreground"
+                )}
+              >
+                {formatAmount(dailyTotal, "mg")} / {formatAmount(limit, "mg")}
+              </span>
+              <span className="text-xs text-muted-foreground/70 ml-2">
+                24h: {formatAmount(rollingTotal, "mg")}
+              </span>
+            </div>
+          </div>
           <Progress
             value={progressPercent}
             className="h-3"

--- a/src/components/liquids-card.tsx
+++ b/src/components/liquids-card.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useRef, useState } from "react";
+import { useMemo, useRef, useState } from "react";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Card, CardContent } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
@@ -16,6 +16,7 @@ import {
   useRecentIntakeRecords,
   useDeleteIntake,
   useUpdateIntake,
+  useSugarTotalsByGroupIds,
 } from "@/hooks/use-intake-queries";
 import { useSettings } from "@/hooks/use-settings";
 import { useToast } from "@/hooks/use-toast";
@@ -48,6 +49,17 @@ export function LiquidsCard() {
   const waterIntake = useIntake("water");
   const settings = useSettings();
   const recentRecords = useRecentIntakeRecords("water");
+
+  // Sugar logged alongside a drink is stored as a linked sugar intake record;
+  // look it up by groupId so recent entries can show it.
+  const groupIds = useMemo(
+    () =>
+      (recentRecords || [])
+        .map((r) => r.groupId)
+        .filter((id): id is string => !!id),
+    [recentRecords]
+  );
+  const groupSugarMap = useSugarTotalsByGroupIds(groupIds);
 
   const { toast } = useToast();
   const deleteMutation = useDeleteIntake();
@@ -330,6 +342,11 @@ export function LiquidsCard() {
                   <span className="font-medium shrink-0">
                     {formatAmount(record.amount, "ml")}
                   </span>
+                  {record.groupId && groupSugarMap.get(record.groupId) ? (
+                    <span className="text-xs font-medium text-pink-600 dark:text-pink-400 shrink-0">
+                      {groupSugarMap.get(record.groupId)}g sugar
+                    </span>
+                  ) : null}
                   {sourceLabel && (
                     <span className="text-xs text-muted-foreground/80 bg-muted/60 px-1.5 py-0.5 rounded truncate">
                       {sourceLabel}

--- a/src/components/liquids/beverage-tab.tsx
+++ b/src/components/liquids/beverage-tab.tsx
@@ -3,6 +3,7 @@
 import { useState, useCallback } from "react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
 import { Progress } from "@/components/ui/progress";
 import { Minus, Plus, Check } from "lucide-react";
 import { cn, formatAmount } from "@/lib/utils";
@@ -11,6 +12,16 @@ import { ManualInputDialog } from "@/components/manual-input-dialog";
 import { useSettings } from "@/hooks/use-settings";
 import { useToast } from "@/hooks/use-toast";
 import { useIntake } from "@/hooks/use-intake-queries";
+import {
+  useAddComposableEntry,
+  type ComposableEntryInput,
+} from "@/hooks/use-composable-entry";
+
+/** Parse the optional sugar field into rounded grams (0 when empty/invalid). */
+function parseSugarGrams(value: string): number {
+  const parsed = parseFloat(value);
+  return Number.isFinite(parsed) && parsed > 0 ? Math.round(parsed) : 0;
+}
 
 const theme = CARD_THEMES.water;
 const unit = "ml";
@@ -29,10 +40,12 @@ export function BeverageTab() {
 
   const [pendingAmount, setPendingAmount] = useState(waterIncrement);
   const [beverageName, setBeverageName] = useState("");
+  const [sugarG, setSugarG] = useState("");
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [showManualInput, setShowManualInput] = useState(false);
 
   const { toast } = useToast();
+  const addEntry = useAddComposableEntry();
 
   const handleIncrement = useCallback(() => {
     setPendingAmount((prev) => prev + waterIncrement);
@@ -42,15 +55,37 @@ export function BeverageTab() {
     setPendingAmount((prev) => Math.max(waterIncrement, prev - waterIncrement));
   }, [waterIncrement]);
 
+  // Log the beverage — when a sugar amount is present, the drink volume and
+  // sugar are written together as one grouped composable entry; otherwise a
+  // plain water record.
+  const logBeverage = useCallback(
+    async (amount: number, timestamp?: number, note?: string) => {
+      const source = beverageName.trim()
+        ? `beverage:${beverageName.trim()}`
+        : "beverage";
+      const sugar = parseSugarGrams(sugarG);
+      if (sugar > 0) {
+        const intakes: ComposableEntryInput["intakes"] = [
+          { type: "water", amount, source, ...(note ? { note } : {}) },
+          { type: "sugar", amount: sugar, source: "manual:sugar" },
+        ];
+        await addEntry(
+          { intakes, groupSource: "manual_beverage_entry" },
+          timestamp
+        );
+      } else {
+        await waterIntake.addRecord(amount, source, timestamp, note);
+      }
+    },
+    [beverageName, sugarG, addEntry, waterIntake]
+  );
+
   const handleConfirm = useCallback(async () => {
     if (pendingAmount <= 0 || isSubmitting) return;
 
     setIsSubmitting(true);
     try {
-      const source = beverageName.trim()
-        ? `beverage:${beverageName.trim()}`
-        : "beverage";
-      await waterIntake.addRecord(pendingAmount, source);
+      await logBeverage(pendingAmount);
       toast({
         title: `Added ${formatAmount(pendingAmount, unit)}`,
         description: "Beverage intake recorded",
@@ -58,6 +93,7 @@ export function BeverageTab() {
       });
       setPendingAmount(waterIncrement);
       setBeverageName("");
+      setSugarG("");
     } catch {
       toast({
         title: "Error",
@@ -67,16 +103,13 @@ export function BeverageTab() {
     } finally {
       setIsSubmitting(false);
     }
-  }, [pendingAmount, isSubmitting, beverageName, waterIntake, toast, waterIncrement]);
+  }, [pendingAmount, isSubmitting, logBeverage, toast, waterIncrement]);
 
   const handleManualSubmit = useCallback(
     async (amount: number, timestamp?: number, note?: string) => {
       setIsSubmitting(true);
       try {
-        const source = beverageName.trim()
-          ? `beverage:${beverageName.trim()}`
-          : "beverage";
-        await waterIntake.addRecord(amount, source, timestamp, note);
+        await logBeverage(amount, timestamp, note);
         toast({
           title: `Added ${formatAmount(amount, unit)}`,
           description: timestamp
@@ -85,6 +118,7 @@ export function BeverageTab() {
           variant: "success",
         });
         setShowManualInput(false);
+        setSugarG("");
       } catch {
         toast({
           title: "Error",
@@ -95,7 +129,7 @@ export function BeverageTab() {
         setIsSubmitting(false);
       }
     },
-    [beverageName, waterIntake, toast]
+    [logBeverage, toast]
   );
 
   return (
@@ -177,6 +211,23 @@ export function BeverageTab() {
         >
           <Plus className="w-6 h-6" />
         </Button>
+      </div>
+
+      {/* Optional sugar content */}
+      <div className="mt-4 space-y-1">
+        <Label htmlFor="beverage-sugar" className="text-sm">
+          Sugar (g){" "}
+          <span className="text-muted-foreground font-normal">(optional)</span>
+        </Label>
+        <Input
+          id="beverage-sugar"
+          type="number"
+          min="0"
+          inputMode="decimal"
+          placeholder="g"
+          value={sugarG}
+          onChange={(e) => setSugarG(e.target.value)}
+        />
       </div>
 
       {/* Confirm Button */}

--- a/src/components/liquids/preset-tab.tsx
+++ b/src/components/liquids/preset-tab.tsx
@@ -41,6 +41,7 @@ export function PresetTab({ tab }: PresetTabProps) {
   const [saltPer100ml, setSaltPer100ml] = useState<number>(0);
   const [waterContentPercent, setWaterContentPercent] = useState<number>(100);
   const [beverageName, setBeverageName] = useState("");
+  const [sugarG, setSugarG] = useState("");
   const [isLookingUp, setIsLookingUp] = useState(false);
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [aiLookupUsed, setAiLookupUsed] = useState(false);
@@ -246,6 +247,15 @@ export function PresetTab({ tab }: PresetTabProps) {
         amount: Math.round((volumeMl / 100) * saltPer100ml),
       });
     }
+    // Sugar intake — direct per-entry gram amount
+    const parsedSugar = parseFloat(sugarG);
+    const sugar =
+      Number.isFinite(parsedSugar) && parsedSugar > 0
+        ? Math.round(parsedSugar)
+        : 0;
+    if (sugar > 0) {
+      intakes.push({ type: "sugar", amount: sugar, source: "manual:sugar" });
+    }
     if (intakes.length > 0) {
       entry.intakes = intakes;
     }
@@ -360,6 +370,7 @@ export function PresetTab({ tab }: PresetTabProps) {
     setSearchText("");
     setSelectedPresetId(null);
     setAiLookupUsed(false);
+    setSugarG("");
   };
 
   // Primary substance label for the per-100ml input
@@ -528,6 +539,26 @@ export function PresetTab({ tab }: PresetTabProps) {
             step={tab === "alcohol" ? "0.5" : "1"}
           />
         </div>
+      </div>
+
+      {/* Optional sugar content */}
+      <div className="mb-3 space-y-1">
+        <Label
+          htmlFor={`${tab}-sugar`}
+          className="text-xs text-muted-foreground"
+        >
+          Sugar (g) — optional
+        </Label>
+        <Input
+          id={`${tab}-sugar`}
+          type="number"
+          min={0}
+          inputMode="decimal"
+          placeholder="g"
+          value={sugarG}
+          onChange={(e) => setSugarG(e.target.value)}
+          className="h-10"
+        />
       </div>
 
       {/* 4. Calculated Amount Display */}

--- a/src/components/liquids/water-tab.tsx
+++ b/src/components/liquids/water-tab.tsx
@@ -2,8 +2,6 @@
 
 import { useState, useCallback } from "react";
 import { Button } from "@/components/ui/button";
-import { Input } from "@/components/ui/input";
-import { Label } from "@/components/ui/label";
 import { Progress } from "@/components/ui/progress";
 import { Minus, Plus, Check } from "lucide-react";
 import { cn, formatAmount } from "@/lib/utils";
@@ -12,16 +10,6 @@ import { ManualInputDialog } from "@/components/manual-input-dialog";
 import { useSettings } from "@/hooks/use-settings";
 import { useToast } from "@/hooks/use-toast";
 import { useIntake } from "@/hooks/use-intake-queries";
-import {
-  useAddComposableEntry,
-  type ComposableEntryInput,
-} from "@/hooks/use-composable-entry";
-
-/** Parse the optional sugar field into rounded grams (0 when empty/invalid). */
-function parseSugarGrams(value: string): number {
-  const parsed = parseFloat(value);
-  return Number.isFinite(parsed) && parsed > 0 ? Math.round(parsed) : 0;
-}
 
 const theme = CARD_THEMES.water;
 const unit = "ml";
@@ -34,12 +22,10 @@ export function WaterTab() {
   const waterIntake = useIntake("water");
 
   const [pendingAmount, setPendingAmount] = useState(waterIncrement);
-  const [sugarG, setSugarG] = useState("");
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [showManualInput, setShowManualInput] = useState(false);
 
   const { toast } = useToast();
-  const addEntry = useAddComposableEntry();
 
   const { dailyTotal } = waterIntake;
 
@@ -57,37 +43,18 @@ export function WaterTab() {
     setPendingAmount((prev) => Math.max(waterIncrement, prev - waterIncrement));
   }, [waterIncrement]);
 
-  // Log water — when a sugar amount is present, water and sugar are written
-  // together as one grouped composable entry; otherwise a plain water record.
-  const logWater = useCallback(
-    async (amount: number, timestamp?: number, note?: string) => {
-      const sugar = parseSugarGrams(sugarG);
-      if (sugar > 0) {
-        const intakes: ComposableEntryInput["intakes"] = [
-          { type: "water", amount, source: "manual", ...(note ? { note } : {}) },
-          { type: "sugar", amount: sugar, source: "manual:sugar" },
-        ];
-        await addEntry({ intakes, groupSource: "manual_water_entry" }, timestamp);
-      } else {
-        await waterIntake.addRecord(amount, "manual", timestamp, note);
-      }
-    },
-    [sugarG, addEntry, waterIntake]
-  );
-
   const handleConfirm = useCallback(async () => {
     if (pendingAmount <= 0 || isSubmitting) return;
 
     setIsSubmitting(true);
     try {
-      await logWater(pendingAmount);
+      await waterIntake.addRecord(pendingAmount, "manual");
       toast({
         title: `Added ${formatAmount(pendingAmount, unit)}`,
         description: "Water intake recorded",
         variant: "success",
       });
       setPendingAmount(waterIncrement);
-      setSugarG("");
     } catch {
       toast({
         title: "Error",
@@ -97,13 +64,13 @@ export function WaterTab() {
     } finally {
       setIsSubmitting(false);
     }
-  }, [pendingAmount, isSubmitting, logWater, toast, waterIncrement]);
+  }, [pendingAmount, isSubmitting, waterIntake, toast, waterIncrement]);
 
   const handleManualSubmit = useCallback(
     async (amount: number, timestamp?: number, note?: string) => {
       setIsSubmitting(true);
       try {
-        await logWater(amount, timestamp, note);
+        await waterIntake.addRecord(amount, "manual", timestamp, note);
         toast({
           title: `Added ${formatAmount(amount, unit)}`,
           description: timestamp
@@ -112,7 +79,6 @@ export function WaterTab() {
           variant: "success",
         });
         setShowManualInput(false);
-        setSugarG("");
       } catch {
         toast({
           title: "Error",
@@ -123,7 +89,7 @@ export function WaterTab() {
         setIsSubmitting(false);
       }
     },
-    [logWater, toast]
+    [waterIntake, toast]
   );
 
   return (
@@ -204,23 +170,6 @@ export function WaterTab() {
         >
           <Plus className="w-6 h-6" />
         </Button>
-      </div>
-
-      {/* Optional sugar content */}
-      <div className="mt-4 space-y-1">
-        <Label htmlFor="water-sugar" className="text-sm">
-          Sugar (g){" "}
-          <span className="text-muted-foreground font-normal">(optional)</span>
-        </Label>
-        <Input
-          id="water-sugar"
-          type="number"
-          min="0"
-          inputMode="decimal"
-          placeholder="g"
-          value={sugarG}
-          onChange={(e) => setSugarG(e.target.value)}
-        />
       </div>
 
       {/* Confirm Button */}

--- a/src/components/liquids/water-tab.tsx
+++ b/src/components/liquids/water-tab.tsx
@@ -2,6 +2,8 @@
 
 import { useState, useCallback } from "react";
 import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
 import { Progress } from "@/components/ui/progress";
 import { Minus, Plus, Check } from "lucide-react";
 import { cn, formatAmount } from "@/lib/utils";
@@ -10,6 +12,16 @@ import { ManualInputDialog } from "@/components/manual-input-dialog";
 import { useSettings } from "@/hooks/use-settings";
 import { useToast } from "@/hooks/use-toast";
 import { useIntake } from "@/hooks/use-intake-queries";
+import {
+  useAddComposableEntry,
+  type ComposableEntryInput,
+} from "@/hooks/use-composable-entry";
+
+/** Parse the optional sugar field into rounded grams (0 when empty/invalid). */
+function parseSugarGrams(value: string): number {
+  const parsed = parseFloat(value);
+  return Number.isFinite(parsed) && parsed > 0 ? Math.round(parsed) : 0;
+}
 
 const theme = CARD_THEMES.water;
 const unit = "ml";
@@ -22,10 +34,12 @@ export function WaterTab() {
   const waterIntake = useIntake("water");
 
   const [pendingAmount, setPendingAmount] = useState(waterIncrement);
+  const [sugarG, setSugarG] = useState("");
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [showManualInput, setShowManualInput] = useState(false);
 
   const { toast } = useToast();
+  const addEntry = useAddComposableEntry();
 
   const { dailyTotal } = waterIntake;
 
@@ -43,18 +57,37 @@ export function WaterTab() {
     setPendingAmount((prev) => Math.max(waterIncrement, prev - waterIncrement));
   }, [waterIncrement]);
 
+  // Log water — when a sugar amount is present, water and sugar are written
+  // together as one grouped composable entry; otherwise a plain water record.
+  const logWater = useCallback(
+    async (amount: number, timestamp?: number, note?: string) => {
+      const sugar = parseSugarGrams(sugarG);
+      if (sugar > 0) {
+        const intakes: ComposableEntryInput["intakes"] = [
+          { type: "water", amount, source: "manual", ...(note ? { note } : {}) },
+          { type: "sugar", amount: sugar, source: "manual:sugar" },
+        ];
+        await addEntry({ intakes, groupSource: "manual_water_entry" }, timestamp);
+      } else {
+        await waterIntake.addRecord(amount, "manual", timestamp, note);
+      }
+    },
+    [sugarG, addEntry, waterIntake]
+  );
+
   const handleConfirm = useCallback(async () => {
     if (pendingAmount <= 0 || isSubmitting) return;
 
     setIsSubmitting(true);
     try {
-      await waterIntake.addRecord(pendingAmount, "manual");
+      await logWater(pendingAmount);
       toast({
         title: `Added ${formatAmount(pendingAmount, unit)}`,
         description: "Water intake recorded",
         variant: "success",
       });
       setPendingAmount(waterIncrement);
+      setSugarG("");
     } catch {
       toast({
         title: "Error",
@@ -64,13 +97,13 @@ export function WaterTab() {
     } finally {
       setIsSubmitting(false);
     }
-  }, [pendingAmount, isSubmitting, waterIntake, toast, waterIncrement]);
+  }, [pendingAmount, isSubmitting, logWater, toast, waterIncrement]);
 
   const handleManualSubmit = useCallback(
     async (amount: number, timestamp?: number, note?: string) => {
       setIsSubmitting(true);
       try {
-        await waterIntake.addRecord(amount, "manual", timestamp, note);
+        await logWater(amount, timestamp, note);
         toast({
           title: `Added ${formatAmount(amount, unit)}`,
           description: timestamp
@@ -79,6 +112,7 @@ export function WaterTab() {
           variant: "success",
         });
         setShowManualInput(false);
+        setSugarG("");
       } catch {
         toast({
           title: "Error",
@@ -89,7 +123,7 @@ export function WaterTab() {
         setIsSubmitting(false);
       }
     },
-    [waterIntake, toast]
+    [logWater, toast]
   );
 
   return (
@@ -170,6 +204,23 @@ export function WaterTab() {
         >
           <Plus className="w-6 h-6" />
         </Button>
+      </div>
+
+      {/* Optional sugar content */}
+      <div className="mt-4 space-y-1">
+        <Label htmlFor="water-sugar" className="text-sm">
+          Sugar (g){" "}
+          <span className="text-muted-foreground font-normal">(optional)</span>
+        </Label>
+        <Input
+          id="water-sugar"
+          type="number"
+          min="0"
+          inputMode="decimal"
+          placeholder="g"
+          value={sugarG}
+          onChange={(e) => setSugarG(e.target.value)}
+        />
       </div>
 
       {/* Confirm Button */}


### PR DESCRIPTION
Adds an optional "Sugar (g)" field to all four Liquids tabs (Water,
Beverage, Coffee, Alcohol). When a sugar amount is entered, the drink
and its sugar are written together as one grouped composable entry, so
drink sugar counts toward the daily sugar total alongside food sugar.
Logged sugar is shown on the Liquids card's recent entries.

Standardizes the Food card's sodium bar to use the same uppercase
labelled-row format as the sugar bar.

https://claude.ai/code/session_012jUcEWKtqiN4uQoBABmEyb

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional sugar (g) input when logging beverages and presets.
  * Sugar intake now displays alongside water entries when linked.

* **UI Improvements**
  * Restructured food card header and tightened nutrient summary layout.
  * Clearer labels for Sodium and Sugar and improved spacing for rolling 24h totals.

* **Tests**
  * Updated end-to-end test mock to align with adjusted nutrient response format.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/RyRy79261/intake-tracker/pull/132?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->