### PR TITLE
fix(swipe-nav): stop tall next-page skeleton from leaking scroll

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -83,7 +83,7 @@ export default function RootLayout({
         </div>
         <script dangerouslySetInnerHTML={{ __html: BOOT_SHELL_FALLBACK_TIMER }} />
         <Providers>
-          <main className="min-h-screen overflow-x-hidden bg-gradient-to-b from-slate-50 to-slate-100 dark:from-slate-950 dark:to-slate-900">
+          <main className="min-h-screen overflow-x-clip bg-gradient-to-b from-slate-50 to-slate-100 dark:from-slate-950 dark:to-slate-900">
             <div className="container mx-auto max-w-lg px-4 pt-6">
               <AppHeader />
             </div>

--- a/src/components/swipe-nav.tsx
+++ b/src/components/swipe-nav.tsx
@@ -167,7 +167,15 @@ export function SwipeNav({ children }: { children: React.ReactNode }) {
   );
 
   return (
-    <div className="relative overflow-x-hidden">
+    // `overflow-clip` is load-bearing. The offscreen skeletons are
+    // absolutely positioned at `top: 0, left: ±100vw`; if their box leaks
+    // out of this wrapper they add bogus scrollHeight to a `position:
+    // relative` ancestor and the page picks up phantom vertical scroll —
+    // most visible on short pages like /profile next to the tall /intake
+    // skeleton. `clip` (not `hidden`) avoids the spec's overflow-axis
+    // coercion that would otherwise turn this wrapper into its own scroll
+    // container.
+    <div className="relative overflow-clip">
       {/* Skeleton overlays. They share the drag motion value `x` for the
           translateX, but the resting offset (one viewport over) is set via
           plain CSS `left`. Doing the offset via `left` instead of folding it


### PR DESCRIPTION
The SwipeNav renders the previous/next page skeletons as
position:absolute siblings at top:0, left:±100vw. The wrapper used
`overflow-x: hidden`, which (per CSS spec) coerces `overflow-y: visible`
to `overflow-y: auto`, turning the wrapper into a vertical scroll
container. On short pages like /profile, the offscreen but tall /intake
skeleton then padded that scroll container's scrollHeight with phantom
height, producing a scrollbar even though no real content overflowed.

Switch the wrapper to `overflow-clip` so it clips the skeletons on both
axes without becoming a scroll container, and change the page <main>
from `overflow-x-hidden` to `overflow-x-clip` for the same reason at the
outer level. Tall pages (intake, medications) still scroll naturally at
the document root.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved horizontal overflow rendering behavior in the main layout and navigation components to enhance visual presentation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/RyRy79261/intake-tracker/pull/158?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->