### PR TITLE
fix(intake): make dashboard queries tolerate string timestamps

### DIFF
--- a/src/lib/intake-service.ts
+++ b/src/lib/intake-service.ts
@@ -86,12 +86,18 @@ export async function getRecordsInLast24Hours(
   type?: "water" | "salt" | "sugar"
 ): Promise<IntakeRecord[]> {
   const cutoffTime = Date.now() - TWENTY_FOUR_HOURS_MS;
-  const query = db.intakeRecords.where("timestamp").aboveOrEqual(cutoffTime);
-  const records = await query.toArray();
-  if (type) {
-    return records.filter((r) => r.type === type && r.deletedAt === null);
-  }
-  return records.filter((r) => r.deletedAt === null);
+  // Full scan + JS filter rather than `where("timestamp").aboveOrEqual(...)`.
+  // IndexedDB compares index keys by type, so a single row whose `timestamp`
+  // was bulkPut as a string (a pull-path bigint round-trip edge case) silently
+  // drops the entire range result and the dashboard reads zero. JS-side
+  // coercion via `Number()` tolerates both shapes; cost is trivial here.
+  const records = await db.intakeRecords.toArray();
+  return records.filter(
+    (r) =>
+      r.deletedAt === null &&
+      Number(r.timestamp) >= cutoffTime &&
+      (!type || r.type === type),
+  );
 }
 
 export async function getTotalInLast24Hours(type: "water" | "salt" | "sugar"): Promise<number> {
@@ -114,12 +120,17 @@ function getDayStartTimestamp(dayStartHour: number): number {
 
 export async function getDailyTotal(type: "water" | "salt" | "sugar", dayStartHour: number): Promise<number> {
   const cutoffTime = getDayStartTimestamp(dayStartHour);
-  const records = await db.intakeRecords
-    .where("timestamp")
-    .aboveOrEqual(cutoffTime)
-    .filter((r) => r.type === type && r.deletedAt === null)
-    .toArray();
-  return records.reduce((sum, r) => sum + r.amount, 0);
+  // Full scan + JS filter — see comment on `getRecordsInLast24Hours` for why
+  // we deliberately avoid the timestamp index range scan here.
+  const records = await db.intakeRecords.toArray();
+  return records
+    .filter(
+      (r) =>
+        r.deletedAt === null &&
+        r.type === type &&
+        Number(r.timestamp) >= cutoffTime,
+    )
+    .reduce((sum, r) => sum + r.amount, 0);
 }
 
 export async function getRecentRecords(type: "water" | "salt" | "sugar", limit: number = 3): Promise<IntakeRecord[]> {


### PR DESCRIPTION
The dashboard's `getDailyTotal` / `getRecordsInLast24Hours` / `getTotalInLast24Hours`
used `db.intakeRecords.where("timestamp").aboveOrEqual(cutoffTime)` — an IndexedDB
range scan on the `timestamp` index. IndexedDB compares index keys by type, so a
single row whose `timestamp` was bulkPut as a string (a pull-path bigint
round-trip edge case under Drizzle + neon HTTP) silently drops the whole range
result and the dashboard reads zero, even when `/history` (which uses
`orderBy().toArray()` and JS-side filtering) still surfaces the same rows.

User-reported regression: ~4.3k records intact in Dexie, /history renders
fine, dashboard cards (water/salt/sugar daily + rolling 24h) all show 0.

Switch the three dashboard read paths to full-scan + JS-side filter with
`Number(r.timestamp) >= cutoffTime`, so the comparison tolerates either shape.
At single-user record volumes the index-range optimisation isn't load-bearing.

Doesn't address the root cause (a pull writing string timestamps) — a
follow-up needs to lock down bulkPut input shape and add a one-shot
normalisation migration — but it unblocks the dashboard immediately.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved filtering of deleted records in intake data queries to ensure deleted entries no longer appear in results.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/RyRy79261/intake-tracker/pull/161?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->