### PR TITLE
Route OAuth callback through /auth page instead of API endpoint

### DIFF
--- a/src/app/api/mcp/oauth/authorize/route.ts
+++ b/src/app/api/mcp/oauth/authorize/route.ts
@@ -3,9 +3,13 @@
  *
  *   1. Validate query params (client_id, redirect_uri, PKCE, state).
  *   2. Check Neon Auth session.
- *      - If none, redirect to /api/auth/sign-in/social?provider=google with
- *        callbackURL pointing back here. After Google sign-in completes,
- *        Neon Auth sets the session cookie and re-delivers the user to us.
+ *      - If none, redirect to /auth?callbackURL=<this-url>. The /auth
+ *        page is the client-side sign-in UI (email/password + Google
+ *        button) — it forwards the callbackURL into signIn.social /
+ *        signIn.email so the user lands back here after sign-in.
+ *        We can't redirect straight to /api/auth/sign-in/social: that
+ *        endpoint is the Neon Auth POST-only JSON API, not a navigable
+ *        browser URL.
  *   3. Verify the signed-in email is on the ALLOWED_EMAILS whitelist.
  *   4. Mirror the user into neon_auth.users_sync (FK target for auth_codes).
  *   5. Render a minimal consent page on first GET; on POST (Approve), mint
@@ -152,11 +156,16 @@ export async function GET(req: NextRequest) {
 
   const user = await getSignedInUser();
   if (!user) {
+    // Bounce through the /auth page (client UI) rather than the
+    // /api/auth/sign-in/social JSON endpoint, which only accepts POST.
+    // The /auth page reads `callbackURL` from its query string and
+    // passes it into signIn.social({...}), so the user lands back here
+    // after Google completes. callbackURL is a same-origin relative
+    // path (sign-in-form.tsx rejects anything else).
     const origin = getPublicOrigin(req);
-    const callback = `${origin}/api/mcp/oauth/authorize?${req.nextUrl.searchParams.toString()}`;
-    const signInUrl = new URL("/api/auth/sign-in/social", origin);
-    signInUrl.searchParams.set("provider", "google");
-    signInUrl.searchParams.set("callbackURL", callback);
+    const callbackPath = `/api/mcp/oauth/authorize?${req.nextUrl.searchParams.toString()}`;
+    const signInUrl = new URL("/auth", origin);
+    signInUrl.searchParams.set("callbackURL", callbackPath);
     return NextResponse.redirect(signInUrl.toString(), { status: 302 });
   }
 

--- a/src/app/auth/page.tsx
+++ b/src/app/auth/page.tsx
@@ -1,3 +1,4 @@
+import { Suspense } from "react";
 import { AuthShell } from "@/app/auth/auth-shell";
 import { SignInForm } from "@/app/auth/sign-in-form";
 
@@ -5,11 +6,18 @@ import { SignInForm } from "@/app/auth/sign-in-form";
  * The single sign-in surface for the app. Middleware (src/middleware.ts)
  * redirects every unauthenticated page request here. Uses the login-04
  * two-column shadcn layout via `AuthShell`.
+ *
+ * SignInForm calls `useSearchParams()` to honour a `?callbackURL=` query
+ * param (used by the MCP authorize route to return the user here after
+ * Google sign-in). Next.js 14 requires that hook to be inside a Suspense
+ * boundary so the page can still be statically prerendered.
  */
 export default function AuthPage() {
   return (
     <AuthShell>
-      <SignInForm />
+      <Suspense fallback={null}>
+        <SignInForm />
+      </Suspense>
     </AuthShell>
   );
 }

--- a/src/app/auth/sign-in-form.tsx
+++ b/src/app/auth/sign-in-form.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import Link from "next/link";
-import { useRouter } from "next/navigation";
+import { useRouter, useSearchParams } from "next/navigation";
 import { useState, type FormEvent } from "react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -9,8 +9,23 @@ import { Label } from "@/components/ui/label";
 import { signIn } from "@/lib/auth-client";
 import { isCapacitorMode } from "@/lib/api-fetch";
 
+/**
+ * Only accept a same-origin relative path as the post-sign-in target.
+ * Rejects absolute URLs (cross-origin redirect attack), protocol-relative
+ * URLs (`//evil.example`), and anything that doesn't start with a single
+ * `/`. Returns the canonical fallback `/` for anything invalid.
+ */
+function safeCallbackUrl(raw: string | null | undefined): string {
+  if (!raw) return "/";
+  if (!raw.startsWith("/")) return "/";
+  if (raw.startsWith("//")) return "/";
+  return raw;
+}
+
 export function SignInForm() {
   const router = useRouter();
+  const searchParams = useSearchParams();
+  const callbackURL = safeCallbackUrl(searchParams.get("callbackURL"));
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
   const [error, setError] = useState<string | null>(null);
@@ -34,12 +49,12 @@ export function SignInForm() {
       const result = await signIn.email({
         email: email.trim(),
         password,
-        callbackURL: "/",
+        callbackURL,
       });
       if (result && "error" in result && result.error) {
         setError(result.error.message ?? "Sign in failed");
       } else if (isCapacitorMode()) {
-        router.replace("/");
+        router.replace(callbackURL);
       }
     } catch (err) {
       setError(err instanceof Error ? err.message : "Sign in failed");
@@ -52,7 +67,7 @@ export function SignInForm() {
     setError(null);
     setLoading(true);
     try {
-      await signIn.social({ provider: "google", callbackURL: "/" });
+      await signIn.social({ provider: "google", callbackURL });
     } catch (err) {
       setError(err instanceof Error ? err.message : "Google sign in failed");
       setLoading(false);


### PR DESCRIPTION
## Summary

Refactors the MCP OAuth authorize flow to redirect unauthenticated users through the `/auth` sign-in page (client-side UI) rather than directly to the `/api/auth/sign-in/social` API endpoint. This allows the sign-in page to capture and honor a `callbackURL` query parameter, returning users to the OAuth flow after authentication completes.

## Key Changes

- **src/app/api/mcp/oauth/authorize/route.ts**
  - Changed unauthenticated redirect target from `/api/auth/sign-in/social?provider=google&callbackURL=...` to `/auth?callbackURL=...`
  - Updated comments to explain that `/api/auth/sign-in/social` is a POST-only JSON API, not a navigable browser URL
  - Simplified redirect logic: now passes only `callbackURL` (the OAuth authorize URL with all query params) to the `/auth` page

- **src/app/auth/sign-in-form.tsx**
  - Added `useSearchParams()` hook to read `callbackURL` from query string
  - Implemented `safeCallbackUrl()` validation function to prevent open redirect attacks (rejects absolute URLs, protocol-relative URLs, and anything not starting with `/`)
  - Updated both email and social sign-in calls to use the validated `callbackURL` instead of hardcoded `/`
  - Updated Capacitor mode fallback to use `callbackURL` instead of `/`

- **src/app/auth/page.tsx**
  - Wrapped `<SignInForm />` in a `<Suspense>` boundary to support Next.js 14's static prerendering requirement when using `useSearchParams()`
  - Added documentation explaining the `callbackURL` parameter and Suspense requirement

## Implementation Details

The `safeCallbackUrl()` function validates the callback URL by:
1. Returning `/` for null/undefined/empty values
2. Rejecting URLs that don't start with `/` (prevents cross-origin redirects)
3. Rejecting protocol-relative URLs starting with `//` (prevents `//evil.example` attacks)
4. Accepting any other same-origin relative path

This ensures that after Google sign-in completes via the `/auth` page, users are safely returned to the MCP OAuth authorize endpoint with all original query parameters intact.

https://claude.ai/code/session_01SzeaVzTJo454ehDf6Y3itX