### PR TITLE
Auto-forward authenticated users from sign-in page

### DIFF
--- a/src/app/auth/sign-in-form.tsx
+++ b/src/app/auth/sign-in-form.tsx
@@ -2,11 +2,11 @@
 
 import Link from "next/link";
 import { useRouter, useSearchParams } from "next/navigation";
-import { useState, type FormEvent } from "react";
+import { useEffect, useState, type FormEvent } from "react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
-import { signIn } from "@/lib/auth-client";
+import { signIn, useSession } from "@/lib/auth-client";
 import { isCapacitorMode } from "@/lib/api-fetch";
 
 /**
@@ -26,10 +26,25 @@ export function SignInForm() {
   const router = useRouter();
   const searchParams = useSearchParams();
   const callbackURL = safeCallbackUrl(searchParams.get("callbackURL"));
+  const { data: session, isPending: sessionPending } = useSession();
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
+
+  // Auto-forward when the user lands here with an active session AND a
+  // pending callbackURL. This catches the case where Better Auth's social
+  // sign-in returns the user to the originating page (/auth?callbackURL=…)
+  // instead of unwrapping the callbackURL value itself — without this the
+  // user would just see the sign-in form again despite being authenticated.
+  useEffect(() => {
+    if (sessionPending) return;
+    if (!session?.user) return;
+    if (callbackURL === "/") return;
+    // Hard navigation: callbackURL may be an API route (e.g. the MCP
+    // authorize endpoint), which router.push won't reach.
+    window.location.replace(callbackURL);
+  }, [sessionPending, session, callbackURL]);
 
   async function handleEmailSubmit(e: FormEvent<HTMLFormElement>) {
     e.preventDefault();


### PR DESCRIPTION
## Summary

Adds automatic redirection logic to the sign-in form when a user arrives with an active session and a pending `callbackURL`. This fixes a UX issue where Better Auth's social sign-in flow would return users to the sign-in page (`/auth?callbackURL=…`) instead of completing the redirect to their intended destination.

## Changes

- Import `useEffect` and `useSession` hook from auth client
- Add session state tracking via `useSession()` hook
- Implement `useEffect` that monitors session status and auto-redirects when:
  - Session data has loaded (`!sessionPending`)
  - User is authenticated (`session?.user` exists)
  - A non-root `callbackURL` is present
- Use `window.location.replace()` for hard navigation to support API route callbacks (e.g., MCP authorize endpoints) that `router.push()` cannot reach

## Implementation Details

The redirect logic uses `window.location.replace()` rather than Next.js's `router.push()` because the `callbackURL` may point to API routes or external endpoints that the client-side router cannot handle. The effect dependency array ensures the redirect fires once session data is available and stable.

https://claude.ai/code/session_01SzeaVzTJo454ehDf6Y3itX