### PR TITLE
fix: use router.back() from help manual pages

### DIFF
--- a/src/components/help/manual-view.tsx
+++ b/src/components/help/manual-view.tsx
@@ -15,7 +15,7 @@ export function ManualView({ manual }: { manual: Manual }) {
 
   return (
     <div className="pb-12">
-      <HelpTopBar title="User Manual" onBack={() => router.push("/help")} />
+      <HelpTopBar title="User Manual" onBack={() => router.back()} />
 
       <header className="mb-6">
         <div className="mb-1 flex items-center gap-2">


### PR DESCRIPTION
The manual page's back button was calling router.push("/help"), which
appended a new /help entry on top of the existing one. Pressing the
browser back button then alternated between /help and /help/<slug>
instead of unwinding past the manual.

https://claude.ai/code/session_01BCEb3375jZJ3nEgn6ALVRx

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved back navigation in manual help section to use browser history instead of a hardcoded path, allowing users to return to their previous location rather than being redirected to a fixed destination.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/RyRy79261/intake-tracker/pull/141?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->