### PR TITLE
feat(voice): track sugar in voice input pipeline

### DIFF
--- a/src/app/api/ai/voice-parse/route.ts
+++ b/src/app/api/ai/voice-parse/route.ts
@@ -29,7 +29,7 @@ Item kinds (use exactly these strings):
 - "weight": weightKg (number, convert if user says lbs: kg = lbs * 0.4536)
 - "water": ml (number, convert oz: ml = oz * 29.5735, cup: 240, glass: 250)
 - "salt": sodiumMg (number, in mg sodium NOT salt — if user says "1g of salt" convert: sodium_mg = salt_g * 400)
-- "food": description (short string), grams (optional), waterMl (optional rough estimate of water content), sodiumMg (optional rough estimate of sodium)
+- "food": description (short string), grams (optional), waterMl (optional rough estimate of water content), sodiumMg (optional rough estimate of sodium), sugarG (optional rough estimate of total sugars in grams — the sum of naturally-occurring and added sugars, as on a nutrition label's "of which sugars" line. Examples: 330ml can of regular cola ~35g, medium apple ~19g, banana ~14g, glass of milk 250ml ~12g, fruit juice 250ml ~22g, plain water/black coffee/eggs/plain meat ~0g)
 - "caffeine": description, caffeineMg (e.g. drip coffee 250ml ~ 95mg, espresso 30ml ~ 63mg, tea ~ 47mg), volumeMl (optional)
 - "alcohol": description, abvPercent (alcohol by volume % — the number printed on the bottle label: lager ~5, IPA ~6, red wine ~13, vodka ~40), volumeMl (volume of the drink in ml: pint 568, half pint 284, wine glass 125-175, single spirit measure 25-30, double 50). Always provide BOTH abvPercent and volumeMl. Never report "standard drinks" or "units" — the app derives those from abvPercent and volumeMl.
 - "urination": amountEstimate ("small"|"medium"|"large", optional)

--- a/src/app/api/ai/voice-parse/schema.ts
+++ b/src/app/api/ai/voice-parse/schema.ts
@@ -37,6 +37,7 @@ export const ItemSchema = z.discriminatedUnion("kind", [
     grams: z.number().min(1).max(5000).optional(),
     waterMl: z.number().min(0).max(5000).optional(),
     sodiumMg: z.number().min(0).max(20000).optional(),
+    sugarG: z.number().min(0).max(1000).optional(),
   }),
   z.object({
     kind: z.literal("caffeine"),
@@ -108,6 +109,7 @@ export const PARSE_TOOL = {
             description: { type: "string" },
             grams: { type: "number" },
             waterMl: { type: "number" },
+            sugarG: { type: "number" },
             caffeineMg: { type: "number" },
             abvPercent: { type: "number" },
             volumeMl: { type: "number" },

--- a/src/components/voice/parsed-item-row.tsx
+++ b/src/components/voice/parsed-item-row.tsx
@@ -216,7 +216,7 @@ function ItemEditor({
               onChange={(e) => onChange({ ...item, description: e.target.value })}
             />
           </Field>
-          <div className="grid grid-cols-3 gap-2">
+          <div className="grid grid-cols-2 gap-2">
             <Field label="Grams">
               <Input
                 type="number"
@@ -250,6 +250,19 @@ function ItemEditor({
                 placeholder="—"
                 onChange={(e) =>
                   onChange(setOptionalNumber(item, "sodiumMg", e.target.value))
+                }
+              />
+            </Field>
+            <Field label="Sugar (g)">
+              <Input
+                type="number"
+                inputMode="decimal"
+                step="0.1"
+                disabled={disabled}
+                value={item.sugarG ?? ""}
+                placeholder="—"
+                onChange={(e) =>
+                  onChange(setOptionalNumber(item, "sugarG", e.target.value))
                 }
               />
             </Field>

--- a/src/components/voice/voice-panel.tsx
+++ b/src/components/voice/voice-panel.tsx
@@ -211,6 +211,14 @@ export function VoicePanel({ onCommitted }: VoicePanelProps) {
                 note: item.description,
               });
             }
+            if (item.sugarG && item.sugarG > 0) {
+              await addIntake.mutateAsync({
+                type: "sugar",
+                amount: item.sugarG,
+                source: `voice:food:${eating.id}`,
+                note: item.description,
+              });
+            }
             break;
           }
           case "caffeine":

--- a/src/lib/voice-types.ts
+++ b/src/lib/voice-types.ts
@@ -52,6 +52,7 @@ export interface FoodItem {
   grams?: number;
   waterMl?: number;
   sodiumMg?: number;
+  sugarG?: number;
 }
 
 export interface CaffeineItem {


### PR DESCRIPTION
The voice-parse flow extracted water and sodium from food items but
ignored sugar entirely — Claude was never asked for it, the schema
rejected it, the review UI hid it, and commit never wrote a sugar
intake. Add sugarG end-to-end so spoken food/drink entries record
sugar the same way the manual food form does.