### PR TITLE
fix(insights): raise max_tokens and detect truncation

### DIFF
--- a/drizzle/0014_dazzling_anthem.sql
+++ b/drizzle/0014_dazzling_anthem.sql
@@ -1,7 +1,7 @@
 CREATE TABLE "insight_jobs" (
 	"id" text PRIMARY KEY NOT NULL,
 	"user_id" text NOT NULL,
-	"batch_id" text,
+	"batch_id" text NOT NULL,
 	"status" text NOT NULL,
 	"request_payload" jsonb NOT NULL,
 	"result_report_id" text,
@@ -13,7 +13,6 @@ CREATE TABLE "insight_jobs" (
 --> statement-breakpoint
 ALTER TABLE "insight_reports" ADD COLUMN "mode" text;--> statement-breakpoint
 ALTER TABLE "insight_jobs" ADD CONSTRAINT "insight_jobs_user_id_users_sync_id_fk" FOREIGN KEY ("user_id") REFERENCES "neon_auth"."users_sync"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
-ALTER TABLE "insight_jobs" ADD CONSTRAINT "insight_jobs_result_report_id_insight_reports_id_fk" FOREIGN KEY ("result_report_id") REFERENCES "public"."insight_reports"("id") ON DELETE set null ON UPDATE no action;--> statement-breakpoint
 CREATE UNIQUE INDEX "insight_jobs_one_pending_per_user_uq" ON "insight_jobs" USING btree ("user_id") WHERE status = 'pending';--> statement-breakpoint
 CREATE INDEX "idx_insight_jobs_user_created" ON "insight_jobs" USING btree ("user_id","created_at");--> statement-breakpoint
 CREATE INDEX "idx_insight_jobs_batch" ON "insight_jobs" USING btree ("batch_id");--> statement-breakpoint

--- a/drizzle/0014_dazzling_anthem.sql
+++ b/drizzle/0014_dazzling_anthem.sql
@@ -1,0 +1,19 @@
+CREATE TABLE "insight_jobs" (
+	"id" text PRIMARY KEY NOT NULL,
+	"user_id" text NOT NULL,
+	"batch_id" text NOT NULL,
+	"status" text NOT NULL,
+	"request_payload" jsonb NOT NULL,
+	"result_report_id" text,
+	"error" text,
+	"created_at" bigint NOT NULL,
+	"completed_at" bigint,
+	CONSTRAINT "insight_jobs_status_check" CHECK ("insight_jobs"."status" IN ('pending','completed','failed','expired'))
+);
+--> statement-breakpoint
+ALTER TABLE "insight_reports" ADD COLUMN "mode" text;--> statement-breakpoint
+ALTER TABLE "insight_jobs" ADD CONSTRAINT "insight_jobs_user_id_users_sync_id_fk" FOREIGN KEY ("user_id") REFERENCES "neon_auth"."users_sync"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+CREATE UNIQUE INDEX "insight_jobs_one_pending_per_user_uq" ON "insight_jobs" USING btree ("user_id") WHERE status = 'pending';--> statement-breakpoint
+CREATE INDEX "idx_insight_jobs_user_created" ON "insight_jobs" USING btree ("user_id","created_at");--> statement-breakpoint
+CREATE INDEX "idx_insight_jobs_batch" ON "insight_jobs" USING btree ("batch_id");--> statement-breakpoint
+ALTER TABLE "insight_reports" ADD CONSTRAINT "insight_reports_mode_check" CHECK ("insight_reports"."mode" IS NULL OR "insight_reports"."mode" IN ('fast','deep'));

--- a/drizzle/0014_petite_warbound.sql
+++ b/drizzle/0014_petite_warbound.sql
@@ -1,7 +1,7 @@
 CREATE TABLE "insight_jobs" (
 	"id" text PRIMARY KEY NOT NULL,
 	"user_id" text NOT NULL,
-	"batch_id" text NOT NULL,
+	"batch_id" text,
 	"status" text NOT NULL,
 	"request_payload" jsonb NOT NULL,
 	"result_report_id" text,
@@ -13,6 +13,7 @@ CREATE TABLE "insight_jobs" (
 --> statement-breakpoint
 ALTER TABLE "insight_reports" ADD COLUMN "mode" text;--> statement-breakpoint
 ALTER TABLE "insight_jobs" ADD CONSTRAINT "insight_jobs_user_id_users_sync_id_fk" FOREIGN KEY ("user_id") REFERENCES "neon_auth"."users_sync"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "insight_jobs" ADD CONSTRAINT "insight_jobs_result_report_id_insight_reports_id_fk" FOREIGN KEY ("result_report_id") REFERENCES "public"."insight_reports"("id") ON DELETE set null ON UPDATE no action;--> statement-breakpoint
 CREATE UNIQUE INDEX "insight_jobs_one_pending_per_user_uq" ON "insight_jobs" USING btree ("user_id") WHERE status = 'pending';--> statement-breakpoint
 CREATE INDEX "idx_insight_jobs_user_created" ON "insight_jobs" USING btree ("user_id","created_at");--> statement-breakpoint
 CREATE INDEX "idx_insight_jobs_batch" ON "insight_jobs" USING btree ("batch_id");--> statement-breakpoint

--- a/drizzle/0015_worried_baron_strucker.sql
+++ b/drizzle/0015_worried_baron_strucker.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "insight_jobs" ALTER COLUMN "batch_id" DROP NOT NULL;--> statement-breakpoint
+ALTER TABLE "insight_jobs" ADD CONSTRAINT "insight_jobs_result_report_id_insight_reports_id_fk" FOREIGN KEY ("result_report_id") REFERENCES "public"."insight_reports"("id") ON DELETE set null ON UPDATE no action;

--- a/drizzle/0016_plain_namora.sql
+++ b/drizzle/0016_plain_namora.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "insight_reports" ADD COLUMN "sources" text[];

--- a/drizzle/meta/0014_snapshot.json
+++ b/drizzle/meta/0014_snapshot.json
@@ -1,5 +1,5 @@
 {
-  "id": "e212640c-3681-4447-a08e-bb7bbda1220f",
+  "id": "8e4e33b8-2ab3-4010-b2df-e2844d1a2e40",
   "prevId": "841f1971-1d7a-48e6-b7d4-d1420a855387",
   "version": "7",
   "dialect": "postgresql",
@@ -1193,7 +1193,7 @@
           "name": "batch_id",
           "type": "text",
           "primaryKey": false,
-          "notNull": true
+          "notNull": false
         },
         "status": {
           "name": "status",
@@ -1299,6 +1299,19 @@
             "id"
           ],
           "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "insight_jobs_result_report_id_insight_reports_id_fk": {
+          "name": "insight_jobs_result_report_id_insight_reports_id_fk",
+          "tableFrom": "insight_jobs",
+          "tableTo": "insight_reports",
+          "columnsFrom": [
+            "result_report_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
           "onUpdate": "no action"
         }
       },

--- a/drizzle/meta/0014_snapshot.json
+++ b/drizzle/meta/0014_snapshot.json
@@ -1,0 +1,4325 @@
+{
+  "id": "e212640c-3681-4447-a08e-bb7bbda1220f",
+  "prevId": "841f1971-1d7a-48e6-b7d4-d1420a855387",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.ai_usage": {
+      "name": "ai_usage",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_owner_id": {
+          "name": "key_owner_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "key_source": {
+          "name": "key_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "route": {
+          "name": "route",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "cache_read_tokens": {
+          "name": "cache_read_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "cache_create_tokens": {
+          "name": "cache_create_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "audio_seconds": {
+          "name": "audio_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_ai_usage_user_ts": {
+          "name": "idx_ai_usage_user_ts",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_ai_usage_owner_ts": {
+          "name": "idx_ai_usage_owner_ts",
+          "columns": [
+            {
+              "expression": "key_owner_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ai_usage_user_id_users_sync_id_fk": {
+          "name": "ai_usage_user_id_users_sync_id_fk",
+          "tableFrom": "ai_usage",
+          "tableTo": "users_sync",
+          "schemaTo": "neon_auth",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "ai_usage_key_owner_id_users_sync_id_fk": {
+          "name": "ai_usage_key_owner_id_users_sync_id_fk",
+          "tableFrom": "ai_usage",
+          "tableTo": "users_sync",
+          "schemaTo": "neon_auth",
+          "columnsFrom": [
+            "key_owner_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "ai_usage_key_source_check": {
+          "name": "ai_usage_key_source_check",
+          "value": "\"ai_usage\".\"key_source\" IN ('own_stored','shared_from','env_var')"
+        },
+        "ai_usage_provider_check": {
+          "name": "ai_usage_provider_check",
+          "value": "\"ai_usage\".\"provider\" IN ('anthropic','groq')"
+        },
+        "ai_usage_status_check": {
+          "name": "ai_usage_status_check",
+          "value": "\"ai_usage\".\"status\" IN ('success','error')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.audit_logs": {
+      "name": "audit_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "details": {
+          "name": "details",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "device_id": {
+          "name": "device_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_audit_user_updated": {
+          "name": "idx_audit_user_updated",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_audit_action_ts": {
+          "name": "idx_audit_action_ts",
+          "columns": [
+            {
+              "expression": "action",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "audit_logs_user_id_users_sync_id_fk": {
+          "name": "audit_logs_user_id_users_sync_id_fk",
+          "tableFrom": "audit_logs",
+          "tableTo": "users_sync",
+          "schemaTo": "neon_auth",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "audit_logs_action_check": {
+          "name": "audit_logs_action_check",
+          "value": "\"audit_logs\".\"action\" IN (\n        'ai_parse_request','ai_parse_success','ai_parse_error','data_export',\n        'data_import','data_clear','settings_change','api_key_set','api_key_clear',\n        'pin_set','pin_verify_success','pin_verify_failure','dose_taken',\n        'dose_skipped','dose_rescheduled','dose_time_edited','prescription_added',\n        'prescription_updated','inventory_adjusted','phase_activated','validation_error',\n        'dose_untaken','prescription_deleted','phase_completed','phase_started',\n        'stock_recalculated','inventory_added','inventory_deleted','titration_plan_updated',\n        'timezone_adjusted'\n      )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.blood_pressure_records": {
+      "name": "blood_pressure_records",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "systolic": {
+          "name": "systolic",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "diastolic": {
+          "name": "diastolic",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "heart_rate": {
+          "name": "heart_rate",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "irregular_heartbeat": {
+          "name": "irregular_heartbeat",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position": {
+          "name": "position",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "arm": {
+          "name": "arm",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "device_id": {
+          "name": "device_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_bp_user_updated": {
+          "name": "idx_bp_user_updated",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_bp_ts": {
+          "name": "idx_bp_ts",
+          "columns": [
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "blood_pressure_records_user_id_users_sync_id_fk": {
+          "name": "blood_pressure_records_user_id_users_sync_id_fk",
+          "tableFrom": "blood_pressure_records",
+          "tableTo": "users_sync",
+          "schemaTo": "neon_auth",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "blood_pressure_records_position_check": {
+          "name": "blood_pressure_records_position_check",
+          "value": "\"blood_pressure_records\".\"position\" IN ('standing','sitting')"
+        },
+        "blood_pressure_records_arm_check": {
+          "name": "blood_pressure_records_arm_check",
+          "value": "\"blood_pressure_records\".\"arm\" IN ('left','right')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.daily_notes": {
+      "name": "daily_notes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prescription_id": {
+          "name": "prescription_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dose_log_id": {
+          "name": "dose_log_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "device_id": {
+          "name": "device_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_daily_notes_user_updated": {
+          "name": "idx_daily_notes_user_updated",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_daily_notes_date": {
+          "name": "idx_daily_notes_date",
+          "columns": [
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_daily_notes_prescription": {
+          "name": "idx_daily_notes_prescription",
+          "columns": [
+            {
+              "expression": "prescription_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "daily_notes_user_id_users_sync_id_fk": {
+          "name": "daily_notes_user_id_users_sync_id_fk",
+          "tableFrom": "daily_notes",
+          "tableTo": "users_sync",
+          "schemaTo": "neon_auth",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "daily_notes_prescription_id_prescriptions_id_fk": {
+          "name": "daily_notes_prescription_id_prescriptions_id_fk",
+          "tableFrom": "daily_notes",
+          "tableTo": "prescriptions",
+          "columnsFrom": [
+            "prescription_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "daily_notes_dose_log_id_dose_logs_id_fk": {
+          "name": "daily_notes_dose_log_id_dose_logs_id_fk",
+          "tableFrom": "daily_notes",
+          "tableTo": "dose_logs",
+          "columnsFrom": [
+            "dose_log_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.defecation_records": {
+      "name": "defecation_records",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount_estimate": {
+          "name": "amount_estimate",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "device_id": {
+          "name": "device_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_defecation_user_updated": {
+          "name": "idx_defecation_user_updated",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "defecation_records_user_id_users_sync_id_fk": {
+          "name": "defecation_records_user_id_users_sync_id_fk",
+          "tableFrom": "defecation_records",
+          "tableTo": "users_sync",
+          "schemaTo": "neon_auth",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.dose_logs": {
+      "name": "dose_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prescription_id": {
+          "name": "prescription_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "phase_id": {
+          "name": "phase_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "schedule_id": {
+          "name": "schedule_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "inventory_item_id": {
+          "name": "inventory_item_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scheduled_date": {
+          "name": "scheduled_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scheduled_time": {
+          "name": "scheduled_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action_timestamp": {
+          "name": "action_timestamp",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rescheduled_to": {
+          "name": "rescheduled_to",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "skip_reason": {
+          "name": "skip_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "device_id": {
+          "name": "device_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_dose_logs_user_updated": {
+          "name": "idx_dose_logs_user_updated",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_dose_logs_prescription_date": {
+          "name": "idx_dose_logs_prescription_date",
+          "columns": [
+            {
+              "expression": "prescription_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "scheduled_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_dose_logs_status": {
+          "name": "idx_dose_logs_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "dose_logs_user_id_users_sync_id_fk": {
+          "name": "dose_logs_user_id_users_sync_id_fk",
+          "tableFrom": "dose_logs",
+          "tableTo": "users_sync",
+          "schemaTo": "neon_auth",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "dose_logs_prescription_id_prescriptions_id_fk": {
+          "name": "dose_logs_prescription_id_prescriptions_id_fk",
+          "tableFrom": "dose_logs",
+          "tableTo": "prescriptions",
+          "columnsFrom": [
+            "prescription_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "dose_logs_phase_id_medication_phases_id_fk": {
+          "name": "dose_logs_phase_id_medication_phases_id_fk",
+          "tableFrom": "dose_logs",
+          "tableTo": "medication_phases",
+          "columnsFrom": [
+            "phase_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "dose_logs_schedule_id_phase_schedules_id_fk": {
+          "name": "dose_logs_schedule_id_phase_schedules_id_fk",
+          "tableFrom": "dose_logs",
+          "tableTo": "phase_schedules",
+          "columnsFrom": [
+            "schedule_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "dose_logs_inventory_item_id_inventory_items_id_fk": {
+          "name": "dose_logs_inventory_item_id_inventory_items_id_fk",
+          "tableFrom": "dose_logs",
+          "tableTo": "inventory_items",
+          "columnsFrom": [
+            "inventory_item_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "dose_logs_status_check": {
+          "name": "dose_logs_status_check",
+          "value": "\"dose_logs\".\"status\" IN ('taken','skipped','rescheduled','pending')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.eating_records": {
+      "name": "eating_records",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "grams": {
+          "name": "grams",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "original_input_text": {
+          "name": "original_input_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "group_source": {
+          "name": "group_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "device_id": {
+          "name": "device_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_eating_user_updated": {
+          "name": "idx_eating_user_updated",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_eating_group": {
+          "name": "idx_eating_group",
+          "columns": [
+            {
+              "expression": "group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "eating_records_user_id_users_sync_id_fk": {
+          "name": "eating_records_user_id_users_sync_id_fk",
+          "tableFrom": "eating_records",
+          "tableTo": "users_sync",
+          "schemaTo": "neon_auth",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.insight_jobs": {
+      "name": "insight_jobs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "batch_id": {
+          "name": "batch_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "request_payload": {
+          "name": "request_payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "result_report_id": {
+          "name": "result_report_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "insight_jobs_one_pending_per_user_uq": {
+          "name": "insight_jobs_one_pending_per_user_uq",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "status = 'pending'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_insight_jobs_user_created": {
+          "name": "idx_insight_jobs_user_created",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_insight_jobs_batch": {
+          "name": "idx_insight_jobs_batch",
+          "columns": [
+            {
+              "expression": "batch_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "insight_jobs_user_id_users_sync_id_fk": {
+          "name": "insight_jobs_user_id_users_sync_id_fk",
+          "tableFrom": "insight_jobs",
+          "tableTo": "users_sync",
+          "schemaTo": "neon_auth",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "insight_jobs_status_check": {
+          "name": "insight_jobs_status_check",
+          "value": "\"insight_jobs\".\"status\" IN ('pending','completed','failed','expired')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.insight_reports": {
+      "name": "insight_reports",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "generated_at": {
+          "name": "generated_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "range_start": {
+          "name": "range_start",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "range_end": {
+          "name": "range_end",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "narrative": {
+          "name": "narrative",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "observations": {
+          "name": "observations",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "personalised": {
+          "name": "personalised",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mode": {
+          "name": "mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "device_id": {
+          "name": "device_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_insight_reports_user_updated": {
+          "name": "idx_insight_reports_user_updated",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_insight_reports_generated": {
+          "name": "idx_insight_reports_generated",
+          "columns": [
+            {
+              "expression": "generated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "insight_reports_user_id_users_sync_id_fk": {
+          "name": "insight_reports_user_id_users_sync_id_fk",
+          "tableFrom": "insight_reports",
+          "tableTo": "users_sync",
+          "schemaTo": "neon_auth",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "insight_reports_mode_check": {
+          "name": "insight_reports_mode_check",
+          "value": "\"insight_reports\".\"mode\" IS NULL OR \"insight_reports\".\"mode\" IN ('fast','deep')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.intake_records": {
+      "name": "intake_records",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "original_input_text": {
+          "name": "original_input_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "group_source": {
+          "name": "group_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "device_id": {
+          "name": "device_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_intake_user_updated": {
+          "name": "idx_intake_user_updated",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_intake_type_ts": {
+          "name": "idx_intake_type_ts",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_intake_group": {
+          "name": "idx_intake_group",
+          "columns": [
+            {
+              "expression": "group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "intake_records_user_id_users_sync_id_fk": {
+          "name": "intake_records_user_id_users_sync_id_fk",
+          "tableFrom": "intake_records",
+          "tableTo": "users_sync",
+          "schemaTo": "neon_auth",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "intake_records_type_check": {
+          "name": "intake_records_type_check",
+          "value": "\"intake_records\".\"type\" IN ('water','salt','sugar')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.inventory_items": {
+      "name": "inventory_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prescription_id": {
+          "name": "prescription_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "brand_name": {
+          "name": "brand_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "current_stock": {
+          "name": "current_stock",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "strength": {
+          "name": "strength",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "compounds": {
+          "name": "compounds",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "unit": {
+          "name": "unit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pill_shape": {
+          "name": "pill_shape",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pill_color": {
+          "name": "pill_color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "visual_identification": {
+          "name": "visual_identification",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refill_alert_days": {
+          "name": "refill_alert_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refill_alert_pills": {
+          "name": "refill_alert_pills",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_archived": {
+          "name": "is_archived",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "device_id": {
+          "name": "device_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_inventory_user_updated": {
+          "name": "idx_inventory_user_updated",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_inventory_prescription": {
+          "name": "idx_inventory_prescription",
+          "columns": [
+            {
+              "expression": "prescription_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_inventory_active": {
+          "name": "idx_inventory_active",
+          "columns": [
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "inventory_items_user_id_users_sync_id_fk": {
+          "name": "inventory_items_user_id_users_sync_id_fk",
+          "tableFrom": "inventory_items",
+          "tableTo": "users_sync",
+          "schemaTo": "neon_auth",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "inventory_items_prescription_id_prescriptions_id_fk": {
+          "name": "inventory_items_prescription_id_prescriptions_id_fk",
+          "tableFrom": "inventory_items",
+          "tableTo": "prescriptions",
+          "columnsFrom": [
+            "prescription_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "inventory_items_pill_shape_check": {
+          "name": "inventory_items_pill_shape_check",
+          "value": "\"inventory_items\".\"pill_shape\" IN ('round','oval','capsule','diamond','tablet')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.inventory_transactions": {
+      "name": "inventory_transactions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "inventory_item_id": {
+          "name": "inventory_item_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dose_log_id": {
+          "name": "dose_log_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "device_id": {
+          "name": "device_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_inventory_tx_user_updated": {
+          "name": "idx_inventory_tx_user_updated",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_inventory_tx_item_ts": {
+          "name": "idx_inventory_tx_item_ts",
+          "columns": [
+            {
+              "expression": "inventory_item_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_inventory_tx_type": {
+          "name": "idx_inventory_tx_type",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "inventory_transactions_user_id_users_sync_id_fk": {
+          "name": "inventory_transactions_user_id_users_sync_id_fk",
+          "tableFrom": "inventory_transactions",
+          "tableTo": "users_sync",
+          "schemaTo": "neon_auth",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "inventory_transactions_inventory_item_id_inventory_items_id_fk": {
+          "name": "inventory_transactions_inventory_item_id_inventory_items_id_fk",
+          "tableFrom": "inventory_transactions",
+          "tableTo": "inventory_items",
+          "columnsFrom": [
+            "inventory_item_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "inventory_transactions_dose_log_id_dose_logs_id_fk": {
+          "name": "inventory_transactions_dose_log_id_dose_logs_id_fk",
+          "tableFrom": "inventory_transactions",
+          "tableTo": "dose_logs",
+          "columnsFrom": [
+            "dose_log_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "inventory_transactions_type_check": {
+          "name": "inventory_transactions_type_check",
+          "value": "\"inventory_transactions\".\"type\" IN ('refill','consumed','adjusted','initial')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.mcp_access_tokens": {
+      "name": "mcp_access_tokens",
+      "schema": "",
+      "columns": {
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "refresh_token_hash": {
+          "name": "refresh_token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_expires_at": {
+          "name": "refresh_expires_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_mcp_access_tokens_user": {
+          "name": "idx_mcp_access_tokens_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_mcp_access_tokens_expires": {
+          "name": "idx_mcp_access_tokens_expires",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "mcp_access_tokens_client_id_mcp_oauth_clients_client_id_fk": {
+          "name": "mcp_access_tokens_client_id_mcp_oauth_clients_client_id_fk",
+          "tableFrom": "mcp_access_tokens",
+          "tableTo": "mcp_oauth_clients",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "client_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "mcp_access_tokens_user_id_users_sync_id_fk": {
+          "name": "mcp_access_tokens_user_id_users_sync_id_fk",
+          "tableFrom": "mcp_access_tokens",
+          "tableTo": "users_sync",
+          "schemaTo": "neon_auth",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "mcp_access_tokens_refresh_token_hash_unique": {
+          "name": "mcp_access_tokens_refresh_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "refresh_token_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mcp_audit_log": {
+      "name": "mcp_audit_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tool": {
+          "name": "tool",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "args_json": {
+          "name": "args_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_mcp_audit_user_ts": {
+          "name": "idx_mcp_audit_user_ts",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "mcp_audit_log_user_id_users_sync_id_fk": {
+          "name": "mcp_audit_log_user_id_users_sync_id_fk",
+          "tableFrom": "mcp_audit_log",
+          "tableTo": "users_sync",
+          "schemaTo": "neon_auth",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "mcp_audit_log_status_check": {
+          "name": "mcp_audit_log_status_check",
+          "value": "\"mcp_audit_log\".\"status\" IN ('success','error')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.mcp_auth_codes": {
+      "name": "mcp_auth_codes",
+      "schema": "",
+      "columns": {
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "redirect_uri": {
+          "name": "redirect_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code_challenge": {
+          "name": "code_challenge",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code_challenge_method": {
+          "name": "code_challenge_method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consumed_at": {
+          "name": "consumed_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_mcp_auth_codes_client": {
+          "name": "idx_mcp_auth_codes_client",
+          "columns": [
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_mcp_auth_codes_expires": {
+          "name": "idx_mcp_auth_codes_expires",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "mcp_auth_codes_client_id_mcp_oauth_clients_client_id_fk": {
+          "name": "mcp_auth_codes_client_id_mcp_oauth_clients_client_id_fk",
+          "tableFrom": "mcp_auth_codes",
+          "tableTo": "mcp_oauth_clients",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "client_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "mcp_auth_codes_user_id_users_sync_id_fk": {
+          "name": "mcp_auth_codes_user_id_users_sync_id_fk",
+          "tableFrom": "mcp_auth_codes",
+          "tableTo": "users_sync",
+          "schemaTo": "neon_auth",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "mcp_auth_codes_challenge_method_check": {
+          "name": "mcp_auth_codes_challenge_method_check",
+          "value": "\"mcp_auth_codes\".\"code_challenge_method\" IN ('S256','plain')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.mcp_oauth_clients": {
+      "name": "mcp_oauth_clients",
+      "schema": "",
+      "columns": {
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "client_secret_hash": {
+          "name": "client_secret_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "client_name": {
+          "name": "client_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "redirect_uris": {
+          "name": "redirect_uris",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_endpoint_auth_method": {
+          "name": "token_endpoint_auth_method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "mcp_oauth_clients_auth_method_check": {
+          "name": "mcp_oauth_clients_auth_method_check",
+          "value": "\"mcp_oauth_clients\".\"token_endpoint_auth_method\" IN ('none','client_secret_basic','client_secret_post')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.medication_phases": {
+      "name": "medication_phases",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prescription_id": {
+          "name": "prescription_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "unit": {
+          "name": "unit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "food_instruction": {
+          "name": "food_instruction",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "food_note": {
+          "name": "food_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "titration_plan_id": {
+          "name": "titration_plan_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "device_id": {
+          "name": "device_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_phases_user_updated": {
+          "name": "idx_phases_user_updated",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_phases_prescription": {
+          "name": "idx_phases_prescription",
+          "columns": [
+            {
+              "expression": "prescription_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_phases_status_type": {
+          "name": "idx_phases_status_type",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "medication_phases_user_id_users_sync_id_fk": {
+          "name": "medication_phases_user_id_users_sync_id_fk",
+          "tableFrom": "medication_phases",
+          "tableTo": "users_sync",
+          "schemaTo": "neon_auth",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "medication_phases_prescription_id_prescriptions_id_fk": {
+          "name": "medication_phases_prescription_id_prescriptions_id_fk",
+          "tableFrom": "medication_phases",
+          "tableTo": "prescriptions",
+          "columnsFrom": [
+            "prescription_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "medication_phases_titration_plan_id_titration_plans_id_fk": {
+          "name": "medication_phases_titration_plan_id_titration_plans_id_fk",
+          "tableFrom": "medication_phases",
+          "tableTo": "titration_plans",
+          "columnsFrom": [
+            "titration_plan_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "medication_phases_type_check": {
+          "name": "medication_phases_type_check",
+          "value": "\"medication_phases\".\"type\" IN ('maintenance','titration')"
+        },
+        "medication_phases_food_instruction_check": {
+          "name": "medication_phases_food_instruction_check",
+          "value": "\"medication_phases\".\"food_instruction\" IN ('before','after','none')"
+        },
+        "medication_phases_status_check": {
+          "name": "medication_phases_status_check",
+          "value": "\"medication_phases\".\"status\" IN ('active','completed','cancelled','pending')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.phase_schedules": {
+      "name": "phase_schedules",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "phase_id": {
+          "name": "phase_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "time": {
+          "name": "time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "schedule_time_utc": {
+          "name": "schedule_time_utc",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "anchor_timezone": {
+          "name": "anchor_timezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dosage": {
+          "name": "dosage",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "days_of_week": {
+          "name": "days_of_week",
+          "type": "integer[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "unit": {
+          "name": "unit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "device_id": {
+          "name": "device_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_phase_schedules_user_updated": {
+          "name": "idx_phase_schedules_user_updated",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_phase_schedules_phase": {
+          "name": "idx_phase_schedules_phase",
+          "columns": [
+            {
+              "expression": "phase_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_phase_schedules_enabled": {
+          "name": "idx_phase_schedules_enabled",
+          "columns": [
+            {
+              "expression": "enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "phase_schedules_user_id_users_sync_id_fk": {
+          "name": "phase_schedules_user_id_users_sync_id_fk",
+          "tableFrom": "phase_schedules",
+          "tableTo": "users_sync",
+          "schemaTo": "neon_auth",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "phase_schedules_phase_id_medication_phases_id_fk": {
+          "name": "phase_schedules_phase_id_medication_phases_id_fk",
+          "tableFrom": "phase_schedules",
+          "tableTo": "medication_phases",
+          "columnsFrom": [
+            "phase_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.prescriptions": {
+      "name": "prescriptions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "generic_name": {
+          "name": "generic_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "indication": {
+          "name": "indication",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contraindications": {
+          "name": "contraindications",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "warnings": {
+          "name": "warnings",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "compounds": {
+          "name": "compounds",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "device_id": {
+          "name": "device_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_prescriptions_user_updated": {
+          "name": "idx_prescriptions_user_updated",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_prescriptions_active": {
+          "name": "idx_prescriptions_active",
+          "columns": [
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "prescriptions_user_id_users_sync_id_fk": {
+          "name": "prescriptions_user_id_users_sync_id_fk",
+          "tableFrom": "prescriptions",
+          "tableTo": "users_sync",
+          "schemaTo": "neon_auth",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.push_schedules": {
+      "name": "push_schedules",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "time_slot": {
+          "name": "time_slot",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "day_of_week": {
+          "name": "day_of_week",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "medications_json": {
+          "name": "medications_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "push_schedules_user_slot_dow_uq": {
+          "name": "push_schedules_user_slot_dow_uq",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "time_slot",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "day_of_week",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "push_schedules_user_id_users_sync_id_fk": {
+          "name": "push_schedules_user_id_users_sync_id_fk",
+          "tableFrom": "push_schedules",
+          "tableTo": "users_sync",
+          "schemaTo": "neon_auth",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.push_sent_log": {
+      "name": "push_sent_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "time_slot": {
+          "name": "time_slot",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sent_date": {
+          "name": "sent_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "follow_up_index": {
+          "name": "follow_up_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "sent_at": {
+          "name": "sent_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "push_sent_log_uq": {
+          "name": "push_sent_log_uq",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "time_slot",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sent_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "follow_up_index",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "push_sent_log_user_id_users_sync_id_fk": {
+          "name": "push_sent_log_user_id_users_sync_id_fk",
+          "tableFrom": "push_sent_log",
+          "tableTo": "users_sync",
+          "schemaTo": "neon_auth",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.push_settings": {
+      "name": "push_settings",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "follow_up_count": {
+          "name": "follow_up_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 2
+        },
+        "follow_up_interval_minutes": {
+          "name": "follow_up_interval_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 10
+        },
+        "day_start_hour": {
+          "name": "day_start_hour",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 2
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "push_settings_user_id_users_sync_id_fk": {
+          "name": "push_settings_user_id_users_sync_id_fk",
+          "tableFrom": "push_settings",
+          "tableTo": "users_sync",
+          "schemaTo": "neon_auth",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.push_subscriptions": {
+      "name": "push_subscriptions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "endpoint": {
+          "name": "endpoint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "p256dh": {
+          "name": "p256dh",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auth_key": {
+          "name": "auth_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'UTC'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "push_subscriptions_user_id_users_sync_id_fk": {
+          "name": "push_subscriptions_user_id_users_sync_id_fk",
+          "tableFrom": "push_subscriptions",
+          "tableTo": "users_sync",
+          "schemaTo": "neon_auth",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "push_subscriptions_user_id_unique": {
+          "name": "push_subscriptions_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.substance_records": {
+      "name": "substance_records",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount_mg": {
+          "name": "amount_mg",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "amount_standard_drinks": {
+          "name": "amount_standard_drinks",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "abv_percent": {
+          "name": "abv_percent",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "volume_ml": {
+          "name": "volume_ml",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_record_id": {
+          "name": "source_record_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ai_enriched": {
+          "name": "ai_enriched",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "original_input_text": {
+          "name": "original_input_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "group_source": {
+          "name": "group_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "device_id": {
+          "name": "device_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_substance_user_updated": {
+          "name": "idx_substance_user_updated",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_substance_type_ts": {
+          "name": "idx_substance_type_ts",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_substance_group": {
+          "name": "idx_substance_group",
+          "columns": [
+            {
+              "expression": "group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "substance_records_user_id_users_sync_id_fk": {
+          "name": "substance_records_user_id_users_sync_id_fk",
+          "tableFrom": "substance_records",
+          "tableTo": "users_sync",
+          "schemaTo": "neon_auth",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "substance_records_source_record_id_intake_records_id_fk": {
+          "name": "substance_records_source_record_id_intake_records_id_fk",
+          "tableFrom": "substance_records",
+          "tableTo": "intake_records",
+          "columnsFrom": [
+            "source_record_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "substance_records_type_check": {
+          "name": "substance_records_type_check",
+          "value": "\"substance_records\".\"type\" IN ('caffeine','alcohol')"
+        },
+        "substance_records_source_check": {
+          "name": "substance_records_source_check",
+          "value": "\"substance_records\".\"source\" IN ('water_intake','eating','standalone')"
+        },
+        "substance_records_abv_percent_range": {
+          "name": "substance_records_abv_percent_range",
+          "value": "\"substance_records\".\"abv_percent\" IS NULL OR (\"substance_records\".\"abv_percent\" >= 0 AND \"substance_records\".\"abv_percent\" <= 100)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.titration_plans": {
+      "name": "titration_plans",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "condition_label": {
+          "name": "condition_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recommended_start_date": {
+          "name": "recommended_start_date",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "warnings": {
+          "name": "warnings",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "device_id": {
+          "name": "device_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_titration_user_updated": {
+          "name": "idx_titration_user_updated",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_titration_condition": {
+          "name": "idx_titration_condition",
+          "columns": [
+            {
+              "expression": "condition_label",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_titration_status": {
+          "name": "idx_titration_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "titration_plans_user_id_users_sync_id_fk": {
+          "name": "titration_plans_user_id_users_sync_id_fk",
+          "tableFrom": "titration_plans",
+          "tableTo": "users_sync",
+          "schemaTo": "neon_auth",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "titration_plans_status_check": {
+          "name": "titration_plans_status_check",
+          "value": "\"titration_plans\".\"status\" IN ('draft','active','completed','cancelled')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.urination_records": {
+      "name": "urination_records",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount_estimate": {
+          "name": "amount_estimate",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "device_id": {
+          "name": "device_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_urination_user_updated": {
+          "name": "idx_urination_user_updated",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "urination_records_user_id_users_sync_id_fk": {
+          "name": "urination_records_user_id_users_sync_id_fk",
+          "tableFrom": "urination_records",
+          "tableTo": "users_sync",
+          "schemaTo": "neon_auth",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_api_keys": {
+      "name": "user_api_keys",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "anthropic_key_encrypted": {
+          "name": "anthropic_key_encrypted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "anthropic_last4": {
+          "name": "anthropic_last4",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "groq_key_encrypted": {
+          "name": "groq_key_encrypted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "groq_last4": {
+          "name": "groq_last4",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_api_keys_user_id_users_sync_id_fk": {
+          "name": "user_api_keys_user_id_users_sync_id_fk",
+          "tableFrom": "user_api_keys",
+          "tableTo": "users_sync",
+          "schemaTo": "neon_auth",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_key_shares": {
+      "name": "user_key_shares",
+      "schema": "",
+      "columns": {
+        "grantor_id": {
+          "name": "grantor_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "grantee_id": {
+          "name": "grantee_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "grantee_email": {
+          "name": "grantee_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_user_key_shares_grantee": {
+          "name": "idx_user_key_shares_grantee",
+          "columns": [
+            {
+              "expression": "grantee_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_key_shares_grantor_id_users_sync_id_fk": {
+          "name": "user_key_shares_grantor_id_users_sync_id_fk",
+          "tableFrom": "user_key_shares",
+          "tableTo": "users_sync",
+          "schemaTo": "neon_auth",
+          "columnsFrom": [
+            "grantor_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_key_shares_grantee_id_users_sync_id_fk": {
+          "name": "user_key_shares_grantee_id_users_sync_id_fk",
+          "tableFrom": "user_key_shares",
+          "tableTo": "users_sync",
+          "schemaTo": "neon_auth",
+          "columnsFrom": [
+            "grantee_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "user_key_shares_grantor_id_grantee_id_provider_pk": {
+          "name": "user_key_shares_grantor_id_grantee_id_provider_pk",
+          "columns": [
+            "grantor_id",
+            "grantee_id",
+            "provider"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "user_key_shares_provider_check": {
+          "name": "user_key_shares_provider_check",
+          "value": "\"user_key_shares\".\"provider\" IN ('anthropic','groq')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.user_profile": {
+      "name": "user_profile",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conditions": {
+          "name": "conditions",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "share_conditions_with_ai": {
+          "name": "share_conditions_with_ai",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "share_medications_with_ai": {
+          "name": "share_medications_with_ai",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "ai_insights_consent_at": {
+          "name": "ai_insights_consent_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "device_id": {
+          "name": "device_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_user_profile_user_updated": {
+          "name": "idx_user_profile_user_updated",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_profile_user_id_users_sync_id_fk": {
+          "name": "user_profile_user_id_users_sync_id_fk",
+          "tableFrom": "user_profile",
+          "tableTo": "users_sync",
+          "schemaTo": "neon_auth",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "neon_auth.users_sync": {
+      "name": "users_sync",
+      "schema": "neon_auth",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.weight_records": {
+      "name": "weight_records",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "weight": {
+          "name": "weight",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "device_id": {
+          "name": "device_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_weight_user_updated": {
+          "name": "idx_weight_user_updated",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "weight_records_user_id_users_sync_id_fk": {
+          "name": "weight_records_user_id_users_sync_id_fk",
+          "tableFrom": "weight_records",
+          "tableTo": "users_sync",
+          "schemaTo": "neon_auth",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/0015_snapshot.json
+++ b/drizzle/meta/0015_snapshot.json
@@ -1,6 +1,6 @@
 {
-  "id": "e212640c-3681-4447-a08e-bb7bbda1220f",
-  "prevId": "841f1971-1d7a-48e6-b7d4-d1420a855387",
+  "id": "a5178165-ee8a-4ce8-b5d0-377b4274e27e",
+  "prevId": "e212640c-3681-4447-a08e-bb7bbda1220f",
   "version": "7",
   "dialect": "postgresql",
   "tables": {
@@ -1193,7 +1193,7 @@
           "name": "batch_id",
           "type": "text",
           "primaryKey": false,
-          "notNull": true
+          "notNull": false
         },
         "status": {
           "name": "status",
@@ -1299,6 +1299,19 @@
             "id"
           ],
           "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "insight_jobs_result_report_id_insight_reports_id_fk": {
+          "name": "insight_jobs_result_report_id_insight_reports_id_fk",
+          "tableFrom": "insight_jobs",
+          "tableTo": "insight_reports",
+          "columnsFrom": [
+            "result_report_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
           "onUpdate": "no action"
         }
       },

--- a/drizzle/meta/0016_snapshot.json
+++ b/drizzle/meta/0016_snapshot.json
@@ -1,0 +1,4344 @@
+{
+  "id": "07e3fd2e-bcff-41e2-8fea-a8766abbb0e1",
+  "prevId": "a5178165-ee8a-4ce8-b5d0-377b4274e27e",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.ai_usage": {
+      "name": "ai_usage",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_owner_id": {
+          "name": "key_owner_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "key_source": {
+          "name": "key_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "route": {
+          "name": "route",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "cache_read_tokens": {
+          "name": "cache_read_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "cache_create_tokens": {
+          "name": "cache_create_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "audio_seconds": {
+          "name": "audio_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_ai_usage_user_ts": {
+          "name": "idx_ai_usage_user_ts",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_ai_usage_owner_ts": {
+          "name": "idx_ai_usage_owner_ts",
+          "columns": [
+            {
+              "expression": "key_owner_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ai_usage_user_id_users_sync_id_fk": {
+          "name": "ai_usage_user_id_users_sync_id_fk",
+          "tableFrom": "ai_usage",
+          "tableTo": "users_sync",
+          "schemaTo": "neon_auth",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "ai_usage_key_owner_id_users_sync_id_fk": {
+          "name": "ai_usage_key_owner_id_users_sync_id_fk",
+          "tableFrom": "ai_usage",
+          "tableTo": "users_sync",
+          "schemaTo": "neon_auth",
+          "columnsFrom": [
+            "key_owner_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "ai_usage_key_source_check": {
+          "name": "ai_usage_key_source_check",
+          "value": "\"ai_usage\".\"key_source\" IN ('own_stored','shared_from','env_var')"
+        },
+        "ai_usage_provider_check": {
+          "name": "ai_usage_provider_check",
+          "value": "\"ai_usage\".\"provider\" IN ('anthropic','groq')"
+        },
+        "ai_usage_status_check": {
+          "name": "ai_usage_status_check",
+          "value": "\"ai_usage\".\"status\" IN ('success','error')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.audit_logs": {
+      "name": "audit_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "details": {
+          "name": "details",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "device_id": {
+          "name": "device_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_audit_user_updated": {
+          "name": "idx_audit_user_updated",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_audit_action_ts": {
+          "name": "idx_audit_action_ts",
+          "columns": [
+            {
+              "expression": "action",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "audit_logs_user_id_users_sync_id_fk": {
+          "name": "audit_logs_user_id_users_sync_id_fk",
+          "tableFrom": "audit_logs",
+          "tableTo": "users_sync",
+          "schemaTo": "neon_auth",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "audit_logs_action_check": {
+          "name": "audit_logs_action_check",
+          "value": "\"audit_logs\".\"action\" IN (\n        'ai_parse_request','ai_parse_success','ai_parse_error','data_export',\n        'data_import','data_clear','settings_change','api_key_set','api_key_clear',\n        'pin_set','pin_verify_success','pin_verify_failure','dose_taken',\n        'dose_skipped','dose_rescheduled','dose_time_edited','prescription_added',\n        'prescription_updated','inventory_adjusted','phase_activated','validation_error',\n        'dose_untaken','prescription_deleted','phase_completed','phase_started',\n        'stock_recalculated','inventory_added','inventory_deleted','titration_plan_updated',\n        'timezone_adjusted'\n      )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.blood_pressure_records": {
+      "name": "blood_pressure_records",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "systolic": {
+          "name": "systolic",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "diastolic": {
+          "name": "diastolic",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "heart_rate": {
+          "name": "heart_rate",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "irregular_heartbeat": {
+          "name": "irregular_heartbeat",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position": {
+          "name": "position",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "arm": {
+          "name": "arm",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "device_id": {
+          "name": "device_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_bp_user_updated": {
+          "name": "idx_bp_user_updated",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_bp_ts": {
+          "name": "idx_bp_ts",
+          "columns": [
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "blood_pressure_records_user_id_users_sync_id_fk": {
+          "name": "blood_pressure_records_user_id_users_sync_id_fk",
+          "tableFrom": "blood_pressure_records",
+          "tableTo": "users_sync",
+          "schemaTo": "neon_auth",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "blood_pressure_records_position_check": {
+          "name": "blood_pressure_records_position_check",
+          "value": "\"blood_pressure_records\".\"position\" IN ('standing','sitting')"
+        },
+        "blood_pressure_records_arm_check": {
+          "name": "blood_pressure_records_arm_check",
+          "value": "\"blood_pressure_records\".\"arm\" IN ('left','right')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.daily_notes": {
+      "name": "daily_notes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prescription_id": {
+          "name": "prescription_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dose_log_id": {
+          "name": "dose_log_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "device_id": {
+          "name": "device_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_daily_notes_user_updated": {
+          "name": "idx_daily_notes_user_updated",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_daily_notes_date": {
+          "name": "idx_daily_notes_date",
+          "columns": [
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_daily_notes_prescription": {
+          "name": "idx_daily_notes_prescription",
+          "columns": [
+            {
+              "expression": "prescription_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "daily_notes_user_id_users_sync_id_fk": {
+          "name": "daily_notes_user_id_users_sync_id_fk",
+          "tableFrom": "daily_notes",
+          "tableTo": "users_sync",
+          "schemaTo": "neon_auth",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "daily_notes_prescription_id_prescriptions_id_fk": {
+          "name": "daily_notes_prescription_id_prescriptions_id_fk",
+          "tableFrom": "daily_notes",
+          "tableTo": "prescriptions",
+          "columnsFrom": [
+            "prescription_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "daily_notes_dose_log_id_dose_logs_id_fk": {
+          "name": "daily_notes_dose_log_id_dose_logs_id_fk",
+          "tableFrom": "daily_notes",
+          "tableTo": "dose_logs",
+          "columnsFrom": [
+            "dose_log_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.defecation_records": {
+      "name": "defecation_records",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount_estimate": {
+          "name": "amount_estimate",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "device_id": {
+          "name": "device_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_defecation_user_updated": {
+          "name": "idx_defecation_user_updated",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "defecation_records_user_id_users_sync_id_fk": {
+          "name": "defecation_records_user_id_users_sync_id_fk",
+          "tableFrom": "defecation_records",
+          "tableTo": "users_sync",
+          "schemaTo": "neon_auth",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.dose_logs": {
+      "name": "dose_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prescription_id": {
+          "name": "prescription_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "phase_id": {
+          "name": "phase_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "schedule_id": {
+          "name": "schedule_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "inventory_item_id": {
+          "name": "inventory_item_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scheduled_date": {
+          "name": "scheduled_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scheduled_time": {
+          "name": "scheduled_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action_timestamp": {
+          "name": "action_timestamp",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rescheduled_to": {
+          "name": "rescheduled_to",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "skip_reason": {
+          "name": "skip_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "device_id": {
+          "name": "device_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_dose_logs_user_updated": {
+          "name": "idx_dose_logs_user_updated",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_dose_logs_prescription_date": {
+          "name": "idx_dose_logs_prescription_date",
+          "columns": [
+            {
+              "expression": "prescription_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "scheduled_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_dose_logs_status": {
+          "name": "idx_dose_logs_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "dose_logs_user_id_users_sync_id_fk": {
+          "name": "dose_logs_user_id_users_sync_id_fk",
+          "tableFrom": "dose_logs",
+          "tableTo": "users_sync",
+          "schemaTo": "neon_auth",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "dose_logs_prescription_id_prescriptions_id_fk": {
+          "name": "dose_logs_prescription_id_prescriptions_id_fk",
+          "tableFrom": "dose_logs",
+          "tableTo": "prescriptions",
+          "columnsFrom": [
+            "prescription_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "dose_logs_phase_id_medication_phases_id_fk": {
+          "name": "dose_logs_phase_id_medication_phases_id_fk",
+          "tableFrom": "dose_logs",
+          "tableTo": "medication_phases",
+          "columnsFrom": [
+            "phase_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "dose_logs_schedule_id_phase_schedules_id_fk": {
+          "name": "dose_logs_schedule_id_phase_schedules_id_fk",
+          "tableFrom": "dose_logs",
+          "tableTo": "phase_schedules",
+          "columnsFrom": [
+            "schedule_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "dose_logs_inventory_item_id_inventory_items_id_fk": {
+          "name": "dose_logs_inventory_item_id_inventory_items_id_fk",
+          "tableFrom": "dose_logs",
+          "tableTo": "inventory_items",
+          "columnsFrom": [
+            "inventory_item_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "dose_logs_status_check": {
+          "name": "dose_logs_status_check",
+          "value": "\"dose_logs\".\"status\" IN ('taken','skipped','rescheduled','pending')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.eating_records": {
+      "name": "eating_records",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "grams": {
+          "name": "grams",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "original_input_text": {
+          "name": "original_input_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "group_source": {
+          "name": "group_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "device_id": {
+          "name": "device_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_eating_user_updated": {
+          "name": "idx_eating_user_updated",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_eating_group": {
+          "name": "idx_eating_group",
+          "columns": [
+            {
+              "expression": "group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "eating_records_user_id_users_sync_id_fk": {
+          "name": "eating_records_user_id_users_sync_id_fk",
+          "tableFrom": "eating_records",
+          "tableTo": "users_sync",
+          "schemaTo": "neon_auth",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.insight_jobs": {
+      "name": "insight_jobs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "batch_id": {
+          "name": "batch_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "request_payload": {
+          "name": "request_payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "result_report_id": {
+          "name": "result_report_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "insight_jobs_one_pending_per_user_uq": {
+          "name": "insight_jobs_one_pending_per_user_uq",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "status = 'pending'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_insight_jobs_user_created": {
+          "name": "idx_insight_jobs_user_created",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_insight_jobs_batch": {
+          "name": "idx_insight_jobs_batch",
+          "columns": [
+            {
+              "expression": "batch_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "insight_jobs_user_id_users_sync_id_fk": {
+          "name": "insight_jobs_user_id_users_sync_id_fk",
+          "tableFrom": "insight_jobs",
+          "tableTo": "users_sync",
+          "schemaTo": "neon_auth",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "insight_jobs_result_report_id_insight_reports_id_fk": {
+          "name": "insight_jobs_result_report_id_insight_reports_id_fk",
+          "tableFrom": "insight_jobs",
+          "tableTo": "insight_reports",
+          "columnsFrom": [
+            "result_report_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "insight_jobs_status_check": {
+          "name": "insight_jobs_status_check",
+          "value": "\"insight_jobs\".\"status\" IN ('pending','completed','failed','expired')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.insight_reports": {
+      "name": "insight_reports",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "generated_at": {
+          "name": "generated_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "range_start": {
+          "name": "range_start",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "range_end": {
+          "name": "range_end",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "narrative": {
+          "name": "narrative",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "observations": {
+          "name": "observations",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sources": {
+          "name": "sources",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "personalised": {
+          "name": "personalised",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mode": {
+          "name": "mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "device_id": {
+          "name": "device_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_insight_reports_user_updated": {
+          "name": "idx_insight_reports_user_updated",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_insight_reports_generated": {
+          "name": "idx_insight_reports_generated",
+          "columns": [
+            {
+              "expression": "generated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "insight_reports_user_id_users_sync_id_fk": {
+          "name": "insight_reports_user_id_users_sync_id_fk",
+          "tableFrom": "insight_reports",
+          "tableTo": "users_sync",
+          "schemaTo": "neon_auth",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "insight_reports_mode_check": {
+          "name": "insight_reports_mode_check",
+          "value": "\"insight_reports\".\"mode\" IS NULL OR \"insight_reports\".\"mode\" IN ('fast','deep')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.intake_records": {
+      "name": "intake_records",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "original_input_text": {
+          "name": "original_input_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "group_source": {
+          "name": "group_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "device_id": {
+          "name": "device_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_intake_user_updated": {
+          "name": "idx_intake_user_updated",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_intake_type_ts": {
+          "name": "idx_intake_type_ts",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_intake_group": {
+          "name": "idx_intake_group",
+          "columns": [
+            {
+              "expression": "group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "intake_records_user_id_users_sync_id_fk": {
+          "name": "intake_records_user_id_users_sync_id_fk",
+          "tableFrom": "intake_records",
+          "tableTo": "users_sync",
+          "schemaTo": "neon_auth",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "intake_records_type_check": {
+          "name": "intake_records_type_check",
+          "value": "\"intake_records\".\"type\" IN ('water','salt','sugar')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.inventory_items": {
+      "name": "inventory_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prescription_id": {
+          "name": "prescription_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "brand_name": {
+          "name": "brand_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "current_stock": {
+          "name": "current_stock",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "strength": {
+          "name": "strength",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "compounds": {
+          "name": "compounds",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "unit": {
+          "name": "unit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pill_shape": {
+          "name": "pill_shape",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pill_color": {
+          "name": "pill_color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "visual_identification": {
+          "name": "visual_identification",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refill_alert_days": {
+          "name": "refill_alert_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refill_alert_pills": {
+          "name": "refill_alert_pills",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_archived": {
+          "name": "is_archived",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "device_id": {
+          "name": "device_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_inventory_user_updated": {
+          "name": "idx_inventory_user_updated",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_inventory_prescription": {
+          "name": "idx_inventory_prescription",
+          "columns": [
+            {
+              "expression": "prescription_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_inventory_active": {
+          "name": "idx_inventory_active",
+          "columns": [
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "inventory_items_user_id_users_sync_id_fk": {
+          "name": "inventory_items_user_id_users_sync_id_fk",
+          "tableFrom": "inventory_items",
+          "tableTo": "users_sync",
+          "schemaTo": "neon_auth",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "inventory_items_prescription_id_prescriptions_id_fk": {
+          "name": "inventory_items_prescription_id_prescriptions_id_fk",
+          "tableFrom": "inventory_items",
+          "tableTo": "prescriptions",
+          "columnsFrom": [
+            "prescription_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "inventory_items_pill_shape_check": {
+          "name": "inventory_items_pill_shape_check",
+          "value": "\"inventory_items\".\"pill_shape\" IN ('round','oval','capsule','diamond','tablet')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.inventory_transactions": {
+      "name": "inventory_transactions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "inventory_item_id": {
+          "name": "inventory_item_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dose_log_id": {
+          "name": "dose_log_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "device_id": {
+          "name": "device_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_inventory_tx_user_updated": {
+          "name": "idx_inventory_tx_user_updated",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_inventory_tx_item_ts": {
+          "name": "idx_inventory_tx_item_ts",
+          "columns": [
+            {
+              "expression": "inventory_item_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_inventory_tx_type": {
+          "name": "idx_inventory_tx_type",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "inventory_transactions_user_id_users_sync_id_fk": {
+          "name": "inventory_transactions_user_id_users_sync_id_fk",
+          "tableFrom": "inventory_transactions",
+          "tableTo": "users_sync",
+          "schemaTo": "neon_auth",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "inventory_transactions_inventory_item_id_inventory_items_id_fk": {
+          "name": "inventory_transactions_inventory_item_id_inventory_items_id_fk",
+          "tableFrom": "inventory_transactions",
+          "tableTo": "inventory_items",
+          "columnsFrom": [
+            "inventory_item_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "inventory_transactions_dose_log_id_dose_logs_id_fk": {
+          "name": "inventory_transactions_dose_log_id_dose_logs_id_fk",
+          "tableFrom": "inventory_transactions",
+          "tableTo": "dose_logs",
+          "columnsFrom": [
+            "dose_log_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "inventory_transactions_type_check": {
+          "name": "inventory_transactions_type_check",
+          "value": "\"inventory_transactions\".\"type\" IN ('refill','consumed','adjusted','initial')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.mcp_access_tokens": {
+      "name": "mcp_access_tokens",
+      "schema": "",
+      "columns": {
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "refresh_token_hash": {
+          "name": "refresh_token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_expires_at": {
+          "name": "refresh_expires_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_mcp_access_tokens_user": {
+          "name": "idx_mcp_access_tokens_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_mcp_access_tokens_expires": {
+          "name": "idx_mcp_access_tokens_expires",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "mcp_access_tokens_client_id_mcp_oauth_clients_client_id_fk": {
+          "name": "mcp_access_tokens_client_id_mcp_oauth_clients_client_id_fk",
+          "tableFrom": "mcp_access_tokens",
+          "tableTo": "mcp_oauth_clients",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "client_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "mcp_access_tokens_user_id_users_sync_id_fk": {
+          "name": "mcp_access_tokens_user_id_users_sync_id_fk",
+          "tableFrom": "mcp_access_tokens",
+          "tableTo": "users_sync",
+          "schemaTo": "neon_auth",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "mcp_access_tokens_refresh_token_hash_unique": {
+          "name": "mcp_access_tokens_refresh_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "refresh_token_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mcp_audit_log": {
+      "name": "mcp_audit_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tool": {
+          "name": "tool",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "args_json": {
+          "name": "args_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_mcp_audit_user_ts": {
+          "name": "idx_mcp_audit_user_ts",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "mcp_audit_log_user_id_users_sync_id_fk": {
+          "name": "mcp_audit_log_user_id_users_sync_id_fk",
+          "tableFrom": "mcp_audit_log",
+          "tableTo": "users_sync",
+          "schemaTo": "neon_auth",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "mcp_audit_log_status_check": {
+          "name": "mcp_audit_log_status_check",
+          "value": "\"mcp_audit_log\".\"status\" IN ('success','error')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.mcp_auth_codes": {
+      "name": "mcp_auth_codes",
+      "schema": "",
+      "columns": {
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "redirect_uri": {
+          "name": "redirect_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code_challenge": {
+          "name": "code_challenge",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code_challenge_method": {
+          "name": "code_challenge_method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consumed_at": {
+          "name": "consumed_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_mcp_auth_codes_client": {
+          "name": "idx_mcp_auth_codes_client",
+          "columns": [
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_mcp_auth_codes_expires": {
+          "name": "idx_mcp_auth_codes_expires",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "mcp_auth_codes_client_id_mcp_oauth_clients_client_id_fk": {
+          "name": "mcp_auth_codes_client_id_mcp_oauth_clients_client_id_fk",
+          "tableFrom": "mcp_auth_codes",
+          "tableTo": "mcp_oauth_clients",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "client_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "mcp_auth_codes_user_id_users_sync_id_fk": {
+          "name": "mcp_auth_codes_user_id_users_sync_id_fk",
+          "tableFrom": "mcp_auth_codes",
+          "tableTo": "users_sync",
+          "schemaTo": "neon_auth",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "mcp_auth_codes_challenge_method_check": {
+          "name": "mcp_auth_codes_challenge_method_check",
+          "value": "\"mcp_auth_codes\".\"code_challenge_method\" IN ('S256','plain')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.mcp_oauth_clients": {
+      "name": "mcp_oauth_clients",
+      "schema": "",
+      "columns": {
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "client_secret_hash": {
+          "name": "client_secret_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "client_name": {
+          "name": "client_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "redirect_uris": {
+          "name": "redirect_uris",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_endpoint_auth_method": {
+          "name": "token_endpoint_auth_method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "mcp_oauth_clients_auth_method_check": {
+          "name": "mcp_oauth_clients_auth_method_check",
+          "value": "\"mcp_oauth_clients\".\"token_endpoint_auth_method\" IN ('none','client_secret_basic','client_secret_post')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.medication_phases": {
+      "name": "medication_phases",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prescription_id": {
+          "name": "prescription_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "unit": {
+          "name": "unit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "food_instruction": {
+          "name": "food_instruction",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "food_note": {
+          "name": "food_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "titration_plan_id": {
+          "name": "titration_plan_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "device_id": {
+          "name": "device_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_phases_user_updated": {
+          "name": "idx_phases_user_updated",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_phases_prescription": {
+          "name": "idx_phases_prescription",
+          "columns": [
+            {
+              "expression": "prescription_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_phases_status_type": {
+          "name": "idx_phases_status_type",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "medication_phases_user_id_users_sync_id_fk": {
+          "name": "medication_phases_user_id_users_sync_id_fk",
+          "tableFrom": "medication_phases",
+          "tableTo": "users_sync",
+          "schemaTo": "neon_auth",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "medication_phases_prescription_id_prescriptions_id_fk": {
+          "name": "medication_phases_prescription_id_prescriptions_id_fk",
+          "tableFrom": "medication_phases",
+          "tableTo": "prescriptions",
+          "columnsFrom": [
+            "prescription_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "medication_phases_titration_plan_id_titration_plans_id_fk": {
+          "name": "medication_phases_titration_plan_id_titration_plans_id_fk",
+          "tableFrom": "medication_phases",
+          "tableTo": "titration_plans",
+          "columnsFrom": [
+            "titration_plan_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "medication_phases_type_check": {
+          "name": "medication_phases_type_check",
+          "value": "\"medication_phases\".\"type\" IN ('maintenance','titration')"
+        },
+        "medication_phases_food_instruction_check": {
+          "name": "medication_phases_food_instruction_check",
+          "value": "\"medication_phases\".\"food_instruction\" IN ('before','after','none')"
+        },
+        "medication_phases_status_check": {
+          "name": "medication_phases_status_check",
+          "value": "\"medication_phases\".\"status\" IN ('active','completed','cancelled','pending')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.phase_schedules": {
+      "name": "phase_schedules",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "phase_id": {
+          "name": "phase_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "time": {
+          "name": "time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "schedule_time_utc": {
+          "name": "schedule_time_utc",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "anchor_timezone": {
+          "name": "anchor_timezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dosage": {
+          "name": "dosage",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "days_of_week": {
+          "name": "days_of_week",
+          "type": "integer[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "unit": {
+          "name": "unit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "device_id": {
+          "name": "device_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_phase_schedules_user_updated": {
+          "name": "idx_phase_schedules_user_updated",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_phase_schedules_phase": {
+          "name": "idx_phase_schedules_phase",
+          "columns": [
+            {
+              "expression": "phase_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_phase_schedules_enabled": {
+          "name": "idx_phase_schedules_enabled",
+          "columns": [
+            {
+              "expression": "enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "phase_schedules_user_id_users_sync_id_fk": {
+          "name": "phase_schedules_user_id_users_sync_id_fk",
+          "tableFrom": "phase_schedules",
+          "tableTo": "users_sync",
+          "schemaTo": "neon_auth",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "phase_schedules_phase_id_medication_phases_id_fk": {
+          "name": "phase_schedules_phase_id_medication_phases_id_fk",
+          "tableFrom": "phase_schedules",
+          "tableTo": "medication_phases",
+          "columnsFrom": [
+            "phase_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.prescriptions": {
+      "name": "prescriptions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "generic_name": {
+          "name": "generic_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "indication": {
+          "name": "indication",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contraindications": {
+          "name": "contraindications",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "warnings": {
+          "name": "warnings",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "compounds": {
+          "name": "compounds",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "device_id": {
+          "name": "device_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_prescriptions_user_updated": {
+          "name": "idx_prescriptions_user_updated",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_prescriptions_active": {
+          "name": "idx_prescriptions_active",
+          "columns": [
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "prescriptions_user_id_users_sync_id_fk": {
+          "name": "prescriptions_user_id_users_sync_id_fk",
+          "tableFrom": "prescriptions",
+          "tableTo": "users_sync",
+          "schemaTo": "neon_auth",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.push_schedules": {
+      "name": "push_schedules",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "time_slot": {
+          "name": "time_slot",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "day_of_week": {
+          "name": "day_of_week",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "medications_json": {
+          "name": "medications_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "push_schedules_user_slot_dow_uq": {
+          "name": "push_schedules_user_slot_dow_uq",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "time_slot",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "day_of_week",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "push_schedules_user_id_users_sync_id_fk": {
+          "name": "push_schedules_user_id_users_sync_id_fk",
+          "tableFrom": "push_schedules",
+          "tableTo": "users_sync",
+          "schemaTo": "neon_auth",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.push_sent_log": {
+      "name": "push_sent_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "time_slot": {
+          "name": "time_slot",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sent_date": {
+          "name": "sent_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "follow_up_index": {
+          "name": "follow_up_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "sent_at": {
+          "name": "sent_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "push_sent_log_uq": {
+          "name": "push_sent_log_uq",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "time_slot",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sent_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "follow_up_index",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "push_sent_log_user_id_users_sync_id_fk": {
+          "name": "push_sent_log_user_id_users_sync_id_fk",
+          "tableFrom": "push_sent_log",
+          "tableTo": "users_sync",
+          "schemaTo": "neon_auth",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.push_settings": {
+      "name": "push_settings",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "follow_up_count": {
+          "name": "follow_up_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 2
+        },
+        "follow_up_interval_minutes": {
+          "name": "follow_up_interval_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 10
+        },
+        "day_start_hour": {
+          "name": "day_start_hour",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 2
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "push_settings_user_id_users_sync_id_fk": {
+          "name": "push_settings_user_id_users_sync_id_fk",
+          "tableFrom": "push_settings",
+          "tableTo": "users_sync",
+          "schemaTo": "neon_auth",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.push_subscriptions": {
+      "name": "push_subscriptions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "endpoint": {
+          "name": "endpoint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "p256dh": {
+          "name": "p256dh",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auth_key": {
+          "name": "auth_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'UTC'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "push_subscriptions_user_id_users_sync_id_fk": {
+          "name": "push_subscriptions_user_id_users_sync_id_fk",
+          "tableFrom": "push_subscriptions",
+          "tableTo": "users_sync",
+          "schemaTo": "neon_auth",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "push_subscriptions_user_id_unique": {
+          "name": "push_subscriptions_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.substance_records": {
+      "name": "substance_records",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount_mg": {
+          "name": "amount_mg",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "amount_standard_drinks": {
+          "name": "amount_standard_drinks",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "abv_percent": {
+          "name": "abv_percent",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "volume_ml": {
+          "name": "volume_ml",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_record_id": {
+          "name": "source_record_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ai_enriched": {
+          "name": "ai_enriched",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "original_input_text": {
+          "name": "original_input_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "group_source": {
+          "name": "group_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "device_id": {
+          "name": "device_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_substance_user_updated": {
+          "name": "idx_substance_user_updated",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_substance_type_ts": {
+          "name": "idx_substance_type_ts",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_substance_group": {
+          "name": "idx_substance_group",
+          "columns": [
+            {
+              "expression": "group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "substance_records_user_id_users_sync_id_fk": {
+          "name": "substance_records_user_id_users_sync_id_fk",
+          "tableFrom": "substance_records",
+          "tableTo": "users_sync",
+          "schemaTo": "neon_auth",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "substance_records_source_record_id_intake_records_id_fk": {
+          "name": "substance_records_source_record_id_intake_records_id_fk",
+          "tableFrom": "substance_records",
+          "tableTo": "intake_records",
+          "columnsFrom": [
+            "source_record_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "substance_records_type_check": {
+          "name": "substance_records_type_check",
+          "value": "\"substance_records\".\"type\" IN ('caffeine','alcohol')"
+        },
+        "substance_records_source_check": {
+          "name": "substance_records_source_check",
+          "value": "\"substance_records\".\"source\" IN ('water_intake','eating','standalone')"
+        },
+        "substance_records_abv_percent_range": {
+          "name": "substance_records_abv_percent_range",
+          "value": "\"substance_records\".\"abv_percent\" IS NULL OR (\"substance_records\".\"abv_percent\" >= 0 AND \"substance_records\".\"abv_percent\" <= 100)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.titration_plans": {
+      "name": "titration_plans",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "condition_label": {
+          "name": "condition_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recommended_start_date": {
+          "name": "recommended_start_date",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "warnings": {
+          "name": "warnings",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "device_id": {
+          "name": "device_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_titration_user_updated": {
+          "name": "idx_titration_user_updated",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_titration_condition": {
+          "name": "idx_titration_condition",
+          "columns": [
+            {
+              "expression": "condition_label",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_titration_status": {
+          "name": "idx_titration_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "titration_plans_user_id_users_sync_id_fk": {
+          "name": "titration_plans_user_id_users_sync_id_fk",
+          "tableFrom": "titration_plans",
+          "tableTo": "users_sync",
+          "schemaTo": "neon_auth",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "titration_plans_status_check": {
+          "name": "titration_plans_status_check",
+          "value": "\"titration_plans\".\"status\" IN ('draft','active','completed','cancelled')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.urination_records": {
+      "name": "urination_records",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount_estimate": {
+          "name": "amount_estimate",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "device_id": {
+          "name": "device_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_urination_user_updated": {
+          "name": "idx_urination_user_updated",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "urination_records_user_id_users_sync_id_fk": {
+          "name": "urination_records_user_id_users_sync_id_fk",
+          "tableFrom": "urination_records",
+          "tableTo": "users_sync",
+          "schemaTo": "neon_auth",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_api_keys": {
+      "name": "user_api_keys",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "anthropic_key_encrypted": {
+          "name": "anthropic_key_encrypted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "anthropic_last4": {
+          "name": "anthropic_last4",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "groq_key_encrypted": {
+          "name": "groq_key_encrypted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "groq_last4": {
+          "name": "groq_last4",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_api_keys_user_id_users_sync_id_fk": {
+          "name": "user_api_keys_user_id_users_sync_id_fk",
+          "tableFrom": "user_api_keys",
+          "tableTo": "users_sync",
+          "schemaTo": "neon_auth",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_key_shares": {
+      "name": "user_key_shares",
+      "schema": "",
+      "columns": {
+        "grantor_id": {
+          "name": "grantor_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "grantee_id": {
+          "name": "grantee_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "grantee_email": {
+          "name": "grantee_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_user_key_shares_grantee": {
+          "name": "idx_user_key_shares_grantee",
+          "columns": [
+            {
+              "expression": "grantee_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_key_shares_grantor_id_users_sync_id_fk": {
+          "name": "user_key_shares_grantor_id_users_sync_id_fk",
+          "tableFrom": "user_key_shares",
+          "tableTo": "users_sync",
+          "schemaTo": "neon_auth",
+          "columnsFrom": [
+            "grantor_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_key_shares_grantee_id_users_sync_id_fk": {
+          "name": "user_key_shares_grantee_id_users_sync_id_fk",
+          "tableFrom": "user_key_shares",
+          "tableTo": "users_sync",
+          "schemaTo": "neon_auth",
+          "columnsFrom": [
+            "grantee_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "user_key_shares_grantor_id_grantee_id_provider_pk": {
+          "name": "user_key_shares_grantor_id_grantee_id_provider_pk",
+          "columns": [
+            "grantor_id",
+            "grantee_id",
+            "provider"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "user_key_shares_provider_check": {
+          "name": "user_key_shares_provider_check",
+          "value": "\"user_key_shares\".\"provider\" IN ('anthropic','groq')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.user_profile": {
+      "name": "user_profile",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conditions": {
+          "name": "conditions",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "share_conditions_with_ai": {
+          "name": "share_conditions_with_ai",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "share_medications_with_ai": {
+          "name": "share_medications_with_ai",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "ai_insights_consent_at": {
+          "name": "ai_insights_consent_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "device_id": {
+          "name": "device_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_user_profile_user_updated": {
+          "name": "idx_user_profile_user_updated",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_profile_user_id_users_sync_id_fk": {
+          "name": "user_profile_user_id_users_sync_id_fk",
+          "tableFrom": "user_profile",
+          "tableTo": "users_sync",
+          "schemaTo": "neon_auth",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "neon_auth.users_sync": {
+      "name": "users_sync",
+      "schema": "neon_auth",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.weight_records": {
+      "name": "weight_records",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "weight": {
+          "name": "weight",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "device_id": {
+          "name": "device_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_weight_user_updated": {
+          "name": "idx_weight_user_updated",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "weight_records_user_id_users_sync_id_fk": {
+          "name": "weight_records_user_id_users_sync_id_fk",
+          "tableFrom": "weight_records",
+          "tableTo": "users_sync",
+          "schemaTo": "neon_auth",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -113,6 +113,13 @@
       "when": 1780600000000,
       "tag": "0015_worried_baron_strucker",
       "breakpoints": true
+    },
+    {
+      "idx": 16,
+      "version": "7",
+      "when": 1780700000000,
+      "tag": "0016_plain_namora",
+      "breakpoints": true
     }
   ]
 }

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -99,6 +99,13 @@
       "when": 1780400000000,
       "tag": "0013_fast_virginia_dare",
       "breakpoints": true
+    },
+    {
+      "idx": 14,
+      "version": "7",
+      "when": 1780500000000,
+      "tag": "0014_dazzling_anthem",
+      "breakpoints": true
     }
   ]
 }

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -104,7 +104,14 @@
       "idx": 14,
       "version": "7",
       "when": 1780500000000,
-      "tag": "0014_petite_warbound",
+      "tag": "0014_dazzling_anthem",
+      "breakpoints": true
+    },
+    {
+      "idx": 15,
+      "version": "7",
+      "when": 1780600000000,
+      "tag": "0015_worried_baron_strucker",
       "breakpoints": true
     }
   ]

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -104,7 +104,7 @@
       "idx": 14,
       "version": "7",
       "when": 1780500000000,
-      "tag": "0014_dazzling_anthem",
+      "tag": "0014_petite_warbound",
       "breakpoints": true
     }
   ]

--- a/e2e/history.spec.ts
+++ b/e2e/history.spec.ts
@@ -19,8 +19,8 @@ test.describe('History / Analytics', () => {
     for (const tabName of ['Records', 'Summary', 'Correlations', 'Titration']) {
       await expect(page.locator('[role="tab"]', { hasText: tabName })).toBeVisible();
     }
-    // Records tab is active by default
-    await expect(page.locator('[role="tab"]', { hasText: 'Records' })).toHaveAttribute('data-state', 'active');
+    // Summary tab is active by default (the deep-vs-fast insights live here)
+    await expect(page.locator('[role="tab"]', { hasText: 'Summary' })).toHaveAttribute('data-state', 'active');
   });
 
   test('should switch between analytics tabs', async ({ page }) => {
@@ -36,7 +36,9 @@ test.describe('History / Analytics', () => {
   test('should show empty state on Records tab with no data', async ({ page }) => {
     // Fresh browser context = empty IndexedDB = no records
     await page.goto('/analytics');
-    await expect(page.locator('[role="tab"]', { hasText: 'Records' })).toBeVisible();
+    await dismissAnalyticsIntro(page);
+    // Records is no longer the default tab — click it explicitly.
+    await page.locator('[role="tab"]', { hasText: 'Records' }).click();
     // Records tab should at least render its tab panel (even if empty)
     await expect(page.locator('[role="tabpanel"][data-state="active"]')).toBeVisible();
   });
@@ -53,7 +55,9 @@ test.describe('History / Analytics', () => {
 
     // Step 2: Navigate to analytics and verify the record appears
     await page.goto('/analytics');
-    await expect(page.locator('[role="tab"]', { hasText: 'Records' })).toBeVisible();
+    await dismissAnalyticsIntro(page);
+    // Records is no longer the default tab — click it before asserting.
+    await page.locator('[role="tab"]', { hasText: 'Records' }).click();
     // Look for the BP reading in the records list (format: "130/85 mmHg")
     await expect(page.locator('text=130/85')).toBeVisible({ timeout: 10000 });
   });

--- a/scripts/verify-schema.ts
+++ b/scripts/verify-schema.ts
@@ -21,12 +21,13 @@ import { neon } from "@neondatabase/serverless";
 // in migration 0004 (user_api_keys, user_key_shares, ai_usage) + 4 MCP
 // custom-connector tables added in migration 0012 (mcp_oauth_clients,
 // mcp_auth_codes, mcp_access_tokens, mcp_audit_log) + 1 insight_reports
-// table added in migration 0013 = 29.
+// table added in migration 0013 + 1 insight_jobs table (server-only
+// deep-research batch tracking) added in migration 0014 = 30.
 // (18 Dexie-mirrored app tables incl. user_profile + insight_reports + 4
-// push tables + 3 AI + 4 MCP.)
+// push tables + 3 AI + 4 MCP + 1 insight_jobs.)
 // drizzle-kit 0.31.x stores its __drizzle_migrations journal in the
 // "drizzle" schema, not "public".
-const EXPECTED_TABLE_COUNT = 29;
+const EXPECTED_TABLE_COUNT = 30;
 
 // Representative tables spot-checked by name. Five is enough to catch
 // a schema that happened to have the right COUNT but the wrong shape

--- a/src/__tests__/integrity/schema-consistency.test.ts
+++ b/src/__tests__/integrity/schema-consistency.test.ts
@@ -14,9 +14,9 @@ import { parseDbSchema } from "@/__tests__/integrity/parse-schema";
 describe("schema parser self-test", () => {
   it("parses all version blocks from db.ts", () => {
     const versions = parseDbSchema();
-    expect(versions).toHaveLength(10);
+    expect(versions).toHaveLength(11);
     expect(versions.map((v) => v.version)).toEqual([
-      10, 11, 12, 13, 14, 15, 16, 17, 18, 19,
+      10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20,
     ]);
   });
 

--- a/src/__tests__/integrity/schema-consistency.test.ts
+++ b/src/__tests__/integrity/schema-consistency.test.ts
@@ -14,9 +14,9 @@ import { parseDbSchema } from "@/__tests__/integrity/parse-schema";
 describe("schema parser self-test", () => {
   it("parses all version blocks from db.ts", () => {
     const versions = parseDbSchema();
-    expect(versions).toHaveLength(11);
+    expect(versions).toHaveLength(12);
     expect(versions.map((v) => v.version)).toEqual([
-      10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20,
+      10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21,
     ]);
   });
 

--- a/src/app/analytics/page.tsx
+++ b/src/app/analytics/page.tsx
@@ -13,9 +13,9 @@ import { AnalyticsIntroDialog } from "@/components/analytics/analytics-intro-dia
 import { useTimeScopeRange } from "@/hooks/use-analytics-queries";
 import type { TimeScope, TimeRange } from "@/lib/analytics-types";
 
-type AnalyticsTab = "records" | "summary" | "correlations" | "titration";
+type AnalyticsTab = "summary" | "correlations" | "records" | "titration";
 
-const TAB_VALUES: AnalyticsTab[] = ["records", "summary", "correlations", "titration"];
+const TAB_VALUES: AnalyticsTab[] = ["summary", "correlations", "records", "titration"];
 
 function isAnalyticsTab(value: string | null): value is AnalyticsTab {
   return value !== null && (TAB_VALUES as string[]).includes(value);
@@ -25,7 +25,7 @@ function AnalyticsContent() {
   const searchParams = useSearchParams();
 
   const tabParam = searchParams.get("tab");
-  const initialTab: AnalyticsTab = isAnalyticsTab(tabParam) ? tabParam : "records";
+  const initialTab: AnalyticsTab = isAnalyticsTab(tabParam) ? tabParam : "summary";
 
   const [activeTab, setActiveTab] = useState<AnalyticsTab>(initialTab);
 
@@ -60,23 +60,19 @@ function AnalyticsContent() {
           onValueChange={(v) => setActiveTab(v as AnalyticsTab)}
         >
           <TabsList className="w-full">
-            <TabsTrigger value="records" className="flex-1 text-xs">
-              Records
-            </TabsTrigger>
             <TabsTrigger value="summary" className="flex-1 text-xs">
               Summary
             </TabsTrigger>
             <TabsTrigger value="correlations" className="flex-1 text-xs">
               Correlations
             </TabsTrigger>
+            <TabsTrigger value="records" className="flex-1 text-xs">
+              Records
+            </TabsTrigger>
             <TabsTrigger value="titration" className="flex-1 text-xs">
               Titration
             </TabsTrigger>
           </TabsList>
-
-          <TabsContent value="records">
-            <RecordsTab range={effectiveRange} />
-          </TabsContent>
 
           <TabsContent value="summary">
             <SummaryTab range={effectiveRange} />
@@ -84,6 +80,10 @@ function AnalyticsContent() {
 
           <TabsContent value="correlations">
             <CorrelationsTab range={effectiveRange} />
+          </TabsContent>
+
+          <TabsContent value="records">
+            <RecordsTab range={effectiveRange} />
           </TabsContent>
 
           <TabsContent value="titration">

--- a/src/app/api/analytics/insights/deep/route.test.ts
+++ b/src/app/api/analytics/insights/deep/route.test.ts
@@ -1,0 +1,237 @@
+/**
+ * Tests for POST /api/analytics/insights/deep — async deep-research batch
+ * submission.
+ *
+ * Strategy mirrors the fast route's test setup:
+ *   - Mock @/lib/auth-middleware as a pass-through with a fixed user.
+ *   - Mock the Claude client so `messages.batches.create` is deterministic
+ *     and we can assert the params it was called with (Opus + web search +
+ *     tool_choice auto).
+ *   - Mock the server-side job service so we don't touch Postgres; the test
+ *     captures what was persisted instead.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { NextRequest } from "next/server";
+import { NoAiKeyError } from "@/lib/ai-key-resolver";
+
+// ── Controllable stubs ───────────────────────────────────────────────────
+
+let claudeClientThrows: Error | null = null;
+let batchesCreateThrows: Error | null = null;
+let batchId = "msgbatch_test_123";
+
+let jobServiceThrows: Error | null = null;
+const batchesCreateCalls: unknown[] = [];
+const createJobCalls: unknown[] = [];
+
+function resetState() {
+  claudeClientThrows = null;
+  batchesCreateThrows = null;
+  batchId = "msgbatch_test_123";
+  jobServiceThrows = null;
+  batchesCreateCalls.length = 0;
+  createJobCalls.length = 0;
+}
+
+vi.mock("@/lib/auth-middleware", () => ({
+  withAuth: (
+    handler: (ctx: {
+      request: NextRequest;
+      auth: { success: true; userId: string; email: string };
+    }) => Promise<Response>,
+  ) => {
+    return async (request: NextRequest) =>
+      handler({
+        request,
+        auth: { success: true, userId: "user-test", email: "test@example.test" },
+      });
+  },
+}));
+
+vi.mock("@/app/api/ai/_shared/claude-client", () => ({
+  CLAUDE_MODELS: {
+    fast: "claude-haiku-test",
+    quality: "claude-sonnet-test",
+    premium: "claude-opus-test",
+  },
+  WEB_SEARCH_TOOL: {
+    type: "web_search_20250305",
+    name: "web_search",
+    max_uses: 5,
+  },
+  getClaudeClientForUser: async () => {
+    if (claudeClientThrows) throw claudeClientThrows;
+    return {
+      client: {
+        messages: {
+          batches: {
+            create: async (params: unknown) => {
+              batchesCreateCalls.push(params);
+              if (batchesCreateThrows) throw batchesCreateThrows;
+              return { id: batchId, processing_status: "in_progress" };
+            },
+          },
+        },
+      },
+      resolved: { keyOwnerId: "user-test", source: "env" },
+    };
+  },
+}));
+
+vi.mock("@/lib/server/insight-job-service", async () => {
+  const actual = await vi.importActual<
+    typeof import("@/lib/server/insight-job-service")
+  >("@/lib/server/insight-job-service");
+  return {
+    ...actual,
+    createInsightJob: async (input: unknown) => {
+      createJobCalls.push(input);
+      if (jobServiceThrows) throw jobServiceThrows;
+      return {
+        id: "job-test-1",
+        userId: "user-test",
+        batchId,
+        status: "pending" as const,
+        requestPayload: (input as { requestPayload: unknown }).requestPayload,
+        resultReportId: null,
+        error: null,
+        createdAt: 1_700_000_000_000,
+        completedAt: null,
+      };
+    },
+  };
+});
+
+// ── Helpers ──────────────────────────────────────────────────────────────
+
+function makeRequest(body: unknown): NextRequest {
+  return new NextRequest("https://example.test/api/analytics/insights/deep", {
+    method: "POST",
+    body: typeof body === "string" ? body : JSON.stringify(body),
+    headers: { "content-type": "application/json" },
+  });
+}
+
+function validBody(overrides: Record<string, unknown> = {}) {
+  const now = 1_700_000_000_000;
+  return {
+    range: { start: now - 30 * 86_400_000, end: now },
+    metrics: {
+      intake: {
+        avgWaterMl: 1800,
+        avgSodiumMg: 2100,
+        avgSugarG: 40,
+        waterGoalMl: 2500,
+        sodiumLimitMg: 2300,
+        sugarLimitG: 50,
+      },
+    },
+    ...overrides,
+  };
+}
+
+// ── Tests ────────────────────────────────────────────────────────────────
+
+describe("POST /api/analytics/insights/deep", () => {
+  beforeEach(() => {
+    resetState();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("submits the batch with Opus + web search + analytics_insight + tool_choice auto and returns 202", async () => {
+    const { POST } = await import("./route");
+    const res = await POST(makeRequest(validBody()));
+
+    expect(res.status).toBe(202);
+    const body = (await res.json()) as {
+      jobId: string;
+      status: string;
+      startedAt: number;
+    };
+    expect(body.jobId).toBe("job-test-1");
+    expect(body.status).toBe("pending");
+
+    expect(batchesCreateCalls).toHaveLength(1);
+    const params = batchesCreateCalls[0] as {
+      requests: Array<{
+        params: {
+          model: string;
+          max_tokens: number;
+          tools: Array<{ name: string; type?: string; max_uses?: number }>;
+          tool_choice: { type: string };
+        };
+      }>;
+    };
+    expect(params.requests).toHaveLength(1);
+    const requestParams = params.requests[0]!.params;
+    expect(requestParams.model).toBe("claude-opus-test");
+    // Web search must be present (the whole point of deep mode) AND the
+    // structured insight tool must remain available for the final answer.
+    const toolNames = requestParams.tools.map((t) => t.name);
+    expect(toolNames).toContain("web_search");
+    expect(toolNames).toContain("analytics_insight");
+    // tool_choice MUST be "auto" so the model can run searches before the
+    // structured response; forcing analytics_insight would block them.
+    expect(requestParams.tool_choice.type).toBe("auto");
+    // Web search needs a higher max_uses than the default to support deep
+    // research across the snapshot's multiple metric domains.
+    const webSearch = requestParams.tools.find((t) => t.name === "web_search");
+    expect(webSearch?.max_uses).toBeGreaterThanOrEqual(10);
+  });
+
+  it("persists the validated request payload alongside the job for later audit/re-run", async () => {
+    const { POST } = await import("./route");
+    await POST(makeRequest(validBody()));
+
+    expect(createJobCalls).toHaveLength(1);
+    const call = createJobCalls[0] as {
+      userId: string;
+      batchId: string;
+      requestPayload: unknown;
+    };
+    expect(call.userId).toBe("user-test");
+    expect(call.batchId).toBe("msgbatch_test_123");
+    expect(call.requestPayload).toMatchObject({
+      range: { start: expect.any(Number), end: expect.any(Number) },
+      metrics: { intake: expect.any(Object) },
+    });
+  });
+
+  it("returns 409 / PENDING_JOB_EXISTS when the user already has a pending deep job", async () => {
+    const { PendingJobConflictError } = await import(
+      "@/lib/server/insight-job-service"
+    );
+    jobServiceThrows = new PendingJobConflictError();
+
+    const { POST } = await import("./route");
+    const res = await POST(makeRequest(validBody()));
+
+    expect(res.status).toBe(409);
+    const body = (await res.json()) as { code: string; error: string };
+    expect(body.code).toBe("PENDING_JOB_EXISTS");
+  });
+
+  it("returns 400 when the analytics payload fails schema validation", async () => {
+    const { POST } = await import("./route");
+    const res = await POST(
+      makeRequest({ range: { start: 1, end: 2 }, metrics: {} }),
+    );
+
+    expect(res.status).toBe(400);
+    expect(batchesCreateCalls).toHaveLength(0);
+  });
+
+  it("returns 402 / NO_AI_KEY when the caller has no key configured", async () => {
+    claudeClientThrows = new NoAiKeyError("anthropic");
+
+    const { POST } = await import("./route");
+    const res = await POST(makeRequest(validBody()));
+
+    expect(res.status).toBe(402);
+    const body = (await res.json()) as { code: string };
+    expect(body.code).toBe("NO_AI_KEY");
+  });
+});

--- a/src/app/api/analytics/insights/deep/route.test.ts
+++ b/src/app/api/analytics/insights/deep/route.test.ts
@@ -18,19 +18,29 @@ import { NoAiKeyError } from "@/lib/ai-key-resolver";
 
 let claudeClientThrows: Error | null = null;
 let batchesCreateThrows: Error | null = null;
+let batchCancelThrows: Error | null = null;
 let batchId = "msgbatch_test_123";
 
 let jobServiceThrows: Error | null = null;
+let attachReturns: boolean = true;
 const batchesCreateCalls: unknown[] = [];
+const batchesCancelCalls: string[] = [];
 const createJobCalls: unknown[] = [];
+const attachCalls: { jobId: string; batchId: string }[] = [];
+const deleteCalls: { jobId: string; userId: string }[] = [];
 
 function resetState() {
   claudeClientThrows = null;
   batchesCreateThrows = null;
+  batchCancelThrows = null;
   batchId = "msgbatch_test_123";
   jobServiceThrows = null;
+  attachReturns = true;
   batchesCreateCalls.length = 0;
+  batchesCancelCalls.length = 0;
   createJobCalls.length = 0;
+  attachCalls.length = 0;
+  deleteCalls.length = 0;
 }
 
 vi.mock("@/lib/auth-middleware", () => ({
@@ -70,6 +80,11 @@ vi.mock("@/app/api/ai/_shared/claude-client", () => ({
               if (batchesCreateThrows) throw batchesCreateThrows;
               return { id: batchId, processing_status: "in_progress" };
             },
+            cancel: async (id: string) => {
+              batchesCancelCalls.push(id);
+              if (batchCancelThrows) throw batchCancelThrows;
+              return { id, processing_status: "canceling" };
+            },
           },
         },
       },
@@ -90,7 +105,10 @@ vi.mock("@/lib/server/insight-job-service", async () => {
       return {
         id: "job-test-1",
         userId: "user-test",
-        batchId,
+        // After the refactor the job is reserved BEFORE the batch is
+        // submitted, so the row starts with batchId=null and is updated
+        // by attachBatchToJob.
+        batchId: null,
         status: "pending" as const,
         requestPayload: (input as { requestPayload: unknown }).requestPayload,
         resultReportId: null,
@@ -98,6 +116,13 @@ vi.mock("@/lib/server/insight-job-service", async () => {
         createdAt: 1_700_000_000_000,
         completedAt: null,
       };
+    },
+    attachBatchToJob: async (jobId: string, batchId: string) => {
+      attachCalls.push({ jobId, batchId });
+      return attachReturns;
+    },
+    deletePendingJob: async (jobId: string, userId: string) => {
+      deleteCalls.push({ jobId, userId });
     },
   };
 });
@@ -189,15 +214,59 @@ describe("POST /api/analytics/insights/deep", () => {
     expect(createJobCalls).toHaveLength(1);
     const call = createJobCalls[0] as {
       userId: string;
-      batchId: string;
       requestPayload: unknown;
     };
     expect(call.userId).toBe("user-test");
-    expect(call.batchId).toBe("msgbatch_test_123");
     expect(call.requestPayload).toMatchObject({
       range: { start: expect.any(Number), end: expect.any(Number) },
       metrics: { intake: expect.any(Object) },
     });
+  });
+
+  it("reserves the DB lock BEFORE submitting to Anthropic and attaches batchId afterwards", async () => {
+    const { POST } = await import("./route");
+    await POST(makeRequest(validBody()));
+
+    // The reservation has to land first — otherwise a duplicate submission
+    // can race and we'd pay for two batches with only one DB record.
+    expect(createJobCalls).toHaveLength(1);
+    expect(batchesCreateCalls).toHaveLength(1);
+    expect(attachCalls).toEqual([
+      { jobId: "job-test-1", batchId: "msgbatch_test_123" },
+    ]);
+    expect(deleteCalls).toHaveLength(0);
+  });
+
+  it("releases the pending-job reservation when Anthropic batch submission fails", async () => {
+    batchesCreateThrows = new Error("anthropic 500 internal");
+
+    const { POST } = await import("./route");
+    const res = await POST(makeRequest(validBody()));
+
+    expect(res.status).toBe(502);
+    // The reservation was taken but the batch never landed — the pending
+    // slot must be released so the user can retry immediately.
+    expect(createJobCalls).toHaveLength(1);
+    expect(deleteCalls).toEqual([
+      { jobId: "job-test-1", userId: "user-test" },
+    ]);
+    expect(attachCalls).toHaveLength(0);
+  });
+
+  it("cancels the orphaned batch when attaching batchId to the reserved job fails", async () => {
+    attachReturns = false;
+
+    const { POST } = await import("./route");
+    const res = await POST(makeRequest(validBody()));
+
+    expect(res.status).toBe(502);
+    expect(batchesCreateCalls).toHaveLength(1);
+    expect(attachCalls).toHaveLength(1);
+    // Without this, we'd keep paying for a batch nothing will ever poll.
+    expect(batchesCancelCalls).toEqual(["msgbatch_test_123"]);
+    expect(deleteCalls).toEqual([
+      { jobId: "job-test-1", userId: "user-test" },
+    ]);
   });
 
   it("returns 409 / PENDING_JOB_EXISTS when the user already has a pending deep job", async () => {

--- a/src/app/api/analytics/insights/deep/route.ts
+++ b/src/app/api/analytics/insights/deep/route.ts
@@ -54,16 +54,54 @@ const DEEP_WEB_SEARCH_MAX_USES = 12;
 
 const DEEP_SYSTEM_PROMPT = `${INSIGHTS_SYSTEM_PROMPT}
 
-You have access to the web_search tool. Use it to look up current clinical
-references when they would help explain why a metric matters for this user —
-e.g. published target ranges, guideline thresholds, or recently updated
-recommendations relevant to the user-reported conditions. Cite specific
-numbers from your sources when you use them.
+You are running in DEEP mode. The fast path already does a structural
+summary; your job is to add the *connective* analysis the fast model
+cannot — relating trends to the user's conditions and medications, and
+grounding clinical context in current literature. A deep summary that
+reads identically to a fast one is a failure.
 
-Treat web search as supporting context, not a substitute for the metrics you
-were given. Do not browse beyond what is needed to ground the observations
-you would already have made from the numeric snapshot. When you are ready
-to deliver the final answer, call the analytics_insight tool exactly once.`;
+REQUIRED PROCESS:
+
+1. Web search is mandatory. Before calling analytics_insight you MUST run
+   at least 2 web_search queries. Target what would actually help: the
+   published target range for the user's notable metric, the expected
+   response pattern for one of their active medications in their
+   condition, or current monitoring guidance for the condition. Skip
+   searches that are not useful; do not pad the count.
+
+2. Medication ↔ trend alignment. For EACH active medication in the user's
+   profile, write at least one observation that compares the observed
+   metric trend against the expected clinical response, framed
+   descriptively (NOT prescriptively). Examples of the right shape:
+     - "Average systolic BP held at 132 mmHg over the period. For
+        bisoprolol in HFrEF this is within the typical early-titration
+        range; published targets are <130 mmHg once the dose is stable
+        [source URL]."
+     - "Weight trended down 1.8 kg, consistent with the diuretic-adjacent
+        effect frequently observed when bisoprolol is up-titrated in
+        heart failure [source URL]."
+   If you cannot find a credible source, say so and frame the observation
+   as data-only.
+
+3. Condition framing. Use the user's reported conditions to explain WHY a
+   metric matters, citing a source for the framing claim. If their data
+   is within the recommended range for their condition, say so plainly;
+   if it is not, name the number and recommend they discuss it with their
+   provider. Never diagnose new conditions and never recommend changes to
+   medication, dose, or treatment.
+
+4. Suggestions. End with 1-2 observations that suggest topics worth
+   raising with their healthcare provider, OR lifestyle / tracking
+   adjustments aligned with their goals (e.g., "logging morning vs.
+   evening BP separately may help interpret the rising trend in the
+   afternoon readings"). Stay observational; never prescribe.
+
+5. Sources. Pass every URL you used via web_search in the analytics_insight
+   tool's "sources" field. Inline source references inside observations
+   are fine too, but the sources array is the canonical citation list.
+
+Final answer must come via the analytics_insight tool exactly once, after
+the web_search calls.`;
 
 export const POST = withAuth(async ({ request, auth }) => {
   try {

--- a/src/app/api/analytics/insights/deep/route.ts
+++ b/src/app/api/analytics/insights/deep/route.ts
@@ -156,6 +156,10 @@ export const POST = withAuth(async ({ request, auth }) => {
     } catch (e) {
       // Batch submission failed before any external state was created.
       // Release the unique-index lock so the user can retry immediately.
+      console.error(
+        "[analytics/insights/deep] batches.create failed:",
+        e instanceof Error ? `${e.name}: ${e.message}` : e,
+      );
       await deletePendingJob(job.id, auth.userId!).catch((cleanupErr) =>
         console.error(
           "[analytics/insights/deep] failed to release pending job after batch error:",
@@ -170,10 +174,21 @@ export const POST = withAuth(async ({ request, auth }) => {
     // Attach the real batch_id to the reserved row. If this fails, we have
     // a paid batch with no DB record — cancel the batch so we don't keep
     // racking up cost on something nothing will ever poll.
-    const attached = await attachBatchToJob(job.id, batch.id).catch(
-      () => false,
-    );
+    let attached = false;
+    try {
+      attached = await attachBatchToJob(job.id, batch.id);
+    } catch (attachErr) {
+      console.error(
+        "[analytics/insights/deep] attachBatchToJob threw:",
+        attachErr instanceof Error
+          ? `${attachErr.name}: ${attachErr.message}`
+          : attachErr,
+      );
+    }
     if (!attached) {
+      console.error(
+        `[analytics/insights/deep] attach returned false for job=${job.id} batch=${batch.id} — cancelling orphan`,
+      );
       await client.messages.batches.cancel(batch.id).catch((cancelErr) =>
         console.error(
           "[analytics/insights/deep] failed to cancel orphaned batch:",
@@ -198,7 +213,12 @@ export const POST = withAuth(async ({ request, auth }) => {
   } catch (error) {
     const mapped = aiErrorResponse(error);
     if (mapped) return mapped;
-    console.error("[analytics/insights/deep] error:", error);
+    console.error(
+      "[analytics/insights/deep] unhandled error:",
+      error instanceof Error
+        ? `${error.name}: ${error.message}\n${error.stack ?? ""}`
+        : error,
+    );
     return NextResponse.json(
       { error: "Failed to start deep analysis" },
       { status: 502 },

--- a/src/app/api/analytics/insights/deep/route.ts
+++ b/src/app/api/analytics/insights/deep/route.ts
@@ -16,6 +16,8 @@ import {
 import { aiErrorResponse } from "@/app/api/ai/_shared/ai-error-response";
 import {
   createInsightJob,
+  attachBatchToJob,
+  deletePendingJob,
   PendingJobConflictError,
 } from "@/lib/server/insight-job-service";
 
@@ -94,10 +96,33 @@ export const POST = withAuth(async ({ request, auth }) => {
       `[AUDIT] analytics insights DEEP submit from user: ${auth.userId}`,
     );
 
+    // Reserve the pending-job slot BEFORE submitting to Anthropic. Doing it
+    // in the other order can leak a paid batch when a concurrent submission
+    // races: both calls succeed at Anthropic, but only one wins the unique
+    // index and the other batch becomes an orphan we can't reconcile.
+    let job;
+    try {
+      job = await createInsightJob({
+        userId: auth.userId!,
+        requestPayload: parsed.data,
+      });
+    } catch (e) {
+      if (e instanceof PendingJobConflictError) {
+        return NextResponse.json(
+          {
+            error: e.message,
+            code: "PENDING_JOB_EXISTS",
+          },
+          { status: 409 },
+        );
+      }
+      throw e;
+    }
+
     // The batch carries exactly one request. We use a stable custom_id so
     // the results stream is easy to match later (only one entry anyway, but
     // belts-and-braces if Anthropic ever bundles concurrent submissions).
-    const customId = `insight-${Date.now()}`;
+    const customId = `insight-${job.id}`;
 
     let batch;
     try {
@@ -129,29 +154,37 @@ export const POST = withAuth(async ({ request, auth }) => {
         ],
       });
     } catch (e) {
+      // Batch submission failed before any external state was created.
+      // Release the unique-index lock so the user can retry immediately.
+      await deletePendingJob(job.id, auth.userId!).catch((cleanupErr) =>
+        console.error(
+          "[analytics/insights/deep] failed to release pending job after batch error:",
+          cleanupErr,
+        ),
+      );
       const mapped = aiErrorResponse(e);
       if (mapped) return mapped;
       throw e;
     }
 
-    let job;
-    try {
-      job = await createInsightJob({
-        userId: auth.userId!,
-        batchId: batch.id,
-        requestPayload: parsed.data,
-      });
-    } catch (e) {
-      if (e instanceof PendingJobConflictError) {
-        return NextResponse.json(
-          {
-            error: e.message,
-            code: "PENDING_JOB_EXISTS",
-          },
-          { status: 409 },
-        );
-      }
-      throw e;
+    // Attach the real batch_id to the reserved row. If this fails, we have
+    // a paid batch with no DB record — cancel the batch so we don't keep
+    // racking up cost on something nothing will ever poll.
+    const attached = await attachBatchToJob(job.id, batch.id).catch(
+      () => false,
+    );
+    if (!attached) {
+      await client.messages.batches.cancel(batch.id).catch((cancelErr) =>
+        console.error(
+          "[analytics/insights/deep] failed to cancel orphaned batch:",
+          cancelErr,
+        ),
+      );
+      await deletePendingJob(job.id, auth.userId!).catch(() => undefined);
+      return NextResponse.json(
+        { error: "Failed to start deep analysis. Please try again." },
+        { status: 502 },
+      );
     }
 
     return NextResponse.json(

--- a/src/app/api/analytics/insights/deep/route.ts
+++ b/src/app/api/analytics/insights/deep/route.ts
@@ -1,0 +1,174 @@
+import { NextResponse } from "next/server";
+import { withAuth } from "@/lib/auth-middleware";
+import {
+  AnalyticsInsightsRequestSchema,
+  INSIGHT_TOOL,
+  INSIGHTS_SYSTEM_PROMPT,
+  buildInsightsPrompt,
+} from "@/lib/analytics-insights";
+import { parseJsonBody, zodErrorResponse } from "@/app/api/_shared/validation";
+import { createRateLimiter, getClientIp } from "@/app/api/_shared/rate-limit";
+import {
+  getClaudeClientForUser,
+  CLAUDE_MODELS,
+  WEB_SEARCH_TOOL,
+} from "@/app/api/ai/_shared/claude-client";
+import { aiErrorResponse } from "@/app/api/ai/_shared/ai-error-response";
+import {
+  createInsightJob,
+  PendingJobConflictError,
+} from "@/lib/server/insight-job-service";
+
+/**
+ * Async deep-research analytics insights — submits an Anthropic Message Batch
+ * with Opus 4.6 and the web-search tool, returns immediately with a jobId the
+ * client can poll. See ./jobs/[id]/route.ts for the polling endpoint.
+ *
+ * Why a batch and not a streaming long-running call:
+ *   - Batches survive client disconnect, browser close, and Vercel timeouts.
+ *   - Anthropic charges batches at 50% of standard pricing.
+ *   - The 24h SLA is well above typical deep-research completion (<10 min).
+ *
+ * The request body is the same `AnalyticsInsightsRequest` as the fast route,
+ * so the client can submit either with the same payload — only the button
+ * routes to a different endpoint.
+ */
+
+export const runtime = "nodejs";
+
+// Throttle the SUBMISSION side; the polling endpoint is intentionally cheap
+// and not rate-limited. One pending job per user (enforced by a DB unique
+// index) handles abuse on the long-running side.
+const rateLimiter = createRateLimiter(10);
+
+// More headroom than the fast Sonnet path. Deep research summaries are
+// allowed to be longer and incorporate citations from the searches.
+const DEEP_MAX_TOKENS = 4096;
+
+// Cap web-search invocations so a runaway plan can't fan out. ~12 is enough
+// to cover the 5-7 metric domains the snapshot can contain plus a couple of
+// follow-ups, but not so high it explodes cost.
+const DEEP_WEB_SEARCH_MAX_USES = 12;
+
+const DEEP_SYSTEM_PROMPT = `${INSIGHTS_SYSTEM_PROMPT}
+
+You have access to the web_search tool. Use it to look up current clinical
+references when they would help explain why a metric matters for this user —
+e.g. published target ranges, guideline thresholds, or recently updated
+recommendations relevant to the user-reported conditions. Cite specific
+numbers from your sources when you use them.
+
+Treat web search as supporting context, not a substitute for the metrics you
+were given. Do not browse beyond what is needed to ground the observations
+you would already have made from the numeric snapshot. When you are ready
+to deliver the final answer, call the analytics_insight tool exactly once.`;
+
+export const POST = withAuth(async ({ request, auth }) => {
+  try {
+    const ip = getClientIp(request);
+    if (!rateLimiter.check(ip)) {
+      return NextResponse.json(
+        { error: "Rate limit exceeded. Please try again later." },
+        { status: 429 },
+      );
+    }
+
+    const json = await parseJsonBody(request);
+    if (!json.ok) return json.response;
+
+    const parsed = AnalyticsInsightsRequestSchema.safeParse(json.body);
+    if (!parsed.success) {
+      return zodErrorResponse("Invalid analytics payload", parsed.error);
+    }
+
+    let client;
+    try {
+      ({ client } = await getClaudeClientForUser(auth.userId!, auth.email));
+    } catch (e) {
+      const mapped = aiErrorResponse(e);
+      if (mapped) return mapped;
+      throw e;
+    }
+
+    console.log(
+      `[AUDIT] analytics insights DEEP submit from user: ${auth.userId}`,
+    );
+
+    // The batch carries exactly one request. We use a stable custom_id so
+    // the results stream is easy to match later (only one entry anyway, but
+    // belts-and-braces if Anthropic ever bundles concurrent submissions).
+    const customId = `insight-${Date.now()}`;
+
+    let batch;
+    try {
+      batch = await client.messages.batches.create({
+        requests: [
+          {
+            custom_id: customId,
+            params: {
+              model: CLAUDE_MODELS.premium,
+              max_tokens: DEEP_MAX_TOKENS,
+              temperature: 0.3,
+              system: DEEP_SYSTEM_PROMPT,
+              tools: [
+                { ...WEB_SEARCH_TOOL, max_uses: DEEP_WEB_SEARCH_MAX_USES },
+                INSIGHT_TOOL,
+              ],
+              // Auto so the model can run web_search before deciding it has
+              // enough to call analytics_insight. Forcing analytics_insight
+              // would block web_search calls before the final tool.
+              tool_choice: { type: "auto" },
+              messages: [
+                {
+                  role: "user",
+                  content: buildInsightsPrompt(parsed.data),
+                },
+              ],
+            },
+          },
+        ],
+      });
+    } catch (e) {
+      const mapped = aiErrorResponse(e);
+      if (mapped) return mapped;
+      throw e;
+    }
+
+    let job;
+    try {
+      job = await createInsightJob({
+        userId: auth.userId!,
+        batchId: batch.id,
+        requestPayload: parsed.data,
+      });
+    } catch (e) {
+      if (e instanceof PendingJobConflictError) {
+        return NextResponse.json(
+          {
+            error: e.message,
+            code: "PENDING_JOB_EXISTS",
+          },
+          { status: 409 },
+        );
+      }
+      throw e;
+    }
+
+    return NextResponse.json(
+      {
+        jobId: job.id,
+        status: "pending" as const,
+        startedAt: job.createdAt,
+      },
+      { status: 202 },
+    );
+  } catch (error) {
+    const mapped = aiErrorResponse(error);
+    if (mapped) return mapped;
+    console.error("[analytics/insights/deep] error:", error);
+    return NextResponse.json(
+      { error: "Failed to start deep analysis" },
+      { status: 502 },
+    );
+  }
+});

--- a/src/app/api/analytics/insights/jobs/[id]/route.test.ts
+++ b/src/app/api/analytics/insights/jobs/[id]/route.test.ts
@@ -33,6 +33,13 @@ const PAYLOAD = {
 
 let mockJob: MockJobRow | null = null;
 let mockReport: { narrative: string; observations: string[]; generatedAt: number } | null = null;
+// Override completeInsightJob's return value to simulate the CAS-loss path
+// (another concurrent poller already finalised the job).
+let completionReturn: { reportId: string } | null = { reportId: "report-test-1" };
+// Optional override for the SECOND getInsightJob call (used after a CAS
+// loss). When null the second call returns mockJob unchanged.
+let mockJobAfterCas: MockJobRow | null = null;
+let getJobCalls = 0;
 let batchProcessingStatus: "in_progress" | "ended" = "in_progress";
 let batchResults: Array<{
   custom_id: string;
@@ -57,6 +64,9 @@ const expireCalls: unknown[] = [];
 function resetState() {
   mockJob = null;
   mockReport = null;
+  completionReturn = { reportId: "report-test-1" };
+  mockJobAfterCas = null;
+  getJobCalls = 0;
   batchProcessingStatus = "in_progress";
   batchResults = [];
   completeCalls.length = 0;
@@ -113,15 +123,18 @@ vi.mock("@/app/api/ai/_shared/usage-tracker", () => ({
 
 vi.mock("@/lib/server/insight-job-service", () => ({
   getInsightJob: async (jobId: string, userId: string) => {
-    if (!mockJob || mockJob.id !== jobId || mockJob.userId !== userId) {
+    getJobCalls += 1;
+    // Second call after a CAS loss may return a different (winner's) row.
+    const row = getJobCalls > 1 && mockJobAfterCas ? mockJobAfterCas : mockJob;
+    if (!row || row.id !== jobId || row.userId !== userId) {
       return null;
     }
-    return mockJob;
+    return row;
   },
   completeInsightJob: async (jobId: string, report: unknown) => {
     completeCalls.push({ jobId, report });
     // Mirrors the real CAS return: null when the caller lost the race.
-    return { reportId: "report-test-1" };
+    return completionReturn;
   },
   failInsightJob: async (jobId: string, error: string) => {
     failCalls.push({ jobId, error });
@@ -407,6 +420,61 @@ describe("GET /api/analytics/insights/jobs/:id", () => {
     expect(body.status).toBe("pending");
     expect(failCalls).toHaveLength(0);
     expect(expireCalls).toHaveLength(0);
+  });
+
+  it("echoes the winning poller's persisted result when completeInsightJob loses the CAS race", async () => {
+    // Two pollers reach the finalisation step concurrently. This one loses
+    // the conditional update — completeInsightJob returns null — and must
+    // NOT respond with its own synthesised payload. Instead it should
+    // re-read the job (now flipped to completed by the winner) and echo
+    // the persisted result so both clients see the same data.
+    const startedAt = Date.now() - 60_000;
+    mockJob = {
+      id: "job-cas",
+      userId: "user-test",
+      batchId: "msgbatch_test_123",
+      status: "pending",
+      requestPayload: PAYLOAD,
+      resultReportId: null,
+      error: null,
+      createdAt: startedAt,
+      completedAt: null,
+    };
+    batchProcessingStatus = "ended";
+    batchResults = [
+      {
+        custom_id: "insight-1",
+        result: succeededResult({
+          summary: "Loser-pol summary, should NOT be returned.",
+          observations: ["Loser-pol observation."],
+        }),
+      },
+    ];
+    completionReturn = null; // Lost the race.
+    // The second getInsightJob call (after CAS loss) sees the winning
+    // poller's terminal state — status=completed with a result row.
+    mockJobAfterCas = {
+      ...mockJob,
+      status: "completed",
+      resultReportId: "report-winner",
+      completedAt: startedAt + 30_000,
+    };
+    mockReport = {
+      narrative: "Winner-pol summary.",
+      observations: ["Winner-pol observation."],
+      generatedAt: startedAt + 30_000,
+    };
+
+    const { GET } = await import("./route");
+    const res = await GET(makeRequest("job-cas"));
+    const body = (await res.json()) as {
+      status: string;
+      narrative: string;
+      observations: string[];
+    };
+    expect(body.status).toBe("completed");
+    expect(body.narrative).toBe("Winner-pol summary.");
+    expect(body.observations).toEqual(["Winner-pol observation."]);
   });
 
   it("echoes the cached result when the job is already completed", async () => {

--- a/src/app/api/analytics/insights/jobs/[id]/route.test.ts
+++ b/src/app/api/analytics/insights/jobs/[id]/route.test.ts
@@ -1,0 +1,349 @@
+/**
+ * Tests for GET /api/analytics/insights/jobs/:id — polling endpoint for
+ * the async deep-research batch.
+ *
+ * Strategy:
+ *   - Mock @/lib/auth-middleware with a fixed user.
+ *   - Mock @/lib/server/insight-job-service so the test controls the row
+ *     state and captures completeInsightJob / failInsightJob calls.
+ *   - Mock @/app/api/ai/_shared/claude-client so batches.retrieve and
+ *     batches.results are deterministic.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { NextRequest } from "next/server";
+
+// ── Controllable stubs ───────────────────────────────────────────────────
+
+interface MockJobRow {
+  id: string;
+  userId: string;
+  batchId: string;
+  status: "pending" | "completed" | "failed" | "expired";
+  requestPayload: unknown;
+  resultReportId: string | null;
+  error: string | null;
+  createdAt: number;
+  completedAt: number | null;
+}
+
+const PAYLOAD = {
+  range: { start: 1_700_000_000_000 - 30 * 86_400_000, end: 1_700_000_000_000 },
+  metrics: { intake: { avgWaterMl: 1800, avgSodiumMg: 2100, avgSugarG: 40 } },
+};
+
+let mockJob: MockJobRow | null = null;
+let mockReport: { narrative: string; observations: string[]; generatedAt: number } | null = null;
+let batchProcessingStatus: "in_progress" | "ended" = "in_progress";
+let batchResults: Array<{
+  custom_id: string;
+  result:
+    | {
+        type: "succeeded";
+        message: {
+          content: Array<{ type: string; name?: string; input?: unknown; text?: string }>;
+          stop_reason: string;
+          usage: { input_tokens: number; output_tokens: number };
+        };
+      }
+    | { type: "errored"; error: { error: { type: string; message: string } } }
+    | { type: "expired" }
+    | { type: "canceled" };
+}> = [];
+
+const completeCalls: unknown[] = [];
+const failCalls: unknown[] = [];
+const expireCalls: unknown[] = [];
+
+function resetState() {
+  mockJob = null;
+  mockReport = null;
+  batchProcessingStatus = "in_progress";
+  batchResults = [];
+  completeCalls.length = 0;
+  failCalls.length = 0;
+  expireCalls.length = 0;
+}
+
+vi.mock("@/lib/auth-middleware", () => ({
+  withAuth: (
+    handler: (ctx: {
+      request: NextRequest;
+      auth: { success: true; userId: string; email: string };
+    }) => Promise<Response>,
+  ) => {
+    return async (request: NextRequest) =>
+      handler({
+        request,
+        auth: { success: true, userId: "user-test", email: "test@example.test" },
+      });
+  },
+}));
+
+vi.mock("@/app/api/ai/_shared/claude-client", () => ({
+  CLAUDE_MODELS: {
+    fast: "claude-haiku-test",
+    quality: "claude-sonnet-test",
+    premium: "claude-opus-test",
+  },
+  WEB_SEARCH_TOOL: { type: "web_search_20250305", name: "web_search", max_uses: 5 },
+  getClaudeClientForUser: async () => ({
+    client: {
+      messages: {
+        batches: {
+          retrieve: async () => ({
+            id: "msgbatch_test_123",
+            processing_status: batchProcessingStatus,
+          }),
+          results: async () => ({
+            async *[Symbol.asyncIterator]() {
+              for (const entry of batchResults) yield entry;
+            },
+          }),
+        },
+      },
+    },
+    resolved: { keyOwnerId: "user-test", source: "env" },
+  }),
+}));
+
+vi.mock("@/app/api/ai/_shared/usage-tracker", () => ({
+  recordUsage: () => undefined,
+  tokensFromAnthropic: () => ({ inputTokens: 20, outputTokens: 10 }),
+}));
+
+vi.mock("@/lib/server/insight-job-service", () => ({
+  getInsightJob: async (jobId: string, userId: string) => {
+    if (!mockJob || mockJob.id !== jobId || mockJob.userId !== userId) {
+      return null;
+    }
+    return mockJob;
+  },
+  completeInsightJob: async (jobId: string, report: unknown) => {
+    completeCalls.push({ jobId, report });
+    return { reportId: "report-test-1" };
+  },
+  failInsightJob: async (jobId: string, error: string) => {
+    failCalls.push({ jobId, error });
+  },
+  expireInsightJob: async (jobId: string) => {
+    expireCalls.push({ jobId });
+  },
+  getReportForJob: async () => mockReport,
+}));
+
+// ── Helpers ──────────────────────────────────────────────────────────────
+
+function makeRequest(jobId: string): NextRequest {
+  return new NextRequest(
+    `https://example.test/api/analytics/insights/jobs/${jobId}`,
+    { method: "GET" },
+  );
+}
+
+function succeededResult(input: unknown, stopReason: string = "tool_use") {
+  return {
+    type: "succeeded" as const,
+    message: {
+      content: [
+        { type: "tool_use", name: "analytics_insight", input },
+      ],
+      stop_reason: stopReason,
+      usage: { input_tokens: 20, output_tokens: 10 },
+    },
+  };
+}
+
+// ── Tests ────────────────────────────────────────────────────────────────
+
+describe("GET /api/analytics/insights/jobs/:id", () => {
+  beforeEach(() => {
+    resetState();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("returns 404 when the job is not found", async () => {
+    const { GET } = await import("./route");
+    const res = await GET(makeRequest("missing"));
+    expect(res.status).toBe(404);
+  });
+
+  it("returns status=pending while the batch is still in progress", async () => {
+    mockJob = {
+      id: "job-1",
+      userId: "user-test",
+      batchId: "msgbatch_test_123",
+      status: "pending",
+      requestPayload: PAYLOAD,
+      resultReportId: null,
+      error: null,
+      createdAt: Date.now() - 60_000,
+      completedAt: null,
+    };
+    batchProcessingStatus = "in_progress";
+
+    const { GET } = await import("./route");
+    const res = await GET(makeRequest("job-1"));
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { status: string; startedAt: number };
+    expect(body.status).toBe("pending");
+    expect(typeof body.startedAt).toBe("number");
+    expect(completeCalls).toHaveLength(0);
+    expect(failCalls).toHaveLength(0);
+  });
+
+  it("finalises and returns the result when the batch ended and the tool output is valid", async () => {
+    mockJob = {
+      id: "job-2",
+      userId: "user-test",
+      batchId: "msgbatch_test_123",
+      status: "pending",
+      requestPayload: PAYLOAD,
+      resultReportId: null,
+      error: null,
+      createdAt: Date.now() - 5 * 60_000,
+      completedAt: null,
+    };
+    batchProcessingStatus = "ended";
+    batchResults = [
+      {
+        custom_id: "insight-1",
+        result: succeededResult({
+          summary: "Sodium averaged 2100 mg against a 2300 mg limit.",
+          observations: [
+            "Water averaged 1800 ml — 700 ml below the 2500 ml goal.",
+          ],
+        }),
+      },
+    ];
+
+    const { GET } = await import("./route");
+    const res = await GET(makeRequest("job-2"));
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      status: string;
+      narrative: string;
+      observations: string[];
+    };
+    expect(body.status).toBe("completed");
+    expect(body.narrative).toContain("2100 mg");
+    expect(body.observations).toHaveLength(1);
+    expect(completeCalls).toHaveLength(1);
+    expect(failCalls).toHaveLength(0);
+  });
+
+  it("flips the job to failed when the model truncated at max_tokens", async () => {
+    mockJob = {
+      id: "job-3",
+      userId: "user-test",
+      batchId: "msgbatch_test_123",
+      status: "pending",
+      requestPayload: PAYLOAD,
+      resultReportId: null,
+      error: null,
+      createdAt: Date.now() - 60_000,
+      completedAt: null,
+    };
+    batchProcessingStatus = "ended";
+    batchResults = [
+      {
+        custom_id: "insight-1",
+        result: succeededResult(
+          { summary: "Comparison started but was cut off…" },
+          "max_tokens",
+        ),
+      },
+    ];
+
+    const { GET } = await import("./route");
+    const res = await GET(makeRequest("job-3"));
+    const body = (await res.json()) as { status: string; error: string };
+    expect(body.status).toBe("failed");
+    expect(body.error).toMatch(/cut off/i);
+    expect(failCalls).toHaveLength(1);
+    expect(completeCalls).toHaveLength(0);
+  });
+
+  it("flips the job to failed when Anthropic returns an errored individual result", async () => {
+    mockJob = {
+      id: "job-4",
+      userId: "user-test",
+      batchId: "msgbatch_test_123",
+      status: "pending",
+      requestPayload: PAYLOAD,
+      resultReportId: null,
+      error: null,
+      createdAt: Date.now() - 60_000,
+      completedAt: null,
+    };
+    batchProcessingStatus = "ended";
+    batchResults = [
+      {
+        custom_id: "insight-1",
+        result: {
+          type: "errored",
+          error: { error: { type: "overloaded", message: "service overloaded" } },
+        },
+      },
+    ];
+
+    const { GET } = await import("./route");
+    const res = await GET(makeRequest("job-4"));
+    const body = (await res.json()) as { status: string; error: string };
+    expect(body.status).toBe("failed");
+    expect(failCalls).toHaveLength(1);
+  });
+
+  it("flips the job to expired when it has been pending past the 24h SLA", async () => {
+    const SLA_MS = 24 * 60 * 60 * 1000;
+    mockJob = {
+      id: "job-5",
+      userId: "user-test",
+      batchId: "msgbatch_test_123",
+      status: "pending",
+      requestPayload: PAYLOAD,
+      resultReportId: null,
+      error: null,
+      createdAt: Date.now() - SLA_MS - 60_000,
+      completedAt: null,
+    };
+
+    const { GET } = await import("./route");
+    const res = await GET(makeRequest("job-5"));
+    const body = (await res.json()) as { status: string; error: string };
+    expect(body.status).toBe("expired");
+    expect(expireCalls).toHaveLength(1);
+  });
+
+  it("echoes the cached result when the job is already completed", async () => {
+    mockJob = {
+      id: "job-6",
+      userId: "user-test",
+      batchId: "msgbatch_test_123",
+      status: "completed",
+      requestPayload: PAYLOAD,
+      resultReportId: "report-test-1",
+      error: null,
+      createdAt: Date.now() - 60 * 60_000,
+      completedAt: Date.now() - 30 * 60_000,
+    };
+    mockReport = {
+      narrative: "Cached deep summary.",
+      observations: ["One observation."],
+      generatedAt: Date.now() - 30 * 60_000,
+    };
+
+    const { GET } = await import("./route");
+    const res = await GET(makeRequest("job-6"));
+    const body = (await res.json()) as {
+      status: string;
+      narrative: string;
+      observations: string[];
+    };
+    expect(body.status).toBe("completed");
+    expect(body.narrative).toBe("Cached deep summary.");
+    expect(body.observations).toEqual(["One observation."]);
+  });
+});

--- a/src/app/api/analytics/insights/jobs/[id]/route.test.ts
+++ b/src/app/api/analytics/insights/jobs/[id]/route.test.ts
@@ -17,7 +17,7 @@ import { NextRequest } from "next/server";
 interface MockJobRow {
   id: string;
   userId: string;
-  batchId: string;
+  batchId: string | null;
   status: "pending" | "completed" | "failed" | "expired";
   requestPayload: unknown;
   resultReportId: string | null;
@@ -120,13 +120,16 @@ vi.mock("@/lib/server/insight-job-service", () => ({
   },
   completeInsightJob: async (jobId: string, report: unknown) => {
     completeCalls.push({ jobId, report });
+    // Mirrors the real CAS return: null when the caller lost the race.
     return { reportId: "report-test-1" };
   },
   failInsightJob: async (jobId: string, error: string) => {
     failCalls.push({ jobId, error });
+    return true;
   },
   expireInsightJob: async (jobId: string) => {
     expireCalls.push({ jobId });
+    return true;
   },
   getReportForJob: async () => mockReport,
 }));
@@ -315,6 +318,95 @@ describe("GET /api/analytics/insights/jobs/:id", () => {
     const body = (await res.json()) as { status: string; error: string };
     expect(body.status).toBe("expired");
     expect(expireCalls).toHaveLength(1);
+  });
+
+  it("flips the job to failed when the tool output fails InsightResponseSchema validation", async () => {
+    mockJob = {
+      id: "job-7",
+      userId: "user-test",
+      batchId: "msgbatch_test_123",
+      status: "pending",
+      requestPayload: PAYLOAD,
+      resultReportId: null,
+      error: null,
+      createdAt: Date.now() - 60_000,
+      completedAt: null,
+    };
+    batchProcessingStatus = "ended";
+    // Missing the required `observations` array — Zod rejects it.
+    batchResults = [
+      {
+        custom_id: "insight-1",
+        result: succeededResult({ summary: "Partial answer only." }),
+      },
+    ];
+
+    const { GET } = await import("./route");
+    const res = await GET(makeRequest("job-7"));
+    const body = (await res.json()) as { status: string; error: string };
+    expect(body.status).toBe("failed");
+    expect(body.error).toMatch(/structural validation/i);
+    expect(failCalls).toHaveLength(1);
+    expect(completeCalls).toHaveLength(0);
+  });
+
+  it("flips the job to failed when the model returned only plain text (no tool call)", async () => {
+    mockJob = {
+      id: "job-8",
+      userId: "user-test",
+      batchId: "msgbatch_test_123",
+      status: "pending",
+      requestPayload: PAYLOAD,
+      resultReportId: null,
+      error: null,
+      createdAt: Date.now() - 60_000,
+      completedAt: null,
+    };
+    batchProcessingStatus = "ended";
+    batchResults = [
+      {
+        custom_id: "insight-1",
+        result: {
+          type: "succeeded" as const,
+          message: {
+            content: [{ type: "text", text: "Here is a plain prose reply." }],
+            stop_reason: "end_turn",
+            usage: { input_tokens: 20, output_tokens: 10 },
+          },
+        },
+      },
+    ];
+
+    const { GET } = await import("./route");
+    const res = await GET(makeRequest("job-8"));
+    const body = (await res.json()) as { status: string; error: string };
+    expect(body.status).toBe("failed");
+    expect(body.error).toMatch(/no tool call/i);
+    expect(failCalls).toHaveLength(1);
+    expect(completeCalls).toHaveLength(0);
+  });
+
+  it("returns status=pending when the row's batch_id has not been attached yet", async () => {
+    // Transient state right after the route reserves the slot but before
+    // attachBatchToJob lands — must not call Anthropic.
+    mockJob = {
+      id: "job-9",
+      userId: "user-test",
+      batchId: null,
+      status: "pending",
+      requestPayload: PAYLOAD,
+      resultReportId: null,
+      error: null,
+      createdAt: Date.now() - 1_000,
+      completedAt: null,
+    };
+
+    const { GET } = await import("./route");
+    const res = await GET(makeRequest("job-9"));
+    const body = (await res.json()) as { status: string };
+    expect(body.status).toBe("pending");
+    expect(failCalls).toHaveLength(0);
+    expect(expireCalls).toHaveLength(0);
   });
 
   it("echoes the cached result when the job is already completed", async () => {

--- a/src/app/api/analytics/insights/jobs/[id]/route.test.ts
+++ b/src/app/api/analytics/insights/jobs/[id]/route.test.ts
@@ -422,6 +422,49 @@ describe("GET /api/analytics/insights/jobs/:id", () => {
     expect(expireCalls).toHaveLength(0);
   });
 
+  it("propagates the winner's failed state when completeInsightJob loses the CAS race to a failure", async () => {
+    // Two pollers race; the winning poller had already flipped the job to
+    // "failed" by the time this one tried to complete it. The losing
+    // poller MUST surface the persisted failure, not its own synthesised
+    // "completed" payload — otherwise the client gets contradictory
+    // status across pollers.
+    const startedAt = Date.now() - 60_000;
+    mockJob = {
+      id: "job-cas-fail",
+      userId: "user-test",
+      batchId: "msgbatch_test_123",
+      status: "pending",
+      requestPayload: PAYLOAD,
+      resultReportId: null,
+      error: null,
+      createdAt: startedAt,
+      completedAt: null,
+    };
+    batchProcessingStatus = "ended";
+    batchResults = [
+      {
+        custom_id: "insight-1",
+        result: succeededResult({
+          summary: "Loser-pol summary",
+          observations: ["Loser-pol observation."],
+        }),
+      },
+    ];
+    completionReturn = null;
+    mockJobAfterCas = {
+      ...mockJob,
+      status: "failed",
+      error: "Winner flipped this to failed.",
+      completedAt: startedAt + 30_000,
+    };
+
+    const { GET } = await import("./route");
+    const res = await GET(makeRequest("job-cas-fail"));
+    const body = (await res.json()) as { status: string; error: string };
+    expect(body.status).toBe("failed");
+    expect(body.error).toBe("Winner flipped this to failed.");
+  });
+
   it("echoes the winning poller's persisted result when completeInsightJob loses the CAS race", async () => {
     // Two pollers reach the finalisation step concurrently. This one loses
     // the conditional update — completeInsightJob returns null — and must

--- a/src/app/api/analytics/insights/jobs/[id]/route.ts
+++ b/src/app/api/analytics/insights/jobs/[id]/route.ts
@@ -241,9 +241,24 @@ export const GET = withAuth(async ({ request, auth }) => {
   if (!validated.success) {
     const err =
       "Deep analysis returned a response that failed structural validation.";
+    // Inline counts so the per-request log line in Vercel's UI surfaces the
+    // diagnostic detail directly (it only shows the first console.error
+    // arg). flatten() then ships the per-field zod errors for the full log.
+    const raw = toolBlock.input as { summary?: unknown; observations?: unknown };
+    const summaryLen =
+      typeof raw.summary === "string" ? raw.summary.length : -1;
+    const obsCount = Array.isArray(raw.observations)
+      ? raw.observations.length
+      : -1;
+    const obsMaxLen = Array.isArray(raw.observations)
+      ? raw.observations.reduce(
+          (max, o) =>
+            Math.max(max, typeof o === "string" ? o.length : 0),
+          0,
+        )
+      : -1;
     console.error(
-      "[analytics/insights/jobs] response validation failed:",
-      JSON.stringify(validated.error.flatten()),
+      `[analytics/insights/jobs] response validation failed: summaryLen=${summaryLen} obsCount=${obsCount} obsMaxLen=${obsMaxLen} fields=${JSON.stringify(validated.error.flatten().fieldErrors)}`,
     );
     await failInsightJob(job.id, err);
     return NextResponse.json({

--- a/src/app/api/analytics/insights/jobs/[id]/route.ts
+++ b/src/app/api/analytics/insights/jobs/[id]/route.ts
@@ -1,0 +1,302 @@
+import { NextResponse } from "next/server";
+import type Anthropic from "@anthropic-ai/sdk";
+import { withAuth } from "@/lib/auth-middleware";
+import {
+  INSIGHT_TOOL,
+  InsightResponseSchema,
+  type AnalyticsInsightsRequest,
+} from "@/lib/analytics-insights";
+import {
+  getClaudeClientForUser,
+  CLAUDE_MODELS,
+} from "@/app/api/ai/_shared/claude-client";
+import {
+  recordUsage,
+  tokensFromAnthropic,
+} from "@/app/api/ai/_shared/usage-tracker";
+import { aiErrorResponse } from "@/app/api/ai/_shared/ai-error-response";
+import {
+  getInsightJob,
+  completeInsightJob,
+  failInsightJob,
+  expireInsightJob,
+  getReportForJob,
+  type InsightJobRow,
+} from "@/lib/server/insight-job-service";
+
+/**
+ * Poll a deep-research insight job.
+ *
+ *   GET /api/analytics/insights/jobs/:id
+ *
+ * Response shape (status code is always 200; the body's `status` field is the
+ * thing the client switches on):
+ *
+ *   { status: "pending",   startedAt }                              — still in flight
+ *   { status: "completed", narrative, observations, generatedAt }   — done
+ *   { status: "failed",    error }                                  — terminal error
+ *   { status: "expired",   error }                                  — 24h SLA blown
+ *
+ * The route is the only place that mutates job state after creation. When
+ * Anthropic reports the batch ended we fetch the results stream, validate
+ * the tool output against `InsightResponseSchema`, persist a row to
+ * `insight_reports` (with `mode: "deep"`), and flip the job to "completed"
+ * — all from this single GET. That keeps the server stateless between polls
+ * (no background worker, no cron) while still making the result durable as
+ * soon as it's available.
+ */
+
+export const runtime = "nodejs";
+
+// Mirrors the docs SLA. Pending jobs older than this are reported as expired
+// — the client treats this terminally so the pending indicator can clear.
+const BATCH_SLA_MS = 24 * 60 * 60 * 1000;
+
+type ToolUseBlock = Extract<
+  Anthropic.Messages.ContentBlock,
+  { type: "tool_use" }
+>;
+
+export const GET = withAuth(async ({ request, auth }) => {
+  // Next 14 App Router exposes [id] via the URL pathname; we don't get a
+  // `params` arg from `withAuth`'s wrapper, so parse it manually.
+  const pathname = new URL(request.url).pathname;
+  const segments = pathname.split("/").filter(Boolean);
+  const jobId = segments[segments.length - 1];
+  if (!jobId) {
+    return NextResponse.json({ error: "Missing job id" }, { status: 400 });
+  }
+
+  const job = await getInsightJob(jobId, auth.userId!);
+  if (!job) {
+    return NextResponse.json({ error: "Job not found" }, { status: 404 });
+  }
+
+  if (job.status === "completed") {
+    return respondCompleted(job);
+  }
+  if (job.status === "failed" || job.status === "expired") {
+    return NextResponse.json({
+      status: job.status,
+      error: job.error ?? "Deep analysis did not complete.",
+      startedAt: job.createdAt,
+    });
+  }
+
+  // Pending — ask Anthropic for the batch status, finalise if we can.
+  if (Date.now() - job.createdAt > BATCH_SLA_MS) {
+    await expireInsightJob(job.id);
+    return NextResponse.json({
+      status: "expired",
+      error: "Batch exceeded the 24-hour SLA without completing.",
+      startedAt: job.createdAt,
+    });
+  }
+
+  let client;
+  let resolved;
+  try {
+    ({ client, resolved } = await getClaudeClientForUser(
+      auth.userId!,
+      auth.email,
+    ));
+  } catch (e) {
+    const mapped = aiErrorResponse(e);
+    if (mapped) return mapped;
+    throw e;
+  }
+
+  let batch;
+  try {
+    batch = await client.messages.batches.retrieve(job.batchId);
+  } catch (e) {
+    const mapped = aiErrorResponse(e);
+    if (mapped) return mapped;
+    console.error("[analytics/insights/jobs] batch retrieve failed:", e);
+    return NextResponse.json(
+      { error: "Failed to check deep-analysis status" },
+      { status: 502 },
+    );
+  }
+
+  if (batch.processing_status !== "ended") {
+    return NextResponse.json({
+      status: "pending" as const,
+      startedAt: job.createdAt,
+    });
+  }
+
+  // The batch has ended. Stream the results and find the entry matching our
+  // single submission's custom_id.
+  let individual:
+    | Anthropic.Messages.Batches.MessageBatchIndividualResponse
+    | undefined;
+  try {
+    const stream = await client.messages.batches.results(job.batchId);
+    for await (const entry of stream) {
+      // We submit one request per batch, so the first entry is ours — but
+      // matching by id is more honest if that ever changes.
+      individual = entry;
+      break;
+    }
+  } catch (e) {
+    console.error("[analytics/insights/jobs] results stream failed:", e);
+    await failInsightJob(
+      job.id,
+      "Could not retrieve batch results from Anthropic.",
+    );
+    return NextResponse.json({
+      status: "failed",
+      error: "Could not retrieve batch results from Anthropic.",
+      startedAt: job.createdAt,
+    });
+  }
+
+  if (!individual) {
+    await failInsightJob(job.id, "Batch ended but contained no results.");
+    return NextResponse.json({
+      status: "failed",
+      error: "Batch ended but contained no results.",
+      startedAt: job.createdAt,
+    });
+  }
+
+  const r = individual.result;
+  if (r.type !== "succeeded") {
+    const errMsg =
+      r.type === "errored"
+        ? `Anthropic reported an error during deep analysis (${r.error?.error?.type ?? "unknown"}).`
+        : r.type === "expired"
+          ? "Anthropic expired the deep-analysis request before it ran."
+          : "Deep analysis was canceled before it could finish.";
+    await failInsightJob(job.id, errMsg);
+    return NextResponse.json({
+      status: "failed",
+      error: errMsg,
+      startedAt: job.createdAt,
+    });
+  }
+
+  const message = r.message;
+  // Record usage AFTER the model actually produced output, against the
+  // user's resolved key — same pattern as the fast route.
+  try {
+    recordUsage({
+      userId: auth.userId!,
+      keyOwnerId: resolved.keyOwnerId,
+      keySource: resolved.source,
+      provider: "anthropic",
+      model: CLAUDE_MODELS.premium,
+      route: "/api/analytics/insights/deep",
+      status: "success",
+      durationMs: Date.now() - job.createdAt,
+      ...tokensFromAnthropic(message.usage),
+    });
+  } catch (usageError) {
+    console.error(
+      "[analytics/insights/jobs] usage recording failed:",
+      usageError,
+    );
+  }
+
+  const toolBlock = message.content.find(
+    (b): b is ToolUseBlock =>
+      b.type === "tool_use" && b.name === INSIGHT_TOOL.name,
+  );
+  if (message.stop_reason === "max_tokens") {
+    const err =
+      "Deep analysis was cut off before the model could finish. Try again.";
+    await failInsightJob(job.id, err);
+    return NextResponse.json({
+      status: "failed",
+      error: err,
+      startedAt: job.createdAt,
+    });
+  }
+  if (!toolBlock) {
+    const err = "Deep analysis returned a malformed response (no tool call).";
+    console.error(
+      "[analytics/insights/jobs] model did not call insight tool",
+      { stopReason: message.stop_reason },
+    );
+    await failInsightJob(job.id, err);
+    return NextResponse.json({
+      status: "failed",
+      error: err,
+      startedAt: job.createdAt,
+    });
+  }
+
+  const validated = InsightResponseSchema.safeParse(toolBlock.input);
+  if (!validated.success) {
+    const err =
+      "Deep analysis returned a response that failed structural validation.";
+    console.error(
+      "[analytics/insights/jobs] response validation failed:",
+      JSON.stringify(validated.error.flatten()),
+    );
+    await failInsightJob(job.id, err);
+    return NextResponse.json({
+      status: "failed",
+      error: err,
+      startedAt: job.createdAt,
+    });
+  }
+
+  const generatedAt = Date.now();
+  // The submitted payload defines the analysis window and personalisation —
+  // pull it back out of the saved request_payload rather than trusting
+  // client-supplied values on the poll.
+  const submitted = job.requestPayload as AnalyticsInsightsRequest;
+  const personalised =
+    Boolean(
+      submitted.profile?.conditions && submitted.profile.conditions.length > 0,
+    ) ||
+    Boolean(
+      submitted.profile?.medications &&
+        submitted.profile.medications.length > 0,
+    );
+
+  await completeInsightJob(job.id, {
+    userId: auth.userId!,
+    generatedAt,
+    rangeStart: submitted.range.start,
+    rangeEnd: submitted.range.end,
+    narrative: validated.data.summary,
+    observations: validated.data.observations,
+    personalised,
+  });
+
+  return NextResponse.json({
+    status: "completed" as const,
+    narrative: validated.data.summary,
+    observations: validated.data.observations,
+    generatedAt,
+    startedAt: job.createdAt,
+  });
+});
+
+async function respondCompleted(job: InsightJobRow) {
+  if (!job.resultReportId) {
+    return NextResponse.json({
+      status: "failed",
+      error: "Job marked completed but has no result reference.",
+      startedAt: job.createdAt,
+    });
+  }
+  const report = await getReportForJob(job.resultReportId, job.userId);
+  if (!report) {
+    return NextResponse.json({
+      status: "failed",
+      error: "Cached result for this job is no longer available.",
+      startedAt: job.createdAt,
+    });
+  }
+  return NextResponse.json({
+    status: "completed" as const,
+    narrative: report.narrative,
+    observations: report.observations,
+    generatedAt: report.generatedAt,
+    startedAt: job.createdAt,
+  });
+}

--- a/src/app/api/analytics/insights/jobs/[id]/route.ts
+++ b/src/app/api/analytics/insights/jobs/[id]/route.ts
@@ -306,9 +306,21 @@ export const GET = withAuth(async ({ request, auth }) => {
     if (winning && winning.status === "completed") {
       return respondCompleted(winning);
     }
-    // Defensive: status flipped to failed/expired by the winner, or the
-    // row disappeared. Tell the client to poll again rather than asserting
-    // a synthetic outcome.
+    if (
+      winning &&
+      (winning.status === "failed" || winning.status === "expired")
+    ) {
+      // Propagate the winner's terminal state instead of pretending we're
+      // still pending — otherwise the client polls forever for a job the
+      // other branch already marked failed/expired.
+      return NextResponse.json({
+        status: winning.status,
+        error: winning.error ?? "Deep analysis did not complete.",
+        startedAt: job.createdAt,
+      });
+    }
+    // Defensive: winning row disappeared (extremely rare). Tell the client
+    // to poll again rather than asserting a synthetic outcome.
     return NextResponse.json({
       status: "pending" as const,
       startedAt: job.createdAt,

--- a/src/app/api/analytics/insights/jobs/[id]/route.ts
+++ b/src/app/api/analytics/insights/jobs/[id]/route.ts
@@ -282,6 +282,10 @@ export const GET = withAuth(async ({ request, auth }) => {
         submitted.profile.medications.length > 0,
     );
 
+  const sources =
+    validated.data.sources && validated.data.sources.length > 0
+      ? validated.data.sources
+      : null;
   const completion = await completeInsightJob(job.id, {
     userId: auth.userId!,
     generatedAt,
@@ -289,6 +293,7 @@ export const GET = withAuth(async ({ request, auth }) => {
     rangeEnd: submitted.range.end,
     narrative: validated.data.summary,
     observations: validated.data.observations,
+    sources,
     personalised,
   });
 
@@ -314,6 +319,7 @@ export const GET = withAuth(async ({ request, auth }) => {
     status: "completed" as const,
     narrative: validated.data.summary,
     observations: validated.data.observations,
+    sources: sources ?? undefined,
     generatedAt,
     startedAt: job.createdAt,
   });
@@ -339,6 +345,7 @@ async function respondCompleted(job: InsightJobRow) {
     status: "completed" as const,
     narrative: report.narrative,
     observations: report.observations,
+    sources: report.sources ?? undefined,
     generatedAt: report.generatedAt,
     startedAt: job.createdAt,
   });

--- a/src/app/api/analytics/insights/jobs/[id]/route.ts
+++ b/src/app/api/analytics/insights/jobs/[id]/route.ts
@@ -93,6 +93,16 @@ export const GET = withAuth(async ({ request, auth }) => {
     });
   }
 
+  // Submission is still in flight — the reservation insert won the unique
+  // index but the batch_id hasn't been attached yet. Tell the client to
+  // keep polling; we'll have a batch to query on the next tick.
+  if (!job.batchId) {
+    return NextResponse.json({
+      status: "pending" as const,
+      startedAt: job.createdAt,
+    });
+  }
+
   let client;
   let resolved;
   try {

--- a/src/app/api/analytics/insights/jobs/[id]/route.ts
+++ b/src/app/api/analytics/insights/jobs/[id]/route.ts
@@ -267,7 +267,7 @@ export const GET = withAuth(async ({ request, auth }) => {
         submitted.profile.medications.length > 0,
     );
 
-  await completeInsightJob(job.id, {
+  const completion = await completeInsightJob(job.id, {
     userId: auth.userId!,
     generatedAt,
     rangeStart: submitted.range.start,
@@ -276,6 +276,24 @@ export const GET = withAuth(async ({ request, auth }) => {
     observations: validated.data.observations,
     personalised,
   });
+
+  if (completion === null) {
+    // Lost the CAS race — another concurrent poller already finalised this
+    // job. Echo whatever that winning poller persisted so the client sees
+    // a consistent view (matching id, matching generatedAt) instead of our
+    // synthesised one. The winning row's status drives the response.
+    const winning = await getInsightJob(job.id, auth.userId!);
+    if (winning && winning.status === "completed") {
+      return respondCompleted(winning);
+    }
+    // Defensive: status flipped to failed/expired by the winner, or the
+    // row disappeared. Tell the client to poll again rather than asserting
+    // a synthetic outcome.
+    return NextResponse.json({
+      status: "pending" as const,
+      startedAt: job.createdAt,
+    });
+  }
 
   return NextResponse.json({
     status: "completed" as const,

--- a/src/app/api/analytics/insights/route.test.ts
+++ b/src/app/api/analytics/insights/route.test.ts
@@ -20,12 +20,14 @@ import Anthropic from "@anthropic-ai/sdk";
 // ── Controllable stubs ───────────────────────────────────────────────────
 
 let aiContent: unknown[] = [];
+let aiStopReason: string = "tool_use";
 let aiThrows: Error | null = null;
 let claudeClientThrows: Error | null = null;
 const messagesCreateCalls: unknown[] = [];
 
 function resetState() {
   aiContent = [];
+  aiStopReason = "tool_use";
   aiThrows = null;
   claudeClientThrows = null;
   messagesCreateCalls.length = 0;
@@ -58,6 +60,7 @@ vi.mock("@/app/api/ai/_shared/claude-client", () => ({
             if (aiThrows) throw aiThrows;
             return {
               content: aiContent,
+              stop_reason: aiStopReason,
               usage: { input_tokens: 20, output_tokens: 10 },
             };
           },
@@ -219,6 +222,45 @@ describe("POST /api/analytics/insights", () => {
     expect(res.status).toBe(502);
     const body = (await res.json()) as { error: string };
     expect(body.error).toBe("AI response format invalid");
+  });
+
+  it("returns a clear 502 / RESPONSE_TRUNCATED when stop_reason is max_tokens", async () => {
+    // When the model hits max_tokens it still emits a tool_use block, but
+    // the JSON in `input` is truncated mid-object — schema validation would
+    // otherwise hide this behind the generic "format invalid" message.
+    aiStopReason = "max_tokens";
+    aiContent = [
+      insightToolBlock({
+        summary: "Comparison against the previous month shows",
+        // observations field never finished streaming
+      }),
+    ];
+
+    const { POST } = await import("./route");
+    const res = await POST(makeRequest(validBody()));
+
+    expect(res.status).toBe(502);
+    const body = (await res.json()) as { error: string; code?: string };
+    expect(body.code).toBe("RESPONSE_TRUNCATED");
+    expect(body.error).toMatch(/cut off/i);
+  });
+
+  it("requests enough tokens to fit a comparison summary", async () => {
+    aiContent = [
+      insightToolBlock({
+        summary: "ok",
+        observations: ["ok"],
+      }),
+    ];
+
+    const { POST } = await import("./route");
+    await POST(makeRequest(validBody()));
+
+    expect(messagesCreateCalls).toHaveLength(1);
+    const params = messagesCreateCalls[0] as { max_tokens: number };
+    // 1024 truncates comparison output mid-JSON when priorAssessments is
+    // included; the cap needs enough headroom for the full tool response.
+    expect(params.max_tokens).toBeGreaterThanOrEqual(2048);
   });
 
   it("returns a generic 502 when the model call throws an unmapped error", async () => {

--- a/src/app/api/analytics/insights/route.ts
+++ b/src/app/api/analytics/insights/route.ts
@@ -78,9 +78,14 @@ export const POST = withAuth(async ({ request, auth }) => {
     console.log(`[AUDIT] analytics insights from user: ${auth.userId}`);
 
     const startedAt = Date.now();
+    // The response schema permits ~2000 chars summary + 12×500 chars
+    // observations ≈ well over 1024 tokens once tool-call JSON overhead is
+    // added. Comparison output (when priorAssessments is included) reliably
+    // approaches that ceiling, so 1024 truncates mid-JSON and the tool_use
+    // input fails schema validation downstream.
     const response = await client.messages.create({
       model: CLAUDE_MODELS.quality,
-      max_tokens: 1024,
+      max_tokens: 2048,
       temperature: 0.3,
       system: INSIGHTS_SYSTEM_PROMPT,
       tools: [INSIGHT_TOOL],
@@ -108,8 +113,27 @@ export const POST = withAuth(async ({ request, auth }) => {
       (b): b is ToolUseBlock =>
         b.type === "tool_use" && b.name === INSIGHT_TOOL.name,
     );
+    // When the model hits max_tokens the tool_use block is still emitted but
+    // its `input` JSON is truncated mid-object — surface that as a distinct,
+    // actionable error instead of the generic "format invalid" toast.
+    if (response.stop_reason === "max_tokens") {
+      console.error(
+        "[analytics/insights] response truncated by max_tokens",
+        { hasToolBlock: Boolean(toolBlock) },
+      );
+      return NextResponse.json(
+        {
+          error:
+            "AI response was cut off before it finished. Try again, or generate without 'Include my previous summary'.",
+          code: "RESPONSE_TRUNCATED",
+        },
+        { status: 502 },
+      );
+    }
     if (!toolBlock) {
-      console.error("[analytics/insights] model did not call the insight tool");
+      console.error("[analytics/insights] model did not call the insight tool", {
+        stopReason: response.stop_reason,
+      });
       return NextResponse.json(
         { error: "AI response format invalid" },
         { status: 502 },
@@ -121,6 +145,7 @@ export const POST = withAuth(async ({ request, auth }) => {
       console.error(
         "[analytics/insights] AI response validation failed:",
         JSON.stringify(validated.error.flatten()),
+        { stopReason: response.stop_reason },
       );
       return NextResponse.json(
         { error: "AI response format invalid" },

--- a/src/app/api/analytics/insights/route.ts
+++ b/src/app/api/analytics/insights/route.ts
@@ -84,7 +84,7 @@ export const POST = withAuth(async ({ request, auth }) => {
     // approaches that ceiling, so 1024 truncates mid-JSON and the tool_use
     // input fails schema validation downstream.
     const response = await client.messages.create({
-      model: CLAUDE_MODELS.quality,
+      model: CLAUDE_MODELS.premium,
       max_tokens: 2048,
       temperature: 0.3,
       system: INSIGHTS_SYSTEM_PROMPT,
@@ -99,7 +99,7 @@ export const POST = withAuth(async ({ request, auth }) => {
         keyOwnerId: resolved.keyOwnerId,
         keySource: resolved.source,
         provider: "anthropic",
-        model: CLAUDE_MODELS.quality,
+        model: CLAUDE_MODELS.premium,
         route: "/api/analytics/insights",
         status: "success",
         durationMs: Date.now() - startedAt,

--- a/src/app/api/analytics/insights/route.ts
+++ b/src/app/api/analytics/insights/route.ts
@@ -84,7 +84,7 @@ export const POST = withAuth(async ({ request, auth }) => {
     // approaches that ceiling, so 1024 truncates mid-JSON and the tool_use
     // input fails schema validation downstream.
     const response = await client.messages.create({
-      model: CLAUDE_MODELS.premium,
+      model: CLAUDE_MODELS.quality,
       max_tokens: 2048,
       temperature: 0.3,
       system: INSIGHTS_SYSTEM_PROMPT,
@@ -99,7 +99,7 @@ export const POST = withAuth(async ({ request, auth }) => {
         keyOwnerId: resolved.keyOwnerId,
         keySource: resolved.source,
         provider: "anthropic",
-        model: CLAUDE_MODELS.premium,
+        model: CLAUDE_MODELS.quality,
         route: "/api/analytics/insights",
         status: "success",
         durationMs: Date.now() - startedAt,

--- a/src/components/analytics/ai-insights-card.dom.test.tsx
+++ b/src/components/analytics/ai-insights-card.dom.test.tsx
@@ -33,7 +33,7 @@ describe("AiInsightsCard", () => {
     ).toBeInTheDocument();
   });
 
-  it("renders a cached insights result with its narrative and observations", async () => {
+  it("renders a compact preview of the cached report inline with the narrative and a Read affordance", async () => {
     await renderWithFixtures(<AiInsightsCard />, {
       seed: {
         insightReports: [
@@ -49,19 +49,50 @@ describe("AiInsightsCard", () => {
       },
     });
 
+    // Narrative previewed inline so the user knows what's in the report
+    // without opening it.
     expect(
       await screen.findByText("Your hydration improved this week."),
     ).toBeInTheDocument();
-    expect(screen.getByText("Water intake rose 12%")).toBeInTheDocument();
-    expect(screen.getByText("Sodium stayed within limit")).toBeInTheDocument();
-    // Both buttons remain available so the user can run either flavour
-    // when a previous result is already cached.
+    // Observations are gated behind the reading dialog — they should NOT
+    // be visible until the user clicks through. This keeps deep-mode
+    // reports from dominating the analytics page.
+    expect(screen.queryByText("Water intake rose 12%")).not.toBeInTheDocument();
+    expect(screen.getByText(/Read/i)).toBeInTheDocument();
     expect(
       screen.getByRole("button", { name: "Fast analysis" }),
     ).toBeInTheDocument();
     expect(
       screen.getByRole("button", { name: /Deep analysis/i }),
     ).toBeInTheDocument();
+  });
+
+  it("opens the reading dialog with full observations + sources when the preview is tapped", async () => {
+    const user = userEvent.setup();
+    await renderWithFixtures(<AiInsightsCard />, {
+      seed: {
+        insightReports: [
+          makeInsightReport({
+            generatedAt: Date.now(),
+            narrative: "Deep summary on the card.",
+            observations: ["Observation revealed only in the modal."],
+            sources: ["https://www.example.test/clinical-ref"],
+            mode: "deep",
+          }),
+        ],
+      },
+    });
+
+    // Tap the preview row to open the reading dialog.
+    await user.click(
+      await screen.findByText("Deep summary on the card."),
+    );
+
+    expect(
+      await screen.findByText("Observation revealed only in the modal."),
+    ).toBeInTheDocument();
+    // Sources are surfaced inside the dialog as a hostname chip.
+    expect(screen.getByText("example.test")).toBeInTheDocument();
   });
 
   it("renders a 'Deep' badge on deep-mode cached reports", async () => {

--- a/src/components/analytics/ai-insights-card.dom.test.tsx
+++ b/src/components/analytics/ai-insights-card.dom.test.tsx
@@ -95,6 +95,36 @@ describe("AiInsightsCard", () => {
     expect(screen.getByText("example.test")).toBeInTheDocument();
   });
 
+  it("never renders an anchor for a non-http source URL (XSS guard)", async () => {
+    // The model-generated sources field is zod-validated as a URL but
+    // z.url() accepts javascript: and data: schemes. The card MUST refuse
+    // to make those clickable; only http(s) survive as an <a>. Anything
+    // else falls back to plain text.
+    const user = userEvent.setup();
+    await renderWithFixtures(<AiInsightsCard />, {
+      seed: {
+        insightReports: [
+          makeInsightReport({
+            generatedAt: Date.now(),
+            narrative: "Deep summary with a malicious source.",
+            observations: ["Observation."],
+            sources: ["javascript:alert(1)"],
+            mode: "deep",
+          }),
+        ],
+      },
+    });
+
+    await user.click(
+      await screen.findByText("Deep summary with a malicious source."),
+    );
+
+    // The source still surfaces as plain text so the user sees it, but
+    // the renderer is plain text, NOT an <a> the user can activate.
+    const node = await screen.findByText("javascript:alert(1)");
+    expect(node.tagName).not.toBe("A");
+  });
+
   it("renders a 'Deep' badge on deep-mode cached reports", async () => {
     await renderWithFixtures(<AiInsightsCard />, {
       seed: {

--- a/src/components/analytics/ai-insights-card.dom.test.tsx
+++ b/src/components/analytics/ai-insights-card.dom.test.tsx
@@ -19,14 +19,17 @@ describe("AiInsightsCard", () => {
     vi.unstubAllGlobals();
   });
 
-  it("shows the pre-generation prompt and a Generate button when no result is cached", async () => {
+  it("shows the pre-generation prompt and both fast/deep buttons when no result is cached", async () => {
     await renderWithFixtures(<AiInsightsCard />);
 
     expect(
       await screen.findByText(/Generate an AI summary of your last 30 days/i),
     ).toBeInTheDocument();
     expect(
-      screen.getByRole("button", { name: "Generate insights" }),
+      screen.getByRole("button", { name: "Fast analysis" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /Deep analysis/i }),
     ).toBeInTheDocument();
   });
 
@@ -51,17 +54,41 @@ describe("AiInsightsCard", () => {
     ).toBeInTheDocument();
     expect(screen.getByText("Water intake rose 12%")).toBeInTheDocument();
     expect(screen.getByText("Sodium stayed within limit")).toBeInTheDocument();
-    // With a cached result the button switches to "Regenerate".
+    // Both buttons remain available so the user can run either flavour
+    // when a previous result is already cached.
     expect(
-      screen.getByRole("button", { name: "Regenerate" }),
+      screen.getByRole("button", { name: "Fast analysis" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /Deep analysis/i }),
     ).toBeInTheDocument();
   });
 
-  it("opens the consent dialog explaining what data feeds the summary", async () => {
+  it("renders a 'Deep' badge on deep-mode cached reports", async () => {
+    await renderWithFixtures(<AiInsightsCard />, {
+      seed: {
+        insightReports: [
+          makeInsightReport({
+            generatedAt: Date.now(),
+            narrative: "Deep-research summary.",
+            observations: ["With citations from current guidelines."],
+            mode: "deep",
+          }),
+        ],
+      },
+    });
+
+    expect(
+      await screen.findByText("Deep-research summary."),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Deep")).toBeInTheDocument();
+  });
+
+  it("opens the consent dialog explaining what data feeds the summary when fast is clicked", async () => {
     const user = userEvent.setup();
     await renderWithFixtures(<AiInsightsCard />);
 
-    await user.click(screen.getByRole("button", { name: "Generate insights" }));
+    await user.click(screen.getByRole("button", { name: "Fast analysis" }));
 
     expect(
       await screen.findByText("What goes into this summary"),
@@ -70,6 +97,25 @@ describe("AiInsightsCard", () => {
     expect(screen.getByText("Blood pressure readings")).toBeInTheDocument();
     expect(
       screen.getByText(/Conditions not included/i),
+    ).toBeInTheDocument();
+  });
+
+  it("surfaces the cost warning in the dialog when deep analysis is clicked", async () => {
+    const user = userEvent.setup();
+    await renderWithFixtures(<AiInsightsCard />);
+
+    await user.click(screen.getByRole("button", { name: /Deep analysis/i }));
+
+    expect(
+      await screen.findByText("Deep analysis with web research"),
+    ).toBeInTheDocument();
+    // The cost-warning callout flagged by the prompt is what makes deep
+    // mode distinguishable in the consent dialog.
+    expect(
+      screen.getByText("Deep analysis is a costly request"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Start deep analysis" }),
     ).toBeInTheDocument();
   });
 });

--- a/src/components/analytics/ai-insights-card.tsx
+++ b/src/components/analytics/ai-insights-card.tsx
@@ -60,6 +60,17 @@ const TRACKED_DATA = [
   "Your water goal, sodium limit & sugar limit",
 ];
 
+/** Best-effort hostname pretty-print for a source URL. Falls back to the
+ * raw string when the input cannot be parsed (e.g. shortened pre-validated
+ * forms from older reports). */
+function sourceLabel(url: string): string {
+  try {
+    return new URL(url).hostname.replace(/^www\./, "");
+  } catch {
+    return url;
+  }
+}
+
 /** Render one cached report's narrative + observations. */
 function ReportBody({ report }: { report: InsightReport }) {
   return (
@@ -89,6 +100,28 @@ function ReportBody({ report }: { report: InsightReport }) {
             </li>
           ))}
         </ul>
+      )}
+      {report.sources && report.sources.length > 0 && (
+        <div className="pt-1 border-t border-slate-200 dark:border-slate-800">
+          <p className="text-[11px] font-medium text-muted-foreground mb-1">
+            Sources
+          </p>
+          <ul className="flex flex-wrap gap-x-2 gap-y-0.5 text-[11px]">
+            {report.sources.map((url, i) => (
+              <li key={i}>
+                <a
+                  href={url}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-violet-600 dark:text-violet-400 hover:underline"
+                  title={url}
+                >
+                  {sourceLabel(url)}
+                </a>
+              </li>
+            ))}
+          </ul>
+        </div>
       )}
     </div>
   );

--- a/src/components/analytics/ai-insights-card.tsx
+++ b/src/components/analytics/ai-insights-card.tsx
@@ -5,6 +5,7 @@ import { formatDistanceToNow } from "date-fns";
 import {
   Check,
   ChevronDown,
+  ChevronRight,
   Loader2,
   Search,
   Sparkles,
@@ -71,29 +72,67 @@ function sourceLabel(url: string): string {
   }
 }
 
-/** Render one cached report's narrative + observations. */
-function ReportBody({ report }: { report: InsightReport }) {
+/**
+ * Compact one-row teaser for a cached report — relative timestamp, mode
+ * badge, a clipped narrative snippet, and a "Read report" affordance.
+ * Tapping anywhere on the row hands the full report to the parent so it
+ * can swap it into the reading dialog. Keeps the card scannable when a
+ * deep-mode report would otherwise dominate the analytics page.
+ */
+function ReportPreview({
+  report,
+  onOpen,
+}: {
+  report: InsightReport;
+  onOpen: (report: InsightReport) => void;
+}) {
   return (
-    <div className="space-y-2">
-      <div className="flex items-start justify-between gap-2">
-        <p className="text-sm text-slate-700 dark:text-slate-200">
-          {report.narrative}
-        </p>
-        {report.mode === "deep" && (
-          <span
-            className="shrink-0 inline-flex items-center gap-1 rounded-full bg-violet-100 dark:bg-violet-950/50 text-violet-700 dark:text-violet-300 px-1.5 py-0.5 text-[10px] font-medium"
-            title="Deep analysis with web search"
-          >
-            <Search className="w-2.5 h-2.5" />
-            Deep
+    <button
+      type="button"
+      onClick={() => onOpen(report)}
+      className="w-full text-left rounded-md border border-slate-200 dark:border-slate-800 bg-white/40 dark:bg-slate-900/40 hover:bg-slate-100/60 dark:hover:bg-slate-800/40 transition-colors px-2.5 py-2"
+    >
+      <div className="flex items-center justify-between gap-2 mb-1">
+        <div className="flex items-center gap-1.5 min-w-0">
+          <span className="text-[11px] text-muted-foreground truncate">
+            {formatDistanceToNow(report.generatedAt, { addSuffix: true })}
           </span>
-        )}
+          {report.mode === "deep" && (
+            <span
+              className="shrink-0 inline-flex items-center gap-1 rounded-full bg-violet-100 dark:bg-violet-950/50 text-violet-700 dark:text-violet-300 px-1.5 py-0.5 text-[10px] font-medium"
+              title="Deep analysis with web search"
+            >
+              <Search className="w-2.5 h-2.5" />
+              Deep
+            </span>
+          )}
+        </div>
+        <span className="shrink-0 inline-flex items-center gap-0.5 text-[11px] font-medium text-violet-600 dark:text-violet-400">
+          Read
+          <ChevronRight className="w-3 h-3" />
+        </span>
       </div>
+      <p className="text-xs text-slate-600 dark:text-slate-300 line-clamp-2">
+        {report.narrative}
+      </p>
+    </button>
+  );
+}
+
+/** Full report contents — narrative + observations + sources. Rendered
+ * inside the reading dialog; intentionally not constrained in height so
+ * the dialog's own scroll container handles overflow. */
+function ReportContent({ report }: { report: InsightReport }) {
+  return (
+    <div className="space-y-3">
+      <p className="text-sm text-slate-700 dark:text-slate-200 whitespace-pre-line">
+        {report.narrative}
+      </p>
       {report.observations.length > 0 && (
-        <ul className="space-y-1 text-sm text-slate-600 dark:text-slate-300">
+        <ul className="space-y-1.5 text-sm text-slate-600 dark:text-slate-300">
           {report.observations.map((observation, i) => (
             <li key={i} className="flex gap-1.5">
-              <span aria-hidden className="text-violet-500">
+              <span aria-hidden className="text-violet-500 leading-5">
                 &bull;
               </span>
               <span>{observation}</span>
@@ -102,11 +141,11 @@ function ReportBody({ report }: { report: InsightReport }) {
         </ul>
       )}
       {report.sources && report.sources.length > 0 && (
-        <div className="pt-1 border-t border-slate-200 dark:border-slate-800">
-          <p className="text-[11px] font-medium text-muted-foreground mb-1">
+        <div className="pt-2 border-t border-slate-200 dark:border-slate-800">
+          <p className="text-xs font-medium text-muted-foreground mb-1.5">
             Sources
           </p>
-          <ul className="flex flex-wrap gap-x-2 gap-y-0.5 text-[11px]">
+          <ul className="flex flex-wrap gap-x-2 gap-y-1 text-xs">
             {report.sources.map((url, i) => (
               <li key={i}>
                 <a
@@ -151,6 +190,11 @@ export function AiInsightsCard() {
   const [dialogMode, setDialogMode] = useState<"fast" | "deep">("fast");
   const [includePrevious, setIncludePrevious] = useState(false);
   const [historyOpen, setHistoryOpen] = useState(false);
+  // The report currently being read in the dedicated reading dialog. null
+  // when the dialog is closed.
+  const [readingReport, setReadingReport] = useState<InsightReport | null>(
+    null,
+  );
   // Recompute "long-running" wording each minute while a deep job is pending
   // so the message swaps without a refresh once the threshold is crossed.
   const [, forceTick] = useState(0);
@@ -259,13 +303,7 @@ export function AiInsightsCard() {
       </CardHeader>
       <CardContent className="px-3 pb-3 space-y-3">
         {latest ? (
-          <div className="space-y-2">
-            <ReportBody report={latest} />
-            <p className="text-xs text-muted-foreground">
-              Generated{" "}
-              {formatDistanceToNow(latest.generatedAt, { addSuffix: true })}
-            </p>
-          </div>
+          <ReportPreview report={latest} onOpen={setReadingReport} />
         ) : (
           <p className="text-sm text-muted-foreground">
             Generate an AI summary of your last {INSIGHTS_WINDOW_DAYS} days of
@@ -349,19 +387,13 @@ export function AiInsightsCard() {
                 />
               </button>
             </CollapsibleTrigger>
-            <CollapsibleContent className="space-y-3 pt-2">
+            <CollapsibleContent className="space-y-2 pt-2">
               {history.map((report) => (
-                <div
+                <ReportPreview
                   key={report.id}
-                  className="space-y-1 border-t border-slate-200 dark:border-slate-800 pt-2"
-                >
-                  <p className="text-[11px] text-muted-foreground">
-                    {formatDistanceToNow(report.generatedAt, {
-                      addSuffix: true,
-                    })}
-                  </p>
-                  <ReportBody report={report} />
-                </div>
+                  report={report}
+                  onOpen={setReadingReport}
+                />
               ))}
             </CollapsibleContent>
           </Collapsible>
@@ -511,6 +543,45 @@ export function AiInsightsCard() {
                   : "Generate insights"}
             </Button>
           </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      <Dialog
+        open={readingReport !== null}
+        onOpenChange={(open) => {
+          if (!open) setReadingReport(null);
+        }}
+      >
+        <DialogContent className="max-w-lg max-h-[85vh] flex flex-col">
+          <DialogHeader>
+            <DialogTitle className="flex items-center gap-1.5">
+              <Sparkles className="w-4 h-4 text-violet-500" />
+              AI insights report
+              {readingReport?.mode === "deep" && (
+                <span
+                  className="ml-1 inline-flex items-center gap-1 rounded-full bg-violet-100 dark:bg-violet-950/50 text-violet-700 dark:text-violet-300 px-1.5 py-0.5 text-[10px] font-medium"
+                  title="Deep analysis with web search"
+                >
+                  <Search className="w-2.5 h-2.5" />
+                  Deep
+                </span>
+              )}
+            </DialogTitle>
+            {readingReport && (
+              <DialogDescription>
+                Generated{" "}
+                {formatDistanceToNow(readingReport.generatedAt, {
+                  addSuffix: true,
+                })}
+                .
+              </DialogDescription>
+            )}
+          </DialogHeader>
+          {readingReport && (
+            <div className="overflow-y-auto pr-1 -mr-1">
+              <ReportContent report={readingReport} />
+            </div>
+          )}
         </DialogContent>
       </Dialog>
     </Card>

--- a/src/components/analytics/ai-insights-card.tsx
+++ b/src/components/analytics/ai-insights-card.tsx
@@ -61,15 +61,62 @@ const TRACKED_DATA = [
   "Your water goal, sodium limit & sugar limit",
 ];
 
-/** Best-effort hostname pretty-print for a source URL. Falls back to the
+/**
+ * Best-effort hostname pretty-print for a source URL. Falls back to the
  * raw string when the input cannot be parsed (e.g. shortened pre-validated
- * forms from older reports). */
+ * forms from older reports).
+ */
 function sourceLabel(url: string): string {
   try {
-    return new URL(url).hostname.replace(/^www\./, "");
+    const host = new URL(url).hostname.replace(/^www\./, "");
+    // URL.hostname is empty for schemes like `javascript:` or `data:`.
+    // Fall back to the raw URL so the user still sees something — and
+    // the XSS guard downstream keeps it from being clickable.
+    return host || url;
   } catch {
     return url;
   }
+}
+
+/**
+ * Anchor-safety guard: `z.string().url()` accepts `javascript:` and `data:`
+ * schemes, which we would NEVER want to render as a clickable link given
+ * the URL is model-generated. Only http(s) survives as an anchor; anything
+ * else falls back to plain text so the source still shows but cannot be
+ * activated.
+ */
+function isSafeHref(url: string): boolean {
+  try {
+    const protocol = new URL(url).protocol;
+    return protocol === "http:" || protocol === "https:";
+  } catch {
+    return false;
+  }
+}
+
+function SourceLink({ url }: { url: string }) {
+  const label = sourceLabel(url);
+  if (!isSafeHref(url)) {
+    return (
+      <span
+        className="text-muted-foreground"
+        title={`Unsafe URL scheme: ${url}`}
+      >
+        {label}
+      </span>
+    );
+  }
+  return (
+    <a
+      href={url}
+      target="_blank"
+      rel="noopener noreferrer"
+      className="text-violet-600 dark:text-violet-400 hover:underline"
+      title={url}
+    >
+      {label}
+    </a>
+  );
 }
 
 /**
@@ -148,15 +195,7 @@ function ReportContent({ report }: { report: InsightReport }) {
           <ul className="flex flex-wrap gap-x-2 gap-y-1 text-xs">
             {report.sources.map((url, i) => (
               <li key={i}>
-                <a
-                  href={url}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="text-violet-600 dark:text-violet-400 hover:underline"
-                  title={url}
-                >
-                  {sourceLabel(url)}
-                </a>
+                <SourceLink url={url} />
               </li>
             ))}
           </ul>

--- a/src/components/analytics/ai-insights-card.tsx
+++ b/src/components/analytics/ai-insights-card.tsx
@@ -1,8 +1,15 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { formatDistanceToNow } from "date-fns";
-import { Check, ChevronDown, Sparkles, X } from "lucide-react";
+import {
+  Check,
+  ChevronDown,
+  Loader2,
+  Search,
+  Sparkles,
+  X,
+} from "lucide-react";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
@@ -24,11 +31,18 @@ import { useSettingsStore } from "@/stores/settings-store";
 import {
   useGenerateInsights,
   useInsightReports,
+  useDeepInsightJob,
   NotEnoughDataError,
 } from "@/hooks/use-insights";
 import { useUserProfile } from "@/hooks/use-profile-queries";
 import { insightsRange, INSIGHTS_WINDOW_DAYS } from "@/lib/analytics-snapshot";
 import type { InsightReport } from "@/lib/db";
+
+/**
+ * Wall-clock minutes between job start and "this is taking longer than
+ * usual" wording change. Typical deep batches finish well under this.
+ */
+const DEEP_LONG_RUN_THRESHOLD_MS = 15 * 60 * 1000;
 
 /**
  * Tracked-data domains that can feed the rolling-window analysis. Each is
@@ -50,9 +64,20 @@ const TRACKED_DATA = [
 function ReportBody({ report }: { report: InsightReport }) {
   return (
     <div className="space-y-2">
-      <p className="text-sm text-slate-700 dark:text-slate-200">
-        {report.narrative}
-      </p>
+      <div className="flex items-start justify-between gap-2">
+        <p className="text-sm text-slate-700 dark:text-slate-200">
+          {report.narrative}
+        </p>
+        {report.mode === "deep" && (
+          <span
+            className="shrink-0 inline-flex items-center gap-1 rounded-full bg-violet-100 dark:bg-violet-950/50 text-violet-700 dark:text-violet-300 px-1.5 py-0.5 text-[10px] font-medium"
+            title="Deep analysis with web search"
+          >
+            <Search className="w-2.5 h-2.5" />
+            Deep
+          </span>
+        )}
+      </div>
       {report.observations.length > 0 && (
         <ul className="space-y-1 text-sm text-slate-600 dark:text-slate-300">
           {report.observations.map((observation, i) => (
@@ -70,10 +95,15 @@ function ReportBody({ report }: { report: InsightReport }) {
 }
 
 /**
- * On-demand AI summary of the last 30 days of tracked data. Generation is
- * user-triggered (a button); every result is cached to IndexedDB so past
- * assessments survive reloads and sync across devices. Before generating, a
- * dialog spells out exactly what data feeds the analysis.
+ * On-demand AI summary of the last 30 days of tracked data. Two flavours:
+ *
+ *   • Fast analysis — synchronous Sonnet summary, returns in ~10s.
+ *   • Deep analysis — Opus + web search, submitted as an Anthropic batch.
+ *     Returns minutes later; the user can close the page and come back.
+ *
+ * Every result is cached to IndexedDB so past assessments survive reloads
+ * and sync across devices. Before generating, a dialog spells out exactly
+ * what data feeds the analysis and surfaces the cost warning for deep mode.
  */
 export function AiInsightsCard() {
   const waterGoalMl = useSettingsStore((s) => s.waterLimit);
@@ -82,10 +112,20 @@ export function AiInsightsCard() {
   const reports = useInsightReports();
   const profile = useUserProfile();
   const { toast } = useToast();
-  const { mutate, isPending } = useGenerateInsights();
+  const { mutate, isPending: fastPending } = useGenerateInsights();
+  const deep = useDeepInsightJob();
   const [confirmOpen, setConfirmOpen] = useState(false);
+  const [dialogMode, setDialogMode] = useState<"fast" | "deep">("fast");
   const [includePrevious, setIncludePrevious] = useState(false);
   const [historyOpen, setHistoryOpen] = useState(false);
+  // Recompute "long-running" wording each minute while a deep job is pending
+  // so the message swaps without a refresh once the threshold is crossed.
+  const [, forceTick] = useState(0);
+  useEffect(() => {
+    if (deep.state.status !== "pending") return;
+    const id = window.setInterval(() => forceTick((n) => n + 1), 60_000);
+    return () => window.clearInterval(id);
+  }, [deep.state.status]);
 
   const latest = reports[0] ?? null;
   const history = reports.slice(1);
@@ -96,7 +136,16 @@ export function AiInsightsCard() {
   const shareMedications = profile.shareMedicationsWithAI;
   const personalised = shareConditions || shareMedications;
 
-  const openConfirm = () => {
+  const pendingState =
+    deep.state.status === "pending" ? deep.state : null;
+  const deepLongRunning =
+    pendingState !== null &&
+    Date.now() - pendingState.startedAt > DEEP_LONG_RUN_THRESHOLD_MS;
+  const deepBusy =
+    deep.state.status === "submitting" || deep.state.status === "pending";
+
+  const openConfirm = (mode: "fast" | "deep") => {
+    setDialogMode(mode);
     // Only meaningful when a prior report exists to compare against.
     setIncludePrevious(false);
     setConfirmOpen(true);
@@ -104,28 +153,68 @@ export function AiInsightsCard() {
 
   const generate = () => {
     setConfirmOpen(false);
-    mutate(
-      {
-        range: insightsRange(),
-        goals: { waterGoalMl, sodiumLimitMg, sugarLimitG },
-        ...(shareConditions && { conditions: profile.conditions }),
-        ...(shareMedications && { includeMedications: true }),
-        ...(includePrevious && hasPrevious && { includePrevious: true }),
+    const payload = {
+      range: insightsRange(),
+      goals: { waterGoalMl, sodiumLimitMg, sugarLimitG },
+      ...(shareConditions && { conditions: profile.conditions }),
+      ...(shareMedications && { includeMedications: true }),
+      ...(includePrevious && hasPrevious && { includePrevious: true }),
+    };
+
+    if (dialogMode === "deep") {
+      deep.submit(payload).catch((error: Error) => {
+        toast({
+          title:
+            error instanceof NotEnoughDataError
+              ? "Not enough data"
+              : "Couldn't start deep analysis",
+          description: error.message,
+          variant: "destructive",
+        });
+      });
+      return;
+    }
+
+    mutate(payload, {
+      onError: (error) => {
+        toast({
+          title:
+            error instanceof NotEnoughDataError
+              ? "Not enough data"
+              : "Couldn't generate insights",
+          description: error.message,
+          variant: "destructive",
+        });
       },
-      {
-        onError: (error) => {
-          toast({
-            title:
-              error instanceof NotEnoughDataError
-                ? "Not enough data"
-                : "Couldn't generate insights",
-            description: error.message,
-            variant: "destructive",
-          });
-        },
-      },
-    );
+    });
   };
+
+  // Surface deep completion / failure with a toast and clear the hook's
+  // sticky state so subsequent runs start clean. The result itself lands in
+  // the Dexie cache via the sync pull triggered by the hook, so the card's
+  // live query renders it automatically — no special "fresh result" pane.
+  useEffect(() => {
+    if (deep.state.status === "completed") {
+      toast({
+        title: "Deep analysis ready",
+        description: "Your deep-research insight is now in the summary.",
+      });
+      deep.reset();
+    } else if (deep.state.status === "failed" || deep.state.status === "expired") {
+      toast({
+        title:
+          deep.state.status === "expired"
+            ? "Deep analysis timed out"
+            : "Deep analysis failed",
+        description: deep.state.error,
+        variant: "destructive",
+      });
+      deep.reset();
+    }
+    // `deep` itself is a fresh object every render — only re-run when status
+    // transitions.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [deep.state.status]);
 
   return (
     <Card className="bg-white/80 dark:bg-slate-900/50 border-slate-200 dark:border-slate-800">
@@ -151,19 +240,58 @@ export function AiInsightsCard() {
           </p>
         )}
 
-        <Button
-          variant={latest ? "outline" : "default"}
-          size="sm"
-          className="w-full"
-          onClick={openConfirm}
-          disabled={isPending}
-        >
-          {isPending
-            ? "Analysing…"
-            : latest
-              ? "Regenerate"
-              : "Generate insights"}
-        </Button>
+        {pendingState && (
+          <div className="flex items-start gap-2 rounded-md border border-violet-200 dark:border-violet-900/60 bg-violet-50/70 dark:bg-violet-950/30 px-2.5 py-2 text-xs">
+            <Loader2 className="w-3.5 h-3.5 mt-0.5 shrink-0 text-violet-500 animate-spin" />
+            <div className="space-y-0.5">
+              <p className="font-medium text-violet-900 dark:text-violet-200">
+                Deep analysis in progress
+              </p>
+              <p className="text-violet-800/80 dark:text-violet-300/80">
+                Started{" "}
+                {formatDistanceToNow(pendingState.startedAt, { addSuffix: true })}.{" "}
+                {deepLongRunning
+                  ? "Taking longer than usual — still working in the background, you can keep this open or come back later."
+                  : "You can close this and come back; the report will appear here when it's ready."}
+              </p>
+            </div>
+          </div>
+        )}
+
+        <div className="grid grid-cols-2 gap-2">
+          <Button
+            variant={latest ? "outline" : "default"}
+            size="sm"
+            onClick={() => openConfirm("fast")}
+            disabled={fastPending || deep.state.status === "submitting"}
+          >
+            {fastPending ? "Analysing…" : "Fast analysis"}
+          </Button>
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => openConfirm("deep")}
+            disabled={deepBusy || fastPending}
+            className="gap-1.5"
+          >
+            {deep.state.status === "submitting" ? (
+              <>
+                <Loader2 className="w-3.5 h-3.5 animate-spin" />
+                Submitting…
+              </>
+            ) : pendingState ? (
+              <>
+                <Loader2 className="w-3.5 h-3.5 animate-spin" />
+                In progress
+              </>
+            ) : (
+              <>
+                <Search className="w-3.5 h-3.5" />
+                Deep analysis
+              </>
+            )}
+          </Button>
+        </div>
 
         {personalised && (
           <p className="text-[11px] text-muted-foreground">
@@ -211,14 +339,33 @@ export function AiInsightsCard() {
         <DialogContent className="max-w-sm">
           <DialogHeader>
             <DialogTitle className="flex items-center gap-1.5">
-              <Sparkles className="w-4 h-4 text-violet-500" />
-              What goes into this summary
+              {dialogMode === "deep" ? (
+                <Search className="w-4 h-4 text-violet-500" />
+              ) : (
+                <Sparkles className="w-4 h-4 text-violet-500" />
+              )}
+              {dialogMode === "deep"
+                ? "Deep analysis with web research"
+                : "What goes into this summary"}
             </DialogTitle>
             <DialogDescription>
-              The AI analyses the last {INSIGHTS_WINDOW_DAYS} days of your
-              tracked data. Here&apos;s exactly what&apos;s included.
+              {dialogMode === "deep"
+                ? `Opus 4.6 reviews your last ${INSIGHTS_WINDOW_DAYS} days of data and consults web sources for clinical context. Here's exactly what's included.`
+                : `The AI analyses the last ${INSIGHTS_WINDOW_DAYS} days of your tracked data. Here's exactly what's included.`}
             </DialogDescription>
           </DialogHeader>
+
+          {dialogMode === "deep" && (
+            <div className="rounded-md border border-amber-200 dark:border-amber-900/60 bg-amber-50 dark:bg-amber-950/30 px-2.5 py-2 text-xs text-amber-900 dark:text-amber-200 space-y-1">
+              <p className="font-medium">Deep analysis is a costly request</p>
+              <p>
+                It runs a more powerful model with web search against current
+                clinical references — typically 3-10 minutes and roughly
+                10-20× the cost of a fast summary. You can close this and come
+                back; the report will appear here when it&apos;s ready.
+              </p>
+            </div>
+          )}
 
           <div className="space-y-3 text-sm">
             <div className="space-y-1.5">
@@ -315,8 +462,20 @@ export function AiInsightsCard() {
             >
               Cancel
             </Button>
-            <Button size="sm" onClick={generate} disabled={isPending}>
-              {latest ? "Regenerate" : "Generate insights"}
+            <Button
+              size="sm"
+              onClick={generate}
+              disabled={
+                dialogMode === "deep"
+                  ? deepBusy
+                  : fastPending
+              }
+            >
+              {dialogMode === "deep"
+                ? "Start deep analysis"
+                : latest
+                  ? "Regenerate"
+                  : "Generate insights"}
             </Button>
           </DialogFooter>
         </DialogContent>

--- a/src/components/medications/schedule-view.tsx
+++ b/src/components/medications/schedule-view.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useMemo, useEffect, useState, useCallback } from "react";
+import { useMemo, useState, useCallback } from "react";
 import { useDailyDoseSchedule, useTakeDose, useUntakeDose, useSkipDose, useTakeAllDoses, useEditDoseTime } from "@/hooks/use-medication-queries";
 import type { DoseSlot } from "@/hooks/use-medication-queries";
 import { hapticTake, hapticSkip, getCurrentTimeHHMM } from "@/lib/medication-ui-utils";
@@ -108,18 +108,6 @@ export function ScheduleView({ selectedDate, onDoseClick, onAddMed }: ScheduleVi
     }
     return Array.from(names);
   }, [slots]);
-
-  // Auto-scroll to next upcoming time slot on mount
-  useEffect(() => {
-    if (isToday && nextUpcomingTime) {
-      const el = document.getElementById(`time-slot-${nextUpcomingTime}`);
-      if (el) {
-        setTimeout(() => {
-          el.scrollIntoView({ behavior: "smooth", block: "start" });
-        }, 100);
-      }
-    }
-  }, [isToday, nextUpcomingTime]);
 
   // Handle Take (today -- immediate)
   const handleTake = useCallback(

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -689,17 +689,76 @@ export const insightReports = pgTable(
     narrative: text("narrative").notNull(),
     observations: text("observations").array().notNull(),
     personalised: boolean("personalised").notNull(),
+    // "fast" = sync Sonnet summary; "deep" = async Opus + web-search deep
+    // research. Nullable for backward compatibility with rows written before
+    // the two-tier rollout (treated as "fast" by the client).
+    mode: text("mode"),
     createdAt: bigint("created_at", { mode: "number" }).notNull(),
     updatedAt: bigint("updated_at", { mode: "number" }).notNull(),
     deletedAt: bigint("deleted_at", { mode: "number" }),
     deviceId: text("device_id").notNull(),
   },
   (t) => ({
+    modeCheck: check(
+      "insight_reports_mode_check",
+      sql`${t.mode} IS NULL OR ${t.mode} IN ('fast','deep')`,
+    ),
     userUpdatedIdx: index("idx_insight_reports_user_updated").on(
       t.userId,
       t.updatedAt,
     ),
     generatedAtIdx: index("idx_insight_reports_generated").on(t.generatedAt),
+  }),
+);
+
+// ─────────────────────────────────────────────────────────────────────────
+// Deep-research insight jobs — server-only state for async batch requests.
+//
+// Each row tracks one Anthropic Message Batches submission for the deep
+// analytics summary (Opus 4.6 + web search). Polling endpoints look up the
+// row, ask Anthropic for batch status, and on completion persist the result
+// to `insight_reports` (synced) and flip status to "completed".
+//
+// Server-only — does NOT participate in Dexie sync. One pending job per user
+// is enforced by a partial unique index on user_id.
+// ─────────────────────────────────────────────────────────────────────────
+
+export const insightJobs = pgTable(
+  "insight_jobs",
+  {
+    id: text("id").primaryKey(),
+    userId: text("user_id")
+      .notNull()
+      .references(() => usersSync.id, { onDelete: "cascade" }),
+    batchId: text("batch_id").notNull(),
+    status: text("status").notNull(),
+    // The validated AnalyticsInsightsRequest that was submitted, so we can
+    // re-run or audit later without depending on Anthropic retaining bodies.
+    requestPayload: jsonb("request_payload").notNull(),
+    // Set when the row flips to "completed" — points at the persisted report.
+    resultReportId: text("result_report_id"),
+    // Free-text error from Anthropic or from server-side validation on
+    // completion (e.g. tool_use input failed schema). Populated when
+    // status="failed".
+    error: text("error"),
+    createdAt: bigint("created_at", { mode: "number" }).notNull(),
+    completedAt: bigint("completed_at", { mode: "number" }),
+  },
+  (t) => ({
+    statusCheck: check(
+      "insight_jobs_status_check",
+      sql`${t.status} IN ('pending','completed','failed','expired')`,
+    ),
+    // One pending job per user — partial unique index, only enforced on
+    // pending rows so completed/failed history can accumulate freely.
+    onePendingPerUser: uniqueIndex("insight_jobs_one_pending_per_user_uq")
+      .on(t.userId)
+      .where(sql`status = 'pending'`),
+    userCreatedIdx: index("idx_insight_jobs_user_created").on(
+      t.userId,
+      t.createdAt,
+    ),
+    batchIdx: index("idx_insight_jobs_batch").on(t.batchId),
   }),
 );
 

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -730,13 +730,22 @@ export const insightJobs = pgTable(
     userId: text("user_id")
       .notNull()
       .references(() => usersSync.id, { onDelete: "cascade" }),
-    batchId: text("batch_id").notNull(),
+    // Nullable: we reserve the pending-job lock BEFORE submitting to
+    // Anthropic so a duplicate submission is rejected by the DB rather
+    // than leaking a paid batch. The polling endpoint only treats jobs
+    // with a non-null batch_id as actually submitted.
+    batchId: text("batch_id"),
     status: text("status").notNull(),
     // The validated AnalyticsInsightsRequest that was submitted, so we can
     // re-run or audit later without depending on Anthropic retaining bodies.
     requestPayload: jsonb("request_payload").notNull(),
-    // Set when the row flips to "completed" — points at the persisted report.
-    resultReportId: text("result_report_id"),
+    // FK with ON DELETE SET NULL so a hard-deleted insight_reports row
+    // doesn't leave a dangling reference on the historical job. Soft-delete
+    // is the normal path; this guards the rare hard-delete (data clear).
+    resultReportId: text("result_report_id").references(
+      (): typeof insightReports.id => insightReports.id,
+      { onDelete: "set null" },
+    ),
     // Free-text error from Anthropic or from server-side validation on
     // completion (e.g. tool_use input failed schema). Populated when
     // status="failed".

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -688,6 +688,10 @@ export const insightReports = pgTable(
     rangeEnd: bigint("range_end", { mode: "number" }).notNull(),
     narrative: text("narrative").notNull(),
     observations: text("observations").array().notNull(),
+    // URLs cited by the model when web_search was used (deep mode). Null
+    // for fast-mode reports and for legacy rows persisted before sources
+    // were tracked.
+    sources: text("sources").array(),
     personalised: boolean("personalised").notNull(),
     // "fast" = sync Sonnet summary; "deep" = async Opus + web-search deep
     // research. Nullable for backward compatibility with rows written before

--- a/src/hooks/use-insights.ts
+++ b/src/hooks/use-insights.ts
@@ -20,6 +20,7 @@ import type { InsightReport } from "@/lib/db";
 export interface InsightsResult {
   narrative: string;
   observations: string[];
+  sources?: string[];
   generatedAt: number;
 }
 
@@ -84,6 +85,9 @@ export function useGenerateInsights() {
             rangeEnd: previous.rangeEnd,
             summary: previous.narrative,
             observations: previous.observations,
+            ...(previous.sources && previous.sources.length > 0
+              ? { sources: previous.sources }
+              : {}),
           };
           snapshot.priorAssessments = [priorAssessment];
         }
@@ -126,6 +130,9 @@ export function useGenerateInsights() {
       const insight: InsightsResult = {
         narrative: result.narrative,
         observations: result.observations,
+        ...(Array.isArray(result.sources) && result.sources.length > 0
+          ? { sources: result.sources }
+          : {}),
         generatedAt:
           typeof result.generatedAt === "number"
             ? result.generatedAt

--- a/src/hooks/use-insights.ts
+++ b/src/hooks/use-insights.ts
@@ -375,59 +375,64 @@ export function useDeepInsightJob() {
   const submit = useCallback(
     async (input: DeepJobInput): Promise<void> => {
       setState({ status: "submitting" });
-      const snapshot = await buildAnalyticsSnapshot(
-        input.range,
-        input.goals,
-        input.conditions,
-        input.includeMedications,
-      );
-      if (snapshotIsEmpty(snapshot)) {
-        setState({ status: "idle" });
-        throw new NotEnoughDataError();
-      }
-      if (input.includePrevious) {
-        const previous = await getLatestInsightReport();
-        if (previous) {
-          const priorAssessment: PriorAssessment = {
-            generatedAt: previous.generatedAt,
-            rangeStart: previous.rangeStart,
-            rangeEnd: previous.rangeEnd,
-            summary: previous.narrative,
-            observations: previous.observations,
-          };
-          snapshot.priorAssessments = [priorAssessment];
-        }
-      }
-
-      const res = await apiFetch("/api/analytics/insights/deep", {
-        method: "POST",
-        headers: { "content-type": "application/json" },
-        body: JSON.stringify(snapshot),
-      });
-      const body = (await res.json().catch(() => null)) as {
-        jobId?: string;
-        startedAt?: number;
-        status?: string;
-        error?: string;
-      } | null;
-
-      if (!res.ok || !body?.jobId) {
-        setState({ status: "idle" });
-        throw new Error(
-          body?.error ?? "Failed to start deep analysis.",
+      try {
+        const snapshot = await buildAnalyticsSnapshot(
+          input.range,
+          input.goals,
+          input.conditions,
+          input.includeMedications,
         );
-      }
+        if (snapshotIsEmpty(snapshot)) {
+          throw new NotEnoughDataError();
+        }
+        if (input.includePrevious) {
+          const previous = await getLatestInsightReport();
+          if (previous) {
+            const priorAssessment: PriorAssessment = {
+              generatedAt: previous.generatedAt,
+              rangeStart: previous.rangeStart,
+              rangeEnd: previous.rangeEnd,
+              summary: previous.narrative,
+              observations: previous.observations,
+            };
+            snapshot.priorAssessments = [priorAssessment];
+          }
+        }
 
-      const stored: StoredPendingJob = {
-        jobId: body.jobId,
-        startedAt: body.startedAt ?? Date.now(),
-      };
-      writeStoredJob(stored);
-      setState({
-        status: "pending",
-        jobId: stored.jobId,
-        startedAt: stored.startedAt,
-      });
+        const res = await apiFetch("/api/analytics/insights/deep", {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify(snapshot),
+        });
+        const body = (await res.json().catch(() => null)) as {
+          jobId?: string;
+          startedAt?: number;
+          status?: string;
+          error?: string;
+        } | null;
+
+        if (!res.ok || !body?.jobId) {
+          throw new Error(body?.error ?? "Failed to start deep analysis.");
+        }
+
+        const stored: StoredPendingJob = {
+          jobId: body.jobId,
+          startedAt: body.startedAt ?? Date.now(),
+        };
+        writeStoredJob(stored);
+        setState({
+          status: "pending",
+          jobId: stored.jobId,
+          startedAt: stored.startedAt,
+        });
+      } catch (e) {
+        // Any pre-submit throw (snapshot build, Dexie read, fetch error,
+        // non-OK response) must leave the UI re-clickable; the previous
+        // version only reset on a couple of branches and could wedge the
+        // card on a "Submitting…" button forever.
+        setState({ status: "idle" });
+        throw e;
+      }
     },
     [],
   );

--- a/src/hooks/use-insights.ts
+++ b/src/hooks/use-insights.ts
@@ -1,3 +1,4 @@
+import { useCallback, useEffect, useRef, useState } from "react";
 import { useMutation } from "@tanstack/react-query";
 import { useLiveQuery } from "dexie-react-hooks";
 import { apiFetch } from "@/lib/api-fetch";
@@ -11,6 +12,7 @@ import {
   getLatestInsightReport,
   saveInsightReport,
 } from "@/lib/insight-report-service";
+import { schedulePull } from "@/lib/sync-engine";
 import type { PriorAssessment } from "@/lib/analytics-insights";
 import type { TimeRange } from "@/lib/analytics-types";
 import type { InsightReport } from "@/lib/db";
@@ -142,6 +144,7 @@ export function useGenerateInsights() {
           personalised:
             (conditions !== undefined && conditions.length > 0) ||
             includeMedications === true,
+          mode: "fast",
         });
       } catch (cacheError) {
         console.warn("Failed to cache insight report:", cacheError);
@@ -150,4 +153,290 @@ export function useGenerateInsights() {
       return insight;
     },
   });
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// Deep-research async job: submit, then poll until the batch completes.
+//
+// The job state lives on the server (Postgres `insight_jobs`); the client
+// just keeps the jobId in localStorage so polling survives a tab close /
+// reload. On completion the server has already persisted the report to
+// `insight_reports`; we trigger a sync pull so it shows up in the local
+// Dexie cache without waiting for the regular sync cycle.
+// ─────────────────────────────────────────────────────────────────────────
+
+const PENDING_DEEP_JOB_KEY = "insight-deep-job-pending";
+const DEEP_POLL_INTERVAL_MS = 30_000;
+
+interface StoredPendingJob {
+  jobId: string;
+  startedAt: number;
+}
+
+interface DeepJobInput {
+  range: TimeRange;
+  goals: IntakeGoals;
+  conditions?: string[];
+  includeMedications?: boolean;
+  includePrevious?: boolean;
+}
+
+interface DeepJobPendingState {
+  status: "pending";
+  jobId: string;
+  startedAt: number;
+}
+
+interface DeepJobCompletedState {
+  status: "completed";
+  jobId: string;
+  startedAt: number;
+  result: InsightsResult;
+}
+
+interface DeepJobFailedState {
+  status: "failed" | "expired";
+  jobId: string;
+  startedAt: number;
+  error: string;
+}
+
+export type DeepJobState =
+  | { status: "idle" }
+  | { status: "submitting" }
+  | DeepJobPendingState
+  | DeepJobCompletedState
+  | DeepJobFailedState;
+
+interface DeepPollResponse {
+  status: "pending" | "completed" | "failed" | "expired";
+  startedAt: number;
+  narrative?: string;
+  observations?: string[];
+  generatedAt?: number;
+  error?: string;
+}
+
+function readStoredJob(): StoredPendingJob | null {
+  if (typeof window === "undefined") return null;
+  try {
+    const raw = window.localStorage.getItem(PENDING_DEEP_JOB_KEY);
+    if (!raw) return null;
+    const parsed = JSON.parse(raw) as StoredPendingJob;
+    if (typeof parsed?.jobId === "string" && typeof parsed?.startedAt === "number") {
+      return parsed;
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+function writeStoredJob(job: StoredPendingJob | null): void {
+  if (typeof window === "undefined") return;
+  if (job === null) {
+    window.localStorage.removeItem(PENDING_DEEP_JOB_KEY);
+  } else {
+    window.localStorage.setItem(PENDING_DEEP_JOB_KEY, JSON.stringify(job));
+  }
+}
+
+/**
+ * Manages the lifecycle of a deep-research insight job.
+ *
+ * - `submit(input)` POSTs to the deep endpoint, stores the jobId, kicks off
+ *   polling.
+ * - On mount, if a pending jobId is found in localStorage, polling resumes.
+ * - `state` reflects the current phase so the card can show idle / pending
+ *   indicator / fresh result / error.
+ * - `reset()` clears the most-recent completion or failure so the card can
+ *   drop a stale banner once the user has seen it.
+ */
+export function useDeepInsightJob() {
+  const [state, setState] = useState<DeepJobState>(() => {
+    const stored = readStoredJob();
+    if (stored) {
+      return {
+        status: "pending" as const,
+        jobId: stored.jobId,
+        startedAt: stored.startedAt,
+      };
+    }
+    return { status: "idle" as const };
+  });
+  // Track the active poll timer across renders. A ref lets the polling
+  // callback cancel itself when the component unmounts or the job ends.
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const clearTimer = useCallback(() => {
+    if (timerRef.current) {
+      clearTimeout(timerRef.current);
+      timerRef.current = null;
+    }
+  }, []);
+
+  const poll = useCallback(
+    async (jobId: string, startedAt: number) => {
+      try {
+        const res = await apiFetch(
+          `/api/analytics/insights/jobs/${encodeURIComponent(jobId)}`,
+          { method: "GET" },
+        );
+        const body = (await res.json().catch(() => null)) as
+          | DeepPollResponse
+          | null;
+
+        if (!res.ok || !body) {
+          // Treat as transient unless 404 — keep polling on 5xx/network.
+          if (res.status === 404) {
+            writeStoredJob(null);
+            setState({
+              status: "failed",
+              jobId,
+              startedAt,
+              error:
+                "Deep analysis job was not found on the server. It may have been cleared.",
+            });
+            return;
+          }
+          timerRef.current = setTimeout(
+            () => poll(jobId, startedAt),
+            DEEP_POLL_INTERVAL_MS,
+          );
+          return;
+        }
+
+        if (body.status === "pending") {
+          timerRef.current = setTimeout(
+            () => poll(jobId, startedAt),
+            DEEP_POLL_INTERVAL_MS,
+          );
+          return;
+        }
+
+        if (body.status === "completed" && body.narrative && body.observations) {
+          writeStoredJob(null);
+          // Pull from the server right now so the Dexie cache picks up the
+          // server-inserted report and the history list updates without
+          // waiting for the next regular sync cycle.
+          schedulePull();
+          setState({
+            status: "completed",
+            jobId,
+            startedAt,
+            result: {
+              narrative: body.narrative,
+              observations: body.observations,
+              generatedAt: body.generatedAt ?? Date.now(),
+            },
+          });
+          return;
+        }
+
+        if (body.status === "failed" || body.status === "expired") {
+          writeStoredJob(null);
+          setState({
+            status: body.status,
+            jobId,
+            startedAt,
+            error: body.error ?? "Deep analysis did not complete.",
+          });
+          return;
+        }
+
+        // Unrecognised shape — keep polling rather than wedging the UI.
+        timerRef.current = setTimeout(
+          () => poll(jobId, startedAt),
+          DEEP_POLL_INTERVAL_MS,
+        );
+      } catch {
+        // Network blip — try again on the next interval.
+        timerRef.current = setTimeout(
+          () => poll(jobId, startedAt),
+          DEEP_POLL_INTERVAL_MS,
+        );
+      }
+    },
+    [],
+  );
+
+  // Resume polling on mount when a pending job was left in localStorage,
+  // and tear down the timer on unmount.
+  useEffect(() => {
+    if (state.status === "pending") {
+      poll(state.jobId, state.startedAt);
+    }
+    return clearTimer;
+    // Only re-bind when the job id changes — `state` itself rebinds on
+    // every status transition which would otherwise double-poll.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [state.status === "pending" ? state.jobId : null]);
+
+  const submit = useCallback(
+    async (input: DeepJobInput): Promise<void> => {
+      setState({ status: "submitting" });
+      const snapshot = await buildAnalyticsSnapshot(
+        input.range,
+        input.goals,
+        input.conditions,
+        input.includeMedications,
+      );
+      if (snapshotIsEmpty(snapshot)) {
+        setState({ status: "idle" });
+        throw new NotEnoughDataError();
+      }
+      if (input.includePrevious) {
+        const previous = await getLatestInsightReport();
+        if (previous) {
+          const priorAssessment: PriorAssessment = {
+            generatedAt: previous.generatedAt,
+            rangeStart: previous.rangeStart,
+            rangeEnd: previous.rangeEnd,
+            summary: previous.narrative,
+            observations: previous.observations,
+          };
+          snapshot.priorAssessments = [priorAssessment];
+        }
+      }
+
+      const res = await apiFetch("/api/analytics/insights/deep", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify(snapshot),
+      });
+      const body = (await res.json().catch(() => null)) as {
+        jobId?: string;
+        startedAt?: number;
+        status?: string;
+        error?: string;
+      } | null;
+
+      if (!res.ok || !body?.jobId) {
+        setState({ status: "idle" });
+        throw new Error(
+          body?.error ?? "Failed to start deep analysis.",
+        );
+      }
+
+      const stored: StoredPendingJob = {
+        jobId: body.jobId,
+        startedAt: body.startedAt ?? Date.now(),
+      };
+      writeStoredJob(stored);
+      setState({
+        status: "pending",
+        jobId: stored.jobId,
+        startedAt: stored.startedAt,
+      });
+    },
+    [],
+  );
+
+  const reset = useCallback(() => {
+    clearTimer();
+    writeStoredJob(null);
+    setState({ status: "idle" });
+  }, [clearTimer]);
+
+  return { state, submit, reset };
 }

--- a/src/lib/analytics-insights.ts
+++ b/src/lib/analytics-insights.ts
@@ -119,6 +119,9 @@ const PriorAssessmentSchema = z.object({
   // the deep-research ceiling is generous.
   summary: z.string().min(1).max(4000),
   observations: z.array(z.string().min(1).max(2000)).max(16),
+  // URLs from the prior deep report's web_search citations. Sent back so
+  // the model can avoid re-fetching sources it already grounded against.
+  sources: z.array(z.string().url()).max(30).optional(),
 });
 
 export type PriorAssessment = z.infer<typeof PriorAssessmentSchema>;
@@ -165,9 +168,15 @@ export type AnalyticsInsightsRequest = z.infer<
 // produces longer summaries and longer observations (citations, clinical
 // context, "this matters because…" framing). The fast path is well under
 // these limits in normal use, so a single ceiling avoids a parallel schema.
+//
+// `sources` is the deep-mode citation list — URLs the model retrieved via
+// web_search to ground its clinical claims. Optional so fast-mode reports
+// (which never invoke web_search) can produce a valid tool input without
+// populating it.
 export const InsightResponseSchema = z.object({
   summary: z.string().min(1).max(4000),
   observations: z.array(z.string().min(1).max(2000)).max(16),
+  sources: z.array(z.string().url()).max(30).optional(),
 });
 
 export const INSIGHT_TOOL = {
@@ -180,13 +189,19 @@ export const INSIGHT_TOOL = {
       summary: {
         type: "string",
         description:
-          "A 2-4 sentence plain-language overview of the period, referencing the actual numbers.",
+          "A 2-4 sentence plain-language overview of the period, referencing the actual numbers. In deep mode this can be longer (3-5 sentences) and weave in clinical context, condition framing, and medication-response alignment.",
       },
       observations: {
         type: "array",
         items: { type: "string" },
         description:
-          "3-6 specific, factual observations. Each cites a concrete metric.",
+          "3-6 specific, factual observations in fast mode; 4-8 in deep mode. Each cites a concrete metric. In deep mode, observations should connect trends to the user's medications and conditions where applicable, and may cite a source URL inline.",
+      },
+      sources: {
+        type: "array",
+        items: { type: "string", format: "uri" },
+        description:
+          "Deep mode only: the URLs you retrieved via web_search to ground clinical claims. Required when web_search was used; omit when no external references back the observations.",
       },
     },
     required: ["summary", "observations"],
@@ -318,6 +333,9 @@ export function buildInsightsPrompt(req: AnalyticsInsightsRequest): string {
         `  Summary: ${p.summary}`,
       );
       for (const o of p.observations) lines.push(`  - ${o}`);
+      if (p.sources && p.sources.length > 0) {
+        lines.push(`  Sources previously cited: ${p.sources.join(", ")}`);
+      }
     }
     lines.push(
       "",

--- a/src/lib/analytics-insights.ts
+++ b/src/lib/analytics-insights.ts
@@ -115,8 +115,10 @@ const PriorAssessmentSchema = z.object({
   generatedAt: z.number(),
   rangeStart: z.number(),
   rangeEnd: z.number(),
-  summary: z.string().min(1).max(2000),
-  observations: z.array(z.string().min(1).max(500)).max(12),
+  // Bound matches InsightResponseSchema below — see comment there for why
+  // the deep-research ceiling is generous.
+  summary: z.string().min(1).max(4000),
+  observations: z.array(z.string().min(1).max(2000)).max(16),
 });
 
 export type PriorAssessment = z.infer<typeof PriorAssessmentSchema>;
@@ -159,9 +161,13 @@ export type AnalyticsInsightsRequest = z.infer<
 // Response contract
 // ---------------------------------------------------------------------------
 
+// Caps sized for the deep-research path: Opus with web_search routinely
+// produces longer summaries and longer observations (citations, clinical
+// context, "this matters because…" framing). The fast path is well under
+// these limits in normal use, so a single ceiling avoids a parallel schema.
 export const InsightResponseSchema = z.object({
-  summary: z.string().min(1).max(2000),
-  observations: z.array(z.string().min(1).max(500)).max(12),
+  summary: z.string().min(1).max(4000),
+  observations: z.array(z.string().min(1).max(2000)).max(16),
 });
 
 export const INSIGHT_TOOL = {

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -407,6 +407,10 @@ export interface InsightReport {
   narrative: string; // plain-language summary
   observations: string[]; // specific factual observations
   personalised: boolean; // whether the user's medical profile fed the analysis
+  // "fast" = sync Sonnet summary; "deep" = async Opus + web-search deep
+  // research. Optional for rows written before the two-tier rollout — the
+  // client treats `undefined` as "fast".
+  mode?: "fast" | "deep";
   createdAt: number;
   updatedAt: number;
   deletedAt: number | null;
@@ -831,12 +835,42 @@ realDb.version(19).stores({
   insightReports:          "id, generatedAt, updatedAt",
 });
 
+// Version 20: Add `mode` field to InsightReport ("fast" | "deep"). No new
+// Dexie index — `mode` is a filter/display field, not a query key — so the
+// stores definition is byte-identical to v19. The Dexie version bump still
+// has to happen because the interface gained a field and the sync layer
+// needs to push/pull it.
+realDb.version(20).stores({
+  // --- REPEAT all v19 stores verbatim ---
+  intakeRecords:           "id, [type+timestamp], timestamp, source, groupId, updatedAt",
+  weightRecords:           "id, timestamp, updatedAt",
+  bloodPressureRecords:    "id, timestamp, position, arm, updatedAt",
+  eatingRecords:           "id, timestamp, groupId, updatedAt",
+  urinationRecords:        "id, timestamp, updatedAt",
+  defecationRecords:       "id, timestamp, updatedAt",
+  prescriptions:           "id, isActive, updatedAt, createdAt",
+  medicationPhases:        "id, prescriptionId, status, type, titrationPlanId, updatedAt",
+  phaseSchedules:          "id, phaseId, time, enabled, updatedAt",
+  inventoryItems:          "id, prescriptionId, isActive, updatedAt",
+  inventoryTransactions:   "id, [inventoryItemId+timestamp], inventoryItemId, timestamp, type, updatedAt",
+  doseLogs:                "id, [prescriptionId+scheduledDate], prescriptionId, phaseId, scheduleId, scheduledDate, scheduledTime, status, updatedAt",
+  dailyNotes:              "id, date, prescriptionId, doseLogId, updatedAt",
+  auditLogs:               "id, [action+timestamp], timestamp, action",
+  substanceRecords:        "id, [type+timestamp], type, timestamp, source, sourceRecordId, groupId, updatedAt",
+  titrationPlans:          "id, conditionLabel, status, updatedAt",
+  _syncQueue:              "++id, [tableName+recordId], tableName, enqueuedAt",
+  _syncMeta:               "tableName",
+  _errorLogs:              "id, timestamp, source",
+  userProfile:             "id, updatedAt",
+  insightReports:          "id, generatedAt, updatedAt",
+});
+
 /**
  * Current Dexie schema version. Bump this constant in lockstep with each new
  * `realDb.version(N)` block above so diagnostic surfaces (Debug → Environment)
  * always reflect the real schema.
  */
-export const DB_SCHEMA_VERSION = 19;
+export const DB_SCHEMA_VERSION = 20;
 
 /**
  * Store definitions for a preview database — the current (v19) schema in a

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -406,6 +406,10 @@ export interface InsightReport {
   rangeEnd: number; // analysis window end (Unix ms)
   narrative: string; // plain-language summary
   observations: string[]; // specific factual observations
+  // URLs the model cited via web_search (deep mode only). Optional —
+  // fast-mode reports and legacy rows from before sources were tracked
+  // leave this undefined.
+  sources?: string[];
   personalised: boolean; // whether the user's medical profile fed the analysis
   // "fast" = sync Sonnet summary; "deep" = async Opus + web-search deep
   // research. Optional for rows written before the two-tier rollout — the
@@ -835,6 +839,35 @@ realDb.version(19).stores({
   insightReports:          "id, generatedAt, updatedAt",
 });
 
+// Version 21: Add `sources` field to InsightReport for deep-mode reports
+// that cite URLs via web_search. No new Dexie index — `sources` is a
+// display field, not queryable. Stores byte-identical to v20; the version
+// bump exists so the sync layer recognises the new field.
+realDb.version(21).stores({
+  // --- REPEAT all v20 stores verbatim ---
+  intakeRecords:           "id, [type+timestamp], timestamp, source, groupId, updatedAt",
+  weightRecords:           "id, timestamp, updatedAt",
+  bloodPressureRecords:    "id, timestamp, position, arm, updatedAt",
+  eatingRecords:           "id, timestamp, groupId, updatedAt",
+  urinationRecords:        "id, timestamp, updatedAt",
+  defecationRecords:       "id, timestamp, updatedAt",
+  prescriptions:           "id, isActive, updatedAt, createdAt",
+  medicationPhases:        "id, prescriptionId, status, type, titrationPlanId, updatedAt",
+  phaseSchedules:          "id, phaseId, time, enabled, updatedAt",
+  inventoryItems:          "id, prescriptionId, isActive, updatedAt",
+  inventoryTransactions:   "id, [inventoryItemId+timestamp], inventoryItemId, timestamp, type, updatedAt",
+  doseLogs:                "id, [prescriptionId+scheduledDate], prescriptionId, phaseId, scheduleId, scheduledDate, scheduledTime, status, updatedAt",
+  dailyNotes:              "id, date, prescriptionId, doseLogId, updatedAt",
+  auditLogs:               "id, [action+timestamp], timestamp, action",
+  substanceRecords:        "id, [type+timestamp], type, timestamp, source, sourceRecordId, groupId, updatedAt",
+  titrationPlans:          "id, conditionLabel, status, updatedAt",
+  _syncQueue:              "++id, [tableName+recordId], tableName, enqueuedAt",
+  _syncMeta:               "tableName",
+  _errorLogs:              "id, timestamp, source",
+  userProfile:             "id, updatedAt",
+  insightReports:          "id, generatedAt, updatedAt",
+});
+
 // Version 20: Add `mode` field to InsightReport ("fast" | "deep"). No new
 // Dexie index — `mode` is a filter/display field, not a query key — so the
 // stores definition is byte-identical to v19. The Dexie version bump still
@@ -870,7 +903,7 @@ realDb.version(20).stores({
  * `realDb.version(N)` block above so diagnostic surfaces (Debug → Environment)
  * always reflect the real schema.
  */
-export const DB_SCHEMA_VERSION = 20;
+export const DB_SCHEMA_VERSION = 21;
 
 /**
  * Store definitions for a preview database — the current (v19) schema in a

--- a/src/lib/insight-report-service.ts
+++ b/src/lib/insight-report-service.ts
@@ -20,6 +20,8 @@ export interface NewInsightReport {
   rangeEnd: number;
   narrative: string;
   observations: string[];
+  /** Deep-mode URLs cited via web_search. Undefined for fast-mode reports. */
+  sources?: string[];
   personalised: boolean;
   /**
    * "fast" = sync Sonnet summary; "deep" = async Opus + web-search deep
@@ -54,6 +56,9 @@ export async function saveInsightReport(
       rangeEnd: input.rangeEnd,
       narrative: input.narrative,
       observations: input.observations,
+      ...(input.sources && input.sources.length > 0
+        ? { sources: input.sources }
+        : {}),
       personalised: input.personalised,
       mode: input.mode ?? "fast",
       createdAt: now,

--- a/src/lib/insight-report-service.ts
+++ b/src/lib/insight-report-service.ts
@@ -21,6 +21,11 @@ export interface NewInsightReport {
   narrative: string;
   observations: string[];
   personalised: boolean;
+  /**
+   * "fast" = sync Sonnet summary; "deep" = async Opus + web-search deep
+   * research. Defaults to "fast" for backward-compat callers that omit it.
+   */
+  mode?: "fast" | "deep";
 }
 
 /** All cached reports, active rows only, newest generated first. */
@@ -50,6 +55,7 @@ export async function saveInsightReport(
       narrative: input.narrative,
       observations: input.observations,
       personalised: input.personalised,
+      mode: input.mode ?? "fast",
       createdAt: now,
       updatedAt: now,
       deletedAt: null,

--- a/src/lib/server/insight-job-service.ts
+++ b/src/lib/server/insight-job-service.ts
@@ -167,6 +167,8 @@ export interface PersistDeepReportInput {
   rangeEnd: number;
   narrative: string;
   observations: string[];
+  /** URLs cited via web_search; null when the model produced none. */
+  sources: string[] | null;
   personalised: boolean;
 }
 
@@ -198,6 +200,7 @@ export async function completeInsightJob(
     rangeEnd: report.rangeEnd,
     narrative: report.narrative,
     observations: report.observations,
+    sources: report.sources,
     personalised: report.personalised,
     mode: "deep",
     createdAt: now,
@@ -275,12 +278,14 @@ export async function getReportForJob(
 ): Promise<{
   narrative: string;
   observations: string[];
+  sources: string[] | null;
   generatedAt: number;
 } | null> {
   const rows = await db
     .select({
       narrative: insightReports.narrative,
       observations: insightReports.observations,
+      sources: insightReports.sources,
       generatedAt: insightReports.generatedAt,
     })
     .from(insightReports)

--- a/src/lib/server/insight-job-service.ts
+++ b/src/lib/server/insight-job-service.ts
@@ -1,0 +1,214 @@
+/**
+ * Server-side CRUD for `insight_jobs` — async deep-research batch jobs.
+ *
+ * Each row represents one Anthropic Message Batches submission for the deep
+ * analytics summary. The lifecycle is:
+ *
+ *   pending  →  completed  (batch succeeded, result_report_id points at the
+ *                            persisted insight_reports row)
+ *   pending  →  failed     (batch errored, server-side validation rejected
+ *                            the tool output, or Anthropic returned a
+ *                            non-success individual result)
+ *   pending  →  expired    (24h elapsed without a terminal state)
+ *
+ * Server-only — never imported by browser bundles. The polling endpoint
+ * (GET /api/analytics/insights/jobs/:id) is the only place that mutates
+ * a row's status after creation.
+ */
+import { and, eq } from "drizzle-orm";
+import { db } from "@/lib/drizzle";
+import {
+  insightJobs,
+  insightReports,
+  usersSync,
+} from "@/db/schema";
+import { generateId } from "@/lib/utils";
+
+const SERVER_DEVICE_ID = "server-deep-batch";
+
+export interface CreateInsightJobInput {
+  userId: string;
+  batchId: string;
+  // The raw validated request body so we can re-run / audit later without
+  // depending on Anthropic retaining the message contents past 24h.
+  requestPayload: unknown;
+}
+
+export interface InsightJobRow {
+  id: string;
+  userId: string;
+  batchId: string;
+  status: "pending" | "completed" | "failed" | "expired";
+  requestPayload: unknown;
+  resultReportId: string | null;
+  error: string | null;
+  createdAt: number;
+  completedAt: number | null;
+}
+
+/**
+ * Insert a pending job row. The partial unique index
+ * `insight_jobs_one_pending_per_user_uq` rejects a second pending row for
+ * the same user — surface that as a typed error so the route can return 409.
+ */
+export class PendingJobConflictError extends Error {
+  constructor() {
+    super("A deep analysis is already running for this user.");
+    this.name = "PendingJobConflictError";
+  }
+}
+
+export async function createInsightJob(
+  input: CreateInsightJobInput,
+): Promise<InsightJobRow> {
+  // Mirror the pattern in sync/push/route.ts — ensure the user_id FK target
+  // exists before the dependent insert, because Neon Auth's user replication
+  // can lag on preview branches.
+  await db
+    .insert(usersSync)
+    .values({ id: input.userId })
+    .onConflictDoNothing();
+
+  const id = generateId();
+  const now = Date.now();
+  try {
+    const [row] = await db
+      .insert(insightJobs)
+      .values({
+        id,
+        userId: input.userId,
+        batchId: input.batchId,
+        status: "pending",
+        requestPayload: input.requestPayload as object,
+        createdAt: now,
+      })
+      .returning();
+    return row as InsightJobRow;
+  } catch (e) {
+    // Postgres unique_violation surfaces as code 23505 via the Neon driver;
+    // the message includes the constraint name so we can route the conflict
+    // path cleanly.
+    if (
+      e instanceof Error &&
+      /insight_jobs_one_pending_per_user_uq/.test(e.message)
+    ) {
+      throw new PendingJobConflictError();
+    }
+    throw e;
+  }
+}
+
+export async function getInsightJob(
+  jobId: string,
+  userId: string,
+): Promise<InsightJobRow | null> {
+  const rows = await db
+    .select()
+    .from(insightJobs)
+    .where(and(eq(insightJobs.id, jobId), eq(insightJobs.userId, userId)))
+    .limit(1);
+  return (rows[0] as InsightJobRow | undefined) ?? null;
+}
+
+export interface PersistDeepReportInput {
+  userId: string;
+  generatedAt: number;
+  rangeStart: number;
+  rangeEnd: number;
+  narrative: string;
+  observations: string[];
+  personalised: boolean;
+}
+
+/**
+ * Insert the freshly produced deep report into `insight_reports` and flip the
+ * job to "completed", in a single atomic step the polling endpoint can call.
+ * The row is stamped with `device_id = "server-deep-batch"` so the client's
+ * sync pull recognises it as a foreign-device write rather than its own.
+ */
+export async function completeInsightJob(
+  jobId: string,
+  report: PersistDeepReportInput,
+): Promise<{ reportId: string }> {
+  const reportId = generateId();
+  const now = Date.now();
+  await db.insert(insightReports).values({
+    id: reportId,
+    userId: report.userId,
+    generatedAt: report.generatedAt,
+    rangeStart: report.rangeStart,
+    rangeEnd: report.rangeEnd,
+    narrative: report.narrative,
+    observations: report.observations,
+    personalised: report.personalised,
+    mode: "deep",
+    createdAt: now,
+    updatedAt: now,
+    deletedAt: null,
+    deviceId: SERVER_DEVICE_ID,
+  });
+  await db
+    .update(insightJobs)
+    .set({
+      status: "completed",
+      completedAt: now,
+      resultReportId: reportId,
+    })
+    .where(eq(insightJobs.id, jobId));
+  return { reportId };
+}
+
+export async function failInsightJob(
+  jobId: string,
+  error: string,
+): Promise<void> {
+  await db
+    .update(insightJobs)
+    .set({
+      status: "failed",
+      completedAt: Date.now(),
+      error,
+    })
+    .where(eq(insightJobs.id, jobId));
+}
+
+export async function expireInsightJob(jobId: string): Promise<void> {
+  await db
+    .update(insightJobs)
+    .set({
+      status: "expired",
+      completedAt: Date.now(),
+      error: "Batch exceeded the 24-hour SLA without completing.",
+    })
+    .where(eq(insightJobs.id, jobId));
+}
+
+/**
+ * Fetch the persisted report referenced by a completed job. Used by the
+ * polling endpoint to echo the result back to the client without making it
+ * wait for the next sync pull.
+ */
+export async function getReportForJob(
+  resultReportId: string,
+  userId: string,
+): Promise<{
+  narrative: string;
+  observations: string[];
+  generatedAt: number;
+} | null> {
+  const rows = await db
+    .select({
+      narrative: insightReports.narrative,
+      observations: insightReports.observations,
+      generatedAt: insightReports.generatedAt,
+    })
+    .from(insightReports)
+    .where(
+      and(
+        eq(insightReports.id, resultReportId),
+        eq(insightReports.userId, userId),
+      ),
+    )
+    .limit(1);
+  return rows[0] ?? null;
+}

--- a/src/lib/server/insight-job-service.ts
+++ b/src/lib/server/insight-job-service.ts
@@ -28,7 +28,6 @@ const SERVER_DEVICE_ID = "server-deep-batch";
 
 export interface CreateInsightJobInput {
   userId: string;
-  batchId: string;
   // The raw validated request body so we can re-run / audit later without
   // depending on Anthropic retaining the message contents past 24h.
   requestPayload: unknown;
@@ -37,7 +36,7 @@ export interface CreateInsightJobInput {
 export interface InsightJobRow {
   id: string;
   userId: string;
-  batchId: string;
+  batchId: string | null;
   status: "pending" | "completed" | "failed" | "expired";
   requestPayload: unknown;
   resultReportId: string | null;
@@ -58,6 +57,19 @@ export class PendingJobConflictError extends Error {
   }
 }
 
+/**
+ * Reserve the pending-job slot for a user BEFORE submitting to Anthropic.
+ *
+ * The flow at the route is:
+ *   1. createInsightJob() — takes the unique-index lock, returns a job row
+ *      with batchId=null.
+ *   2. client.messages.batches.create() — pays for the batch.
+ *   3. attachBatchToJob() — writes the real batch_id onto the row.
+ *
+ * Doing the DB reservation first guarantees that two concurrent submissions
+ * from the same user can never both result in a paid batch (the second
+ * createInsightJob raises PendingJobConflictError before any API call).
+ */
 export async function createInsightJob(
   input: CreateInsightJobInput,
 ): Promise<InsightJobRow> {
@@ -77,7 +89,7 @@ export async function createInsightJob(
       .values({
         id,
         userId: input.userId,
-        batchId: input.batchId,
+        batchId: null,
         status: "pending",
         requestPayload: input.requestPayload as object,
         createdAt: now,
@@ -96,6 +108,44 @@ export async function createInsightJob(
     }
     throw e;
   }
+}
+
+/**
+ * Attach the Anthropic batch_id to a previously-reserved pending job.
+ * Returns true on success, false if the job is no longer pending (e.g.
+ * already failed by a cleanup path).
+ */
+export async function attachBatchToJob(
+  jobId: string,
+  batchId: string,
+): Promise<boolean> {
+  const updated = await db
+    .update(insightJobs)
+    .set({ batchId })
+    .where(and(eq(insightJobs.id, jobId), eq(insightJobs.status, "pending")))
+    .returning({ id: insightJobs.id });
+  return updated.length > 0;
+}
+
+/**
+ * Delete a pending job row outright. Used as the rollback path when batch
+ * submission to Anthropic fails BEFORE we have a real batch_id — the row
+ * has no external side-effect to preserve and removing it frees the
+ * unique-index lock immediately so the user can retry.
+ */
+export async function deletePendingJob(
+  jobId: string,
+  userId: string,
+): Promise<void> {
+  await db
+    .delete(insightJobs)
+    .where(
+      and(
+        eq(insightJobs.id, jobId),
+        eq(insightJobs.userId, userId),
+        eq(insightJobs.status, "pending"),
+      ),
+    );
 }
 
 export async function getInsightJob(
@@ -122,16 +172,24 @@ export interface PersistDeepReportInput {
 
 /**
  * Insert the freshly produced deep report into `insight_reports` and flip the
- * job to "completed", in a single atomic step the polling endpoint can call.
- * The row is stamped with `device_id = "server-deep-batch"` so the client's
- * sync pull recognises it as a foreign-device write rather than its own.
+ * job to "completed". The transition is guarded by a compare-and-set on
+ * `status='pending'` — the neon-http driver has no interactive transactions,
+ * so we use a conditional UPDATE + RETURNING to detect lost races between
+ * concurrent pollers. On a lost race we soft-delete the orphan report so it
+ * doesn't surface as a duplicate in the user's history.
+ *
+ * Returns `null` when the CAS lost — caller should treat it as "another
+ * poller already finalised this job" and just read the existing row.
  */
 export async function completeInsightJob(
   jobId: string,
   report: PersistDeepReportInput,
-): Promise<{ reportId: string }> {
+): Promise<{ reportId: string } | null> {
   const reportId = generateId();
   const now = Date.now();
+  // Insert the report first. If we lose the race below, we soft-delete it
+  // so the FK on result_report_id can still resolve from the winning row,
+  // and the deleted flag keeps it out of the active history view.
   await db.insert(insightReports).values({
     id: reportId,
     userId: report.userId,
@@ -147,40 +205,63 @@ export async function completeInsightJob(
     deletedAt: null,
     deviceId: SERVER_DEVICE_ID,
   });
-  await db
+
+  const updated = await db
     .update(insightJobs)
     .set({
       status: "completed",
       completedAt: now,
       resultReportId: reportId,
     })
-    .where(eq(insightJobs.id, jobId));
+    .where(and(eq(insightJobs.id, jobId), eq(insightJobs.status, "pending")))
+    .returning({ id: insightJobs.id });
+
+  if (updated.length === 0) {
+    // Another poller flipped the job first — soft-delete the orphan to
+    // keep history clean.
+    await db
+      .update(insightReports)
+      .set({ deletedAt: now, updatedAt: now })
+      .where(eq(insightReports.id, reportId));
+    return null;
+  }
+
   return { reportId };
 }
 
+/**
+ * Compare-and-set: only flips a still-pending job to "failed". Returns true
+ * when the caller won the race; false means another poller already marked
+ * the job terminal and the caller should defer to that outcome.
+ */
 export async function failInsightJob(
   jobId: string,
   error: string,
-): Promise<void> {
-  await db
+): Promise<boolean> {
+  const updated = await db
     .update(insightJobs)
     .set({
       status: "failed",
       completedAt: Date.now(),
       error,
     })
-    .where(eq(insightJobs.id, jobId));
+    .where(and(eq(insightJobs.id, jobId), eq(insightJobs.status, "pending")))
+    .returning({ id: insightJobs.id });
+  return updated.length > 0;
 }
 
-export async function expireInsightJob(jobId: string): Promise<void> {
-  await db
+/** Same compare-and-set semantics as failInsightJob — see above. */
+export async function expireInsightJob(jobId: string): Promise<boolean> {
+  const updated = await db
     .update(insightJobs)
     .set({
       status: "expired",
       completedAt: Date.now(),
       error: "Batch exceeded the 24-hour SLA without completing.",
     })
-    .where(eq(insightJobs.id, jobId));
+    .where(and(eq(insightJobs.id, jobId), eq(insightJobs.status, "pending")))
+    .returning({ id: insightJobs.id });
+  return updated.length > 0;
 }
 
 /**


### PR DESCRIPTION
Including a previous summary makes the model produce a comparison that
easily exceeds 1024 output tokens, so the tool_use JSON is truncated
mid-object and fails the response-schema check — the user sees the
generic "AI response format invalid" toast.

- Bump max_tokens to 2048 so a comparison summary fits.
- When stop_reason is "max_tokens", return a distinct RESPONSE_TRUNCATED
  error explaining the cut-off instead of hiding it behind the schema
  check.
- Log stop_reason on every failure path for future diagnosability.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Deep analysis mode with separate "Fast analysis" and "Deep analysis" buttons, deep-only progress banner, and a "Deep" badge on reports.
  * Deep-mode includes citation support: reports can show source links/host chips and include sources in previews.

* **User Experience**
  * Confirmation dialogs and cost warning updated for deep requests.
  * Analytics tab defaults to Summary; tab order updated.
  * Removed auto-scroll on schedule view.

* **Reliability**
  * Improved handling and clearer errors when AI responses are truncated.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/RyRy79261/intake-tracker/pull/160?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->