### PR TITLE
Fix OAuth origin resolution to prefer custom domains over Vercel URLs

### DIFF
--- a/src/lib/mcp/origin.ts
+++ b/src/lib/mcp/origin.ts
@@ -21,6 +21,14 @@
  */
 import type { NextRequest } from "next/server";
 
+function tryParseUrl(input: string): URL | null {
+  try {
+    return new URL(input);
+  } catch {
+    return null;
+  }
+}
+
 export function getPublicOrigin(req?: NextRequest | Request): string {
   const override = process.env.MCP_PUBLIC_URL?.trim();
   if (override) return override.replace(/\/$/, "");
@@ -30,13 +38,24 @@ export function getPublicOrigin(req?: NextRequest | Request): string {
     if (headers) {
       const fwdHost = headers.get("x-forwarded-host");
       const fwdProto = headers.get("x-forwarded-proto");
+      // Derive the scheme from the request itself as the last-resort
+      // proto fallback — better than hard-coding "http" behind a proxy
+      // that terminates TLS upstream but strips x-forwarded-proto.
+      const requestProto = (() => {
+        const url =
+          "nextUrl" in req
+            ? (req as NextRequest).nextUrl
+            : tryParseUrl(req.url);
+        return url?.protocol.replace(/:$/, "");
+      })();
+
       if (fwdHost) {
-        const proto = fwdProto ?? "https";
+        const proto = fwdProto ?? requestProto ?? "https";
         return `${proto}://${fwdHost}`;
       }
       const host = headers.get("host");
       if (host) {
-        const proto = fwdProto ?? "http";
+        const proto = fwdProto ?? requestProto ?? "http";
         return `${proto}://${host}`;
       }
     }

--- a/src/lib/mcp/origin.ts
+++ b/src/lib/mcp/origin.ts
@@ -2,20 +2,28 @@
  * Resolve the public origin of this app for use in OAuth metadata,
  * redirect URIs, etc.
  *
- * Priority:
+ * Priority (request headers MUST win over VERCEL_URL — see below):
  *   1. MCP_PUBLIC_URL (explicit override for prod / staging)
- *   2. VERCEL_URL (Vercel auto-set, no protocol)
- *   3. Request `x-forwarded-host` + `x-forwarded-proto`
- *   4. Request `host` + `x-forwarded-proto` / req.protocol
+ *   2. Request `x-forwarded-host` + `x-forwarded-proto` (what the user
+ *      actually hit, including custom domains)
+ *   3. Request `host` header (less reliable, but still real)
+ *   4. VERCEL_URL (deployment-hash fallback; useful only when no
+ *      request is available, e.g. background jobs)
+ *   5. localhost (dev fallback)
+ *
+ * Why VERCEL_URL is NOT preferred: Vercel auto-sets it to the
+ * deployment-hash URL (e.g. intake-tracker-ooptvrqpl-…vercel.app),
+ * which is gated by Vercel SSO on production deployments. Using it as
+ * the OAuth issuer means claude.ai's connector tries to redirect users
+ * there and hits a 403. The custom domain (delivered via forwarded
+ * headers) is the URL the user actually configured, and is the right
+ * issuer for every OAuth document.
  */
 import type { NextRequest } from "next/server";
 
 export function getPublicOrigin(req?: NextRequest | Request): string {
   const override = process.env.MCP_PUBLIC_URL?.trim();
   if (override) return override.replace(/\/$/, "");
-
-  const vercel = process.env.VERCEL_URL?.trim();
-  if (vercel) return `https://${vercel.replace(/^https?:\/\//, "")}`;
 
   if (req) {
     const headers = "headers" in req ? req.headers : null;
@@ -33,6 +41,9 @@ export function getPublicOrigin(req?: NextRequest | Request): string {
       }
     }
   }
+
+  const vercel = process.env.VERCEL_URL?.trim();
+  if (vercel) return `https://${vercel.replace(/^https?:\/\//, "")}`;
 
   return "http://localhost:3000";
 }


### PR DESCRIPTION
## Summary

Reorders the origin resolution priority in `getPublicOrigin()` to ensure request headers (which contain the actual custom domain the user hit) take precedence over `VERCEL_URL`. This fixes OAuth redirect failures on production deployments where Vercel's auto-generated deployment-hash URLs are gated behind Vercel SSO.

## Changes

- **Reordered priority chain:**
  1. `MCP_PUBLIC_URL` (explicit override) — unchanged
  2. Request `x-forwarded-host` + `x-forwarded-proto` (custom domain) — **moved up**
  3. Request `host` header — **moved up**
  4. `VERCEL_URL` (deployment-hash fallback) — **moved down**
  5. `localhost:3000` (dev fallback) — unchanged

- **Updated documentation** with detailed explanation of why `VERCEL_URL` must not be preferred:
  - Vercel auto-sets it to a deployment-hash URL (e.g., `intake-tracker-ooptvrqpl-…vercel.app`)
  - Production deployments gate this URL behind Vercel SSO
  - OAuth issuers using this URL cause claude.ai's connector to redirect users there and hit 403
  - The custom domain (delivered via forwarded headers) is the URL users actually configured and the correct OAuth issuer

## Implementation Details

The code now checks for request headers first (when available), falling back to `VERCEL_URL` only when no request context exists (e.g., background jobs). This ensures OAuth metadata and redirect URIs use the user-facing domain rather than Vercel's internal deployment URL.

https://claude.ai/code/session_01SzeaVzTJo454ehDf6Y3itX

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved public origin resolution to prioritize request headers over environment variables, ensuring correct URL detection across various deployment scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/RyRy79261/intake-tracker/pull/148?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->