### PR TITLE
revert(mcp): restore 24h access-token TTL

### DIFF
--- a/src/lib/mcp/tokens.ts
+++ b/src/lib/mcp/tokens.ts
@@ -51,6 +51,6 @@ export const TOKEN_PREFIX = {
 // TTLs in milliseconds.
 export const TOKEN_TTL = {
   AUTH_CODE_MS: 10 * 60_000,
-  ACCESS_TOKEN_MS: 15 * 60_000,
+  ACCESS_TOKEN_MS: 24 * 60 * 60_000,
   REFRESH_TOKEN_MS: 30 * 24 * 60 * 60_000,
 } as const;


### PR DESCRIPTION
## Summary

Follow-up to #168. That PR merged with `ACCESS_TOKEN_MS` at 15 minutes — a security micro-optimisation I added during the review pass that missed the point of the branch.

The goal was "no daily re-auth". With refresh now stable and idempotent for 30 days, a 24h access-token TTL means the client doesn't hit the refresh path at all during typical daily use. 15m forced the refresh endpoint every quarter hour for no real security benefit on a single-user PWA.

This restores the 24h value.

## Test plan

- [ ] No code change beyond the constant; existing test suite still passes
- [ ] Manual: log in via MCP client, confirm no re-auth prompt after >1h of use

https://claude.ai/code/session_01R34FGttKUMMXvJLQMdAwZP

---
_Generated by [Claude Code](https://claude.ai/code/session_01R34FGttKUMMXvJLQMdAwZP)_