### PR TITLE
Add Neon Auth middleware for OAuth verifier exchange

### DIFF
--- a/src/__tests__/auth-middleware.test.ts
+++ b/src/__tests__/auth-middleware.test.ts
@@ -25,6 +25,13 @@ const getSessionMock = vi.fn(
   async (): Promise<GetSessionResult> => ({ data: null, error: null })
 );
 
+// Trackable Neon Auth middleware so the root-middleware delegation test
+// below can assert that requests for /auth (and /auth/*) actually invoke
+// it — not just that the path is on the matcher list.
+const neonAuthMiddlewareFn = vi.fn(
+  async (_req: NextRequest) => new Response(null, { status: 204 })
+);
+
 vi.mock("@/lib/neon-auth", () => ({
   auth: {
     getSession: () => getSessionMock(),
@@ -32,8 +39,7 @@ vi.mock("@/lib/neon-auth", () => ({
       GET: async () => new Response(null, { status: 204 }),
       POST: async () => new Response(null, { status: 204 }),
     }),
-    middleware: (_config?: { loginUrl?: string }) =>
-      async (_req: NextRequest) => new Response(null, { status: 204 }),
+    middleware: (_config?: { loginUrl?: string }) => neonAuthMiddlewareFn,
   },
 }));
 
@@ -171,5 +177,30 @@ describe("root middleware.ts", () => {
     expect(matcher).toEqual(
       expect.arrayContaining(["/api/:path*", "/auth", "/auth/:path*"]),
     );
+  });
+
+  it("delegates /auth requests to the Neon Auth middleware", async () => {
+    neonAuthMiddlewareFn.mockClear();
+    const { default: middleware } = await import("@/middleware");
+    const req = new NextRequest("https://example.test/auth?callbackURL=/foo");
+    await middleware(req);
+    expect(neonAuthMiddlewareFn).toHaveBeenCalledTimes(1);
+    expect(neonAuthMiddlewareFn).toHaveBeenCalledWith(req);
+  });
+
+  it("delegates /auth/* subroutes to the Neon Auth middleware", async () => {
+    neonAuthMiddlewareFn.mockClear();
+    const { default: middleware } = await import("@/middleware");
+    const req = new NextRequest("https://example.test/auth/sign-up");
+    await middleware(req);
+    expect(neonAuthMiddlewareFn).toHaveBeenCalledTimes(1);
+  });
+
+  it("does NOT delegate /api/* requests to the Neon Auth middleware", async () => {
+    neonAuthMiddlewareFn.mockClear();
+    const { default: middleware } = await import("@/middleware");
+    const req = new NextRequest("https://example.test/api/mcp/oauth/register");
+    await middleware(req);
+    expect(neonAuthMiddlewareFn).not.toHaveBeenCalled();
   });
 });

--- a/src/__tests__/auth-middleware.test.ts
+++ b/src/__tests__/auth-middleware.test.ts
@@ -162,7 +162,14 @@ describe("root middleware.ts", () => {
     expect(mod.config).toBeDefined();
     expect(Array.isArray(mod.config.matcher)).toBe(true);
     const matcher = mod.config.matcher as string[];
-    expect(matcher.length).toBe(1);
-    expect(matcher).toContain("/api/:path*");
+    // /api/:path* drives the capacitor CORS branch; /auth and /auth/* are
+    // routed through Neon Auth's middleware so the OAuth verifier-exchange
+    // step runs on the OAuth return trip (without it the session cookie
+    // never materialises and the MCP custom-connector flow stalls after
+    // Google sign-in).
+    expect(matcher.length).toBe(3);
+    expect(matcher).toEqual(
+      expect.arrayContaining(["/api/:path*", "/auth", "/auth/:path*"]),
+    );
   });
 });

--- a/src/__tests__/cors-middleware.test.ts
+++ b/src/__tests__/cors-middleware.test.ts
@@ -1,6 +1,18 @@
 import { describe, it, expect, vi } from "vitest";
 import { NextRequest } from "next/server";
 
+// Mock the Neon Auth module to avoid pulling @neondatabase/auth/next/server
+// (which imports next/headers and fails to resolve under vitest). The CORS
+// branch of the middleware never invokes neonAuthMiddleware, so a no-op
+// stub is sufficient for these tests.
+vi.mock("@/lib/neon-auth", () => ({
+  auth: {
+    middleware: () => () => {
+      throw new Error("neon auth middleware called unexpectedly");
+    },
+  },
+}));
+
 
 function makeApiRequest(
   path: string,
@@ -87,9 +99,15 @@ describe("CORS middleware for /api/* routes", () => {
     expect(res.headers.get("Access-Control-Allow-Origin")).toBeNull();
   });
 
-  it("matcher config includes only /api/:path*", async () => {
+  it("matcher config includes /api/:path* and the /auth paths used by the verifier exchange", async () => {
     const { config } = await import("@/middleware");
-    expect(config.matcher).toContain("/api/:path*");
-    expect(config.matcher.length).toBe(1);
+    expect(config.matcher).toEqual(
+      expect.arrayContaining(["/api/:path*", "/auth", "/auth/:path*"]),
+    );
+    // /auth and /auth/* are added so Neon Auth's auth.middleware() can
+    // run the OAuth verifier-exchange step on the OAuth return trip.
+    // Without them the session cookie is never materialised and the MCP
+    // custom-connector flow fails after Google sign-in.
+    expect(config.matcher.length).toBe(3);
   });
 });

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
+import { auth } from "@/lib/neon-auth";
 
 const ALLOWED_ORIGINS = new Set([
   "https://localhost",
@@ -20,9 +21,44 @@ function corsHeaders(origin: string): Record<string, string> {
   };
 }
 
-export default async function middleware(request: NextRequest) {
-  const origin = request.headers.get("origin");
+/**
+ * Neon Auth middleware — REQUIRED for the OAuth verifier exchange.
+ *
+ * When a user completes social sign-in (Google), Neon Auth's hosted callback
+ * redirects back to the app with `?neon_auth_session_verifier=<token>` on
+ * the URL. The session cookie is NOT set at this point — the verifier has
+ * to be exchanged server-side for the real session cookie on our origin.
+ *
+ * That exchange (`exchangeOAuthToken` in @neondatabase/auth/next/server)
+ * runs inside `auth.middleware()` — it is NOT in `auth.handler()` and
+ * cannot be triggered from a route handler. Without this middleware
+ * installed, the user lands back on /auth with the verifier in the URL
+ * but no session cookie ever materialises and every subsequent request
+ * gets a 401. This was the root cause of the MCP connector flow failing
+ * to return the user to claude.ai after Google sign-in.
+ *
+ * The middleware also redirects unauthenticated requests on protected
+ * routes to `loginUrl`. We scope it narrowly via the matcher below
+ * because most of this app's pages handle auth client-side and our
+ * public MCP endpoints (DCR, well-known, token, the MCP endpoint
+ * itself) must remain unauthenticated.
+ */
+const neonAuthMiddleware = auth.middleware({ loginUrl: "/auth" });
 
+export default async function middleware(request: NextRequest) {
+  const pathname = request.nextUrl.pathname;
+
+  // Route the Neon Auth middleware ONLY for paths where the verifier
+  // exchange (and matching session-protection) is relevant: the /auth
+  // page itself (where social-login returns the user with the verifier
+  // appended) and any /auth/* subroute.
+  if (pathname === "/auth" || pathname.startsWith("/auth/")) {
+    return neonAuthMiddleware(request);
+  }
+
+  // Existing capacitor CORS handling for /api/* requests from the
+  // Android/iOS shell. No change in behaviour for those paths.
+  const origin = request.headers.get("origin");
   if (origin && ALLOWED_ORIGINS.has(origin)) {
     if (request.method === "OPTIONS") {
       return new NextResponse(null, {
@@ -42,5 +78,8 @@ export default async function middleware(request: NextRequest) {
 }
 
 export const config = {
-  matcher: ["/api/:path*"],
+  // /auth + /auth/* added so Neon Auth's verifier-exchange middleware
+  // runs on the OAuth return trip. /api/* preserved for the existing
+  // capacitor CORS layer.
+  matcher: ["/api/:path*", "/auth", "/auth/:path*"],
 };


### PR DESCRIPTION
## Summary

Integrates Neon Auth's middleware into the application's request pipeline to handle the OAuth verifier-exchange step during social sign-in (Google). This fixes the MCP custom-connector flow, which was failing because the session cookie was never materialized after the OAuth callback.

## Key Changes

- **Added Neon Auth middleware routing** (`src/middleware.ts`):
  - Imported `auth` from `@/lib/neon-auth`
  - Created `neonAuthMiddleware` instance with `loginUrl: "/auth"`
  - Conditionally route requests to `/auth` and `/auth/*` through Neon Auth's middleware
  - Preserved existing capacitor CORS handling for `/api/*` routes

- **Updated middleware matcher** (`src/middleware.ts`):
  - Extended `config.matcher` from `["/api/:path*"]` to `["/api/:path*", "/auth", "/auth/:path*"]`
  - This ensures the verifier-exchange middleware runs when users return from the OAuth provider

- **Updated tests** (`src/__tests__/cors-middleware.test.ts` and `src/__tests__/auth-middleware.test.ts`):
  - Mocked `@/lib/neon-auth` to avoid pulling `@neondatabase/auth/next/server` (which fails under vitest)
  - Updated matcher assertions to expect 3 entries instead of 1
  - Added explanatory comments about the OAuth verifier-exchange requirement

## Implementation Details

When a user completes social sign-in via Google, Neon Auth's hosted callback redirects back to the app with `?neon_auth_session_verifier=<token>` in the URL. The session cookie is **not** set at this point—the verifier must be exchanged server-side for the real session cookie via `exchangeOAuthToken()`, which runs only inside `auth.middleware()` (not in route handlers).

Without this middleware installed, users would land on `/auth` with the verifier in the URL but no session cookie would ever materialize, causing every subsequent request to receive a 401. This was the root cause of the MCP connector flow failing to return users to claude.ai after Google sign-in.

The middleware is scoped narrowly to `/auth` and `/auth/*` because most of the app's pages handle auth client-side, and public MCP endpoints (DCR, well-known, token) must remain unauthenticated.

https://claude.ai/code/session_01SzeaVzTJo454ehDf6Y3itX

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Integrated OAuth authentication middleware to securely handle login flows and token exchange across dedicated authentication routes, ensuring proper request routing.

* **Tests**
  * Updated test suites with improved module mocking to prevent import issues and validate correct middleware routing configuration for both CORS and authentication endpoints.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/RyRy79261/intake-tracker/pull/153?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->