### PR TITLE
fix(voice): salvage valid items instead of 422-ing the whole parse

### DIFF
--- a/src/app/api/ai/voice-parse/route.ts
+++ b/src/app/api/ai/voice-parse/route.ts
@@ -8,78 +8,18 @@ import { parseJsonBody, zodErrorResponse } from "@/app/api/_shared/validation";
 import { createRateLimiter, getClientIp } from "@/app/api/_shared/rate-limit";
 import { recordUsage, tokensFromAnthropic } from "@/app/api/ai/_shared/usage-tracker";
 import { aiErrorResponse } from "@/app/api/ai/_shared/ai-error-response";
+import { PARSE_TOOL, extractVoiceItems } from "@/app/api/ai/voice-parse/schema";
 
 /**
  * Parse a voice transcript into a heterogeneous list of health record items
  * (BP, HR, weight, water, sodium, food, caffeine, alcohol, urination,
  * defecation). Mirrors the pattern in /api/ai/parse — structured tool output,
  * two-turn fallback when the model returns prose instead of calling the
- * tool, and Zod validation on the response.
+ * tool, and per-item validation on the response (see schema.ts).
  */
 
 const ParseRequestSchema = z.object({
   transcript: z.string().min(1).max(2000),
-});
-
-const ItemSchema = z.discriminatedUnion("kind", [
-  z.object({
-    kind: z.literal("blood_pressure"),
-    systolic: z.number().int().min(40).max(260),
-    diastolic: z.number().int().min(20).max(200),
-    heartRate: z.number().int().min(20).max(250).optional(),
-    position: z.enum(["sitting", "standing"]).optional(),
-    arm: z.enum(["left", "right"]).optional(),
-    note: z.string().max(200).optional(),
-  }),
-  z.object({
-    kind: z.literal("weight"),
-    weightKg: z.number().min(1).max(500),
-    note: z.string().max(200).optional(),
-  }),
-  z.object({
-    kind: z.literal("water"),
-    ml: z.number().min(1).max(10000),
-    note: z.string().max(200).optional(),
-  }),
-  z.object({
-    kind: z.literal("salt"),
-    sodiumMg: z.number().min(1).max(20000),
-    note: z.string().max(200).optional(),
-  }),
-  z.object({
-    kind: z.literal("food"),
-    description: z.string().min(1).max(200),
-    grams: z.number().min(1).max(5000).optional(),
-    waterMl: z.number().min(0).max(5000).optional(),
-    sodiumMg: z.number().min(0).max(20000).optional(),
-  }),
-  z.object({
-    kind: z.literal("caffeine"),
-    description: z.string().min(1).max(200),
-    caffeineMg: z.number().min(0).max(2000),
-    volumeMl: z.number().min(0).max(5000).optional(),
-  }),
-  z.object({
-    kind: z.literal("alcohol"),
-    description: z.string().min(1).max(200),
-    abvPercent: z.number().min(0).max(95),
-    volumeMl: z.number().min(1).max(5000),
-  }),
-  z.object({
-    kind: z.literal("urination"),
-    amountEstimate: z.enum(["small", "medium", "large"]).optional(),
-    note: z.string().max(200).optional(),
-  }),
-  z.object({
-    kind: z.literal("defecation"),
-    amountEstimate: z.enum(["small", "medium", "large"]).optional(),
-    note: z.string().max(200).optional(),
-  }),
-]);
-
-const ResponseSchema = z.object({
-  items: z.array(ItemSchema).max(20),
-  reasoning: z.string().max(1000).optional(),
 });
 
 const SYSTEM_PROMPT = `You convert a spoken health log transcript into a structured list of items. The user dictates multiple distinct events in one utterance — extract each as its own item.
@@ -105,66 +45,6 @@ Rules:
 7. If you cannot extract anything from the transcript, return items: [].
 8. Always call the parse_voice_log tool. Never return prose only.
 9. Be conservative on optional fields — only include them if the transcript supports the value.`;
-
-const PARSE_TOOL = {
-  name: "parse_voice_log" as const,
-  description:
-    "Return a structured list of health log items extracted from a voice transcript.",
-  input_schema: {
-    type: "object" as const,
-    properties: {
-      items: {
-        type: "array",
-        description: "Ordered list of extracted items. Empty if nothing parseable.",
-        items: {
-          type: "object",
-          properties: {
-            kind: {
-              type: "string",
-              enum: [
-                "blood_pressure",
-                "weight",
-                "water",
-                "salt",
-                "food",
-                "caffeine",
-                "alcohol",
-                "urination",
-                "defecation",
-              ],
-            },
-            // Fields are union — Anthropic tool input schemas don't enforce
-            // discriminated unions, so we list everything and validate
-            // server-side with Zod.
-            systolic: { type: "number" },
-            diastolic: { type: "number" },
-            heartRate: { type: "number" },
-            position: { type: "string", enum: ["sitting", "standing"] },
-            arm: { type: "string", enum: ["left", "right"] },
-            weightKg: { type: "number" },
-            ml: { type: "number" },
-            sodiumMg: { type: "number" },
-            description: { type: "string" },
-            grams: { type: "number" },
-            waterMl: { type: "number" },
-            caffeineMg: { type: "number" },
-            abvPercent: { type: "number" },
-            volumeMl: { type: "number" },
-            amountEstimate: { type: "string", enum: ["small", "medium", "large"] },
-            note: { type: "string" },
-          },
-          required: ["kind"],
-        },
-      },
-      reasoning: {
-        type: "string",
-        description: "Brief explanation of estimates and assumptions.",
-      },
-    },
-    required: ["items"],
-    additionalProperties: false,
-  },
-};
 
 const rateLimiter = createRateLimiter(20);
 
@@ -306,19 +186,27 @@ export const POST = withAuth(async ({ request, auth }) => {
       );
     }
 
-    const validated = ResponseSchema.safeParse(toolBlock.input);
-    if (!validated.success) {
+    const extracted = extractVoiceItems(toolBlock.input);
+    if (!extracted.ok) {
       console.error(
-        "[VALIDATION] voice-parse response invalid:",
-        JSON.stringify(validated.error.flatten())
+        "[VALIDATION] voice-parse: tool output had no usable items:",
+        JSON.stringify(toolBlock.input)
       );
       return NextResponse.json(
         { error: "AI response format invalid" },
         { status: 422 }
       );
     }
+    if (extracted.dropped > 0) {
+      console.warn(
+        `[VALIDATION] voice-parse: dropped ${extracted.dropped} malformed item(s)`
+      );
+    }
 
-    return NextResponse.json(validated.data);
+    return NextResponse.json({
+      items: extracted.items,
+      ...(extracted.reasoning !== undefined && { reasoning: extracted.reasoning }),
+    });
   } catch (error) {
     const mapped = aiErrorResponse(error);
     if (mapped) return mapped;

--- a/src/app/api/ai/voice-parse/schema.test.ts
+++ b/src/app/api/ai/voice-parse/schema.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect } from "vitest";
+import { extractVoiceItems, PARSE_TOOL, MAX_ITEMS } from "@/app/api/ai/voice-parse/schema";
+
+const bp = { kind: "blood_pressure", systolic: 120, diastolic: 80, heartRate: 72 };
+const water = { kind: "water", ml: 250 };
+const food = { kind: "food", description: "toasted cheese sandwich", grams: 180, sodiumMg: 600 };
+
+describe("extractVoiceItems", () => {
+  it("accepts a well-formed multi-item payload", () => {
+    const result = extractVoiceItems({ items: [bp, water, food], reasoning: "ok" });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.items).toHaveLength(3);
+    expect(result.dropped).toBe(0);
+    expect(result.reasoning).toBe("ok");
+  });
+
+  it("keeps valid items and drops a single malformed one instead of failing all", () => {
+    // blood_pressure item missing required systolic/diastolic.
+    const badBp = { kind: "blood_pressure", heartRate: 72 };
+    const result = extractVoiceItems({ items: [badBp, water, food] });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.items).toHaveLength(2);
+    expect(result.dropped).toBe(1);
+    expect(result.items.map((i) => i.kind)).toEqual(["water", "food"]);
+  });
+
+  it("truncates an over-long reasoning string rather than rejecting the payload", () => {
+    const longReasoning = "x".repeat(5000);
+    const result = extractVoiceItems({ items: [water], reasoning: longReasoning });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.items).toHaveLength(1);
+    expect(result.reasoning).toHaveLength(1000);
+  });
+
+  it("returns an empty list (not a failure) when the model parses nothing", () => {
+    const result = extractVoiceItems({ items: [] });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.items).toHaveLength(0);
+    expect(result.dropped).toBe(0);
+  });
+
+  it("fails when items were present but none survived validation", () => {
+    const result = extractVoiceItems({ items: [{ kind: "blood_pressure" }, { kind: "weight" }] });
+    expect(result.ok).toBe(false);
+  });
+
+  it("fails when the tool output has no items array", () => {
+    expect(extractVoiceItems({ reasoning: "no items key" }).ok).toBe(false);
+    expect(extractVoiceItems({ items: "not-an-array" }).ok).toBe(false);
+    expect(extractVoiceItems(null).ok).toBe(false);
+    expect(extractVoiceItems("string").ok).toBe(false);
+  });
+
+  it("caps the returned list at MAX_ITEMS", () => {
+    const many = Array.from({ length: MAX_ITEMS + 5 }, () => water);
+    const result = extractVoiceItems({ items: many });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.items).toHaveLength(MAX_ITEMS);
+  });
+
+  it("omits reasoning when it is absent or blank", () => {
+    const noReasoning = extractVoiceItems({ items: [water] });
+    expect(noReasoning.ok && noReasoning.reasoning).toBeUndefined();
+    const blank = extractVoiceItems({ items: [water], reasoning: "   " });
+    expect(blank.ok && blank.reasoning).toBeUndefined();
+  });
+});
+
+describe("PARSE_TOOL", () => {
+  it("declares the parse_voice_log tool with an items array", () => {
+    expect(PARSE_TOOL.name).toBe("parse_voice_log");
+    expect(PARSE_TOOL.input_schema.required).toContain("items");
+  });
+});

--- a/src/app/api/ai/voice-parse/schema.ts
+++ b/src/app/api/ai/voice-parse/schema.ts
@@ -1,0 +1,180 @@
+import { z } from "zod";
+
+/**
+ * Schema + tool definition for /api/ai/voice-parse, kept separate from the
+ * route so the parsing logic can be unit-tested without pulling in Next.js
+ * request machinery (mirrors api/ai/substance-lookup/schema.ts).
+ */
+
+export const ItemSchema = z.discriminatedUnion("kind", [
+  z.object({
+    kind: z.literal("blood_pressure"),
+    systolic: z.number().int().min(40).max(260),
+    diastolic: z.number().int().min(20).max(200),
+    heartRate: z.number().int().min(20).max(250).optional(),
+    position: z.enum(["sitting", "standing"]).optional(),
+    arm: z.enum(["left", "right"]).optional(),
+    note: z.string().max(200).optional(),
+  }),
+  z.object({
+    kind: z.literal("weight"),
+    weightKg: z.number().min(1).max(500),
+    note: z.string().max(200).optional(),
+  }),
+  z.object({
+    kind: z.literal("water"),
+    ml: z.number().min(1).max(10000),
+    note: z.string().max(200).optional(),
+  }),
+  z.object({
+    kind: z.literal("salt"),
+    sodiumMg: z.number().min(1).max(20000),
+    note: z.string().max(200).optional(),
+  }),
+  z.object({
+    kind: z.literal("food"),
+    description: z.string().min(1).max(200),
+    grams: z.number().min(1).max(5000).optional(),
+    waterMl: z.number().min(0).max(5000).optional(),
+    sodiumMg: z.number().min(0).max(20000).optional(),
+  }),
+  z.object({
+    kind: z.literal("caffeine"),
+    description: z.string().min(1).max(200),
+    caffeineMg: z.number().min(0).max(2000),
+    volumeMl: z.number().min(0).max(5000).optional(),
+  }),
+  z.object({
+    kind: z.literal("alcohol"),
+    description: z.string().min(1).max(200),
+    abvPercent: z.number().min(0).max(95),
+    volumeMl: z.number().min(1).max(5000),
+  }),
+  z.object({
+    kind: z.literal("urination"),
+    amountEstimate: z.enum(["small", "medium", "large"]).optional(),
+    note: z.string().max(200).optional(),
+  }),
+  z.object({
+    kind: z.literal("defecation"),
+    amountEstimate: z.enum(["small", "medium", "large"]).optional(),
+    note: z.string().max(200).optional(),
+  }),
+]);
+
+export type VoiceParsedItem = z.infer<typeof ItemSchema>;
+
+export const MAX_ITEMS = 20;
+const MAX_REASONING_CHARS = 1000;
+
+export const PARSE_TOOL = {
+  name: "parse_voice_log" as const,
+  description:
+    "Return a structured list of health log items extracted from a voice transcript.",
+  input_schema: {
+    type: "object" as const,
+    properties: {
+      items: {
+        type: "array",
+        description: "Ordered list of extracted items. Empty if nothing parseable.",
+        items: {
+          type: "object",
+          properties: {
+            kind: {
+              type: "string",
+              enum: [
+                "blood_pressure",
+                "weight",
+                "water",
+                "salt",
+                "food",
+                "caffeine",
+                "alcohol",
+                "urination",
+                "defecation",
+              ],
+            },
+            // Fields are union — Anthropic tool input schemas don't enforce
+            // discriminated unions, so we list everything and validate
+            // server-side with Zod.
+            systolic: { type: "number" },
+            diastolic: { type: "number" },
+            heartRate: { type: "number" },
+            position: { type: "string", enum: ["sitting", "standing"] },
+            arm: { type: "string", enum: ["left", "right"] },
+            weightKg: { type: "number" },
+            ml: { type: "number" },
+            sodiumMg: { type: "number" },
+            description: { type: "string" },
+            grams: { type: "number" },
+            waterMl: { type: "number" },
+            caffeineMg: { type: "number" },
+            abvPercent: { type: "number" },
+            volumeMl: { type: "number" },
+            amountEstimate: { type: "string", enum: ["small", "medium", "large"] },
+            note: { type: "string" },
+          },
+          required: ["kind"],
+        },
+      },
+      reasoning: {
+        type: "string",
+        description: "Brief (one or two sentences) explanation of estimates and assumptions.",
+      },
+    },
+    required: ["items"],
+    additionalProperties: false,
+  },
+};
+
+export type VoiceExtractResult =
+  | { ok: true; items: VoiceParsedItem[]; reasoning?: string; dropped: number }
+  | { ok: false };
+
+/**
+ * Resiliently extract the parse_voice_log tool output.
+ *
+ * Previously the whole payload was validated atomically (one Zod object with
+ * `items: z.array(ItemSchema)` and `reasoning: z.string().max(1000)`). Any
+ * single defect — one malformed item, or just a `reasoning` string longer
+ * than 1000 chars, which is common once a multi-item log gets a per-item
+ * explanation — rejected the entire response and surfaced to the user as a
+ * 422 "AI response format invalid", discarding every correctly-parsed item.
+ *
+ * Instead: validate each item independently and keep the good ones, and
+ * coerce `reasoning` (truncate) rather than rejecting on its length. Fail
+ * only when there is no usable items array, or items were present but none
+ * survived validation.
+ */
+export function extractVoiceItems(input: unknown): VoiceExtractResult {
+  if (typeof input !== "object" || input === null) return { ok: false };
+  const obj = input as { items?: unknown; reasoning?: unknown };
+  if (!Array.isArray(obj.items)) return { ok: false };
+
+  const items: VoiceParsedItem[] = [];
+  let dropped = 0;
+  for (const raw of obj.items) {
+    const parsed = ItemSchema.safeParse(raw);
+    if (parsed.success) {
+      items.push(parsed.data);
+    } else {
+      dropped++;
+    }
+  }
+
+  // Model returned items but every one failed validation — a genuine format
+  // failure, not an empty result.
+  if (obj.items.length > 0 && items.length === 0) return { ok: false };
+
+  const reasoning =
+    typeof obj.reasoning === "string" && obj.reasoning.trim().length > 0
+      ? obj.reasoning.slice(0, MAX_REASONING_CHARS)
+      : undefined;
+
+  return {
+    ok: true,
+    items: items.slice(0, MAX_ITEMS),
+    dropped,
+    ...(reasoning ? { reasoning } : {}),
+  };
+}


### PR DESCRIPTION
The voice-parse route validated the model's tool output atomically: a
single Zod object with `items: z.array(ItemSchema)` and
`reasoning: z.string().max(1000)`. Any single defect — one malformed
item, or just a `reasoning` string over 1000 chars, which happens
routinely once a multi-item log gets a per-item explanation — rejected
the entire response as a 422 "AI response format invalid", discarding
every correctly-parsed item.

Extract the schema + tool into a testable schema.ts and validate each
item independently: keep the good ones, drop the bad ones, and truncate
`reasoning` rather than rejecting on its length. Only fail when there is
no usable items array or when items were present but none survived.

https://claude.ai/code/session_016kZJ4EeiekY31PRKDrrqeT