### PR TITLE
fix(debug,intake): sort raw logs by date, label inline edit inputs

### DIFF
--- a/src/components/debug-panel.tsx
+++ b/src/components/debug-panel.tsx
@@ -413,13 +413,25 @@ function RawRecordViewer() {
     async () => {
       const table = db.table(selectedTable);
       const count = await table.count();
-      // Get 50 most recent by sorting by createdAt descending (fallback to reverse order)
+      // Every table indexes `updatedAt`, so it's the reliable sort key for a
+      // "most-recent first" debug view. Fall back to an in-memory sort by the
+      // best available date field if the index is somehow missing.
       let items: Record<string, unknown>[];
       try {
-        items = await table.orderBy("createdAt").reverse().limit(50).toArray();
+        items = await table.orderBy("updatedAt").reverse().limit(50).toArray();
       } catch {
-        // Table may not have createdAt index -- fall back to raw limit
-        items = await table.reverse().limit(50).toArray();
+        items = await table.limit(50).toArray();
+        items.sort((a, b) => {
+          const aDate =
+            (typeof a.updatedAt === "number" ? a.updatedAt : undefined) ??
+            (typeof a.timestamp === "number" ? a.timestamp : undefined) ??
+            (typeof a.createdAt === "number" ? a.createdAt : 0);
+          const bDate =
+            (typeof b.updatedAt === "number" ? b.updatedAt : undefined) ??
+            (typeof b.timestamp === "number" ? b.timestamp : undefined) ??
+            (typeof b.createdAt === "number" ? b.createdAt : 0);
+          return bDate - aDate;
+        });
       }
       return { count, items };
     },
@@ -484,11 +496,21 @@ function RawRecordViewer() {
                     <ChevronRight className="h-3 w-3 shrink-0" />
                   )}
                   <span className="font-mono truncate">{id}</span>
-                  {typeof record.timestamp === "number" && (
-                    <span className="text-muted-foreground shrink-0">
-                      {formatTimestamp(record.timestamp)}
-                    </span>
-                  )}
+                  {(() => {
+                    const ts =
+                      typeof record.timestamp === "number"
+                        ? record.timestamp
+                        : typeof record.updatedAt === "number"
+                          ? record.updatedAt
+                          : typeof record.createdAt === "number"
+                            ? record.createdAt
+                            : null;
+                    return ts !== null ? (
+                      <span className="text-muted-foreground shrink-0">
+                        {formatTimestamp(ts)}
+                      </span>
+                    ) : null;
+                  })()}
                 </button>
                 {isExpanded && (
                   <pre className="mt-1 ml-5 p-2 bg-muted rounded text-[10px] overflow-x-auto whitespace-pre-wrap break-all">

--- a/src/components/food-salt/food-section.tsx
+++ b/src/components/food-salt/food-section.tsx
@@ -525,52 +525,68 @@ export function FoodSection() {
         )}
         renderEditForm={() => (
           <InlineEditFormShell timestamp={editTimestamp} onTimestampChange={setEditTimestamp} note={editNote} onNoteChange={setEditNote} onSave={() => handleEditSubmit()} onCancel={closeEdit} buttonClassName={theme.buttonBg}>
-            <Input
-              type="number"
-              placeholder="Grams (optional)"
-              value={editGrams}
-              onChange={(e) => setEditGrams(e.target.value)}
-              className="h-8 text-sm"
-            />
-            <div className="flex gap-2">
+            <div className="space-y-1">
+              <Label htmlFor="edit-eating-grams" className="text-xs text-muted-foreground">Weight (g)</Label>
               <Input
+                id="edit-eating-grams"
+                type="number"
+                placeholder="optional"
+                value={editGrams}
+                onChange={(e) => setEditGrams(e.target.value)}
+                className="h-8 text-sm"
+              />
+            </div>
+            <div className="space-y-1">
+              <Label htmlFor="edit-eating-sodium" className="text-xs text-muted-foreground">Sodium</Label>
+              <div className="flex gap-2">
+                <Input
+                  id="edit-eating-sodium"
+                  type="number"
+                  min="0"
+                  placeholder="mg"
+                  value={editSodiumMg}
+                  onChange={(e) => setEditSodiumMg(e.target.value)}
+                  className="h-8 text-sm flex-1"
+                />
+                <Select
+                  value={editSodiumSource}
+                  onValueChange={(v) => setEditSodiumSource(v as SodiumSource)}
+                >
+                  <SelectTrigger className="h-8 text-sm w-[100px]" aria-label="Measurement source">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="sodium">Sodium</SelectItem>
+                    <SelectItem value="salt">Salt</SelectItem>
+                    <SelectItem value="msg">MSG</SelectItem>
+                  </SelectContent>
+                </Select>
+              </div>
+            </div>
+            <div className="space-y-1">
+              <Label htmlFor="edit-eating-sugar" className="text-xs text-muted-foreground">Sugar (g)</Label>
+              <Input
+                id="edit-eating-sugar"
                 type="number"
                 min="0"
-                placeholder="Sodium (optional)"
-                value={editSodiumMg}
-                onChange={(e) => setEditSodiumMg(e.target.value)}
-                className="h-8 text-sm flex-1"
+                placeholder="optional"
+                value={editSugarG}
+                onChange={(e) => setEditSugarG(e.target.value)}
+                className="h-8 text-sm"
               />
-              <Select
-                value={editSodiumSource}
-                onValueChange={(v) => setEditSodiumSource(v as SodiumSource)}
-              >
-                <SelectTrigger className="h-8 text-sm w-[100px]">
-                  <SelectValue />
-                </SelectTrigger>
-                <SelectContent>
-                  <SelectItem value="sodium">Sodium</SelectItem>
-                  <SelectItem value="salt">Salt</SelectItem>
-                  <SelectItem value="msg">MSG</SelectItem>
-                </SelectContent>
-              </Select>
             </div>
-            <Input
-              type="number"
-              min="0"
-              placeholder="Sugar (g, optional)"
-              value={editSugarG}
-              onChange={(e) => setEditSugarG(e.target.value)}
-              className="h-8 text-sm"
-            />
-            <Input
-              type="number"
-              min="0"
-              placeholder="Water content (ml, optional)"
-              value={editWaterMl}
-              onChange={(e) => setEditWaterMl(e.target.value)}
-              className="h-8 text-sm"
-            />
+            <div className="space-y-1">
+              <Label htmlFor="edit-eating-water" className="text-xs text-muted-foreground">Water content (ml)</Label>
+              <Input
+                id="edit-eating-water"
+                type="number"
+                min="0"
+                placeholder="optional"
+                value={editWaterMl}
+                onChange={(e) => setEditWaterMl(e.target.value)}
+                className="h-8 text-sm"
+              />
+            </div>
           </InlineEditFormShell>
         )}
       />

--- a/src/components/liquids-card.tsx
+++ b/src/components/liquids-card.tsx
@@ -5,6 +5,7 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Card, CardContent } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
 import { CARD_THEMES } from "@/lib/card-themes";
 import { Droplets, Coffee, Wine } from "lucide-react";
 import { WaterTab } from "@/components/liquids/water-tab";
@@ -358,30 +359,37 @@ export function LiquidsCard() {
           }}
           renderEditForm={() => (
             <InlineEditFormShell timestamp={editTimestamp} onTimestampChange={setEditTimestamp} note={editNote} onNoteChange={setEditNote} onSave={() => handleEditSubmit()} onCancel={closeEdit} buttonClassName={CARD_THEMES.water.buttonBg}>
-              <Input type="number" placeholder="Amount (ml)" value={editAmount} onChange={(e) => setEditAmount(e.target.value)} className="h-8 text-sm" />
+              <div className="space-y-1">
+                <Label htmlFor="edit-liquid-amount" className="text-xs text-muted-foreground">Amount (ml)</Label>
+                <Input id="edit-liquid-amount" type="number" value={editAmount} onChange={(e) => setEditAmount(e.target.value)} className="h-8 text-sm" />
+              </div>
               {showBeverageNameField && (
-                <Input
-                  type="text"
-                  placeholder="Beverage name"
-                  value={editBeverageName}
-                  onChange={(e) => setEditBeverageName(e.target.value)}
-                  className="h-8 text-sm"
-                />
+                <div className="space-y-1">
+                  <Label htmlFor="edit-liquid-beverage" className="text-xs text-muted-foreground">Beverage name</Label>
+                  <Input
+                    id="edit-liquid-beverage"
+                    type="text"
+                    value={editBeverageName}
+                    onChange={(e) => setEditBeverageName(e.target.value)}
+                    className="h-8 text-sm"
+                  />
+                </div>
               )}
               {editSubstance && (
-                <Input
-                  type="number"
-                  min="0"
-                  step={editSubstance.type === "alcohol" ? "0.1" : "1"}
-                  placeholder={
-                    editSubstance.type === "caffeine"
-                      ? "Caffeine (mg)"
-                      : "Alcohol (% ABV)"
-                  }
-                  value={editSubstanceAmount}
-                  onChange={(e) => setEditSubstanceAmount(e.target.value)}
-                  className="h-8 text-sm"
-                />
+                <div className="space-y-1">
+                  <Label htmlFor="edit-liquid-substance" className="text-xs text-muted-foreground">
+                    {editSubstance.type === "caffeine" ? "Caffeine (mg)" : "Alcohol (% ABV)"}
+                  </Label>
+                  <Input
+                    id="edit-liquid-substance"
+                    type="number"
+                    min="0"
+                    step={editSubstance.type === "alcohol" ? "0.1" : "1"}
+                    value={editSubstanceAmount}
+                    onChange={(e) => setEditSubstanceAmount(e.target.value)}
+                    className="h-8 text-sm"
+                  />
+                </div>
               )}
             </InlineEditFormShell>
           )}


### PR DESCRIPTION
The debug panel's raw record viewer ordered by `createdAt`, but most
Dexie tables don't index that field — the orderBy threw and the
fallback `table.reverse()` walked the primary key (random UUIDs), so
rows appeared in arbitrary order. Switched to `updatedAt`, which every
table indexes, and the row label now falls back through
timestamp → updatedAt → createdAt so the sort key is always visible.

The inline edit forms on the food and liquids intake cards relied on
placeholders alone, so once a value was typed, fields like Sodium /
Sugar / Water content / Grams became indistinguishable. Added explicit
Label elements per input to match the main "add" form above.