### PR TITLE
fix(voice): disable launch bar button when hidden

### DIFF
--- a/src/components/voice/voice-launch-bar.tsx
+++ b/src/components/voice/voice-launch-bar.tsx
@@ -46,13 +46,17 @@ export function VoiceLaunchBar({
         <button
           type="button"
           onClick={() => setOpen(true)}
+          disabled={hidden}
+          tabIndex={hidden ? -1 : 0}
+          aria-hidden={hidden}
           className={cn(
-            "pointer-events-auto flex w-full items-center justify-center gap-2",
+            "flex w-full items-center justify-center gap-2",
             "border-t bg-gradient-to-t from-slate-50 to-slate-50/95 dark:from-slate-950 dark:to-slate-950/95",
             "backdrop-blur-sm px-4 py-2.5",
             "text-sm font-medium text-muted-foreground transition-colors",
             "hover:bg-muted/40 active:bg-muted/60",
-            "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-inset"
+            "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-inset",
+            hidden ? "pointer-events-none" : "pointer-events-auto"
           )}
           aria-label="Open voice log"
         >


### PR DESCRIPTION
The bar's click target stayed live after the footer animated out,
so taps on its former area still opened the voice sheet. Gate
pointer-events, disabled, tabIndex, and aria-hidden on the hidden prop.