### PR TITLE
feat(liquids): edit caffeine, alcohol, sugar inline for any drink

### DIFF
--- a/src/components/liquids-card.tsx
+++ b/src/components/liquids-card.tsx
@@ -23,11 +23,12 @@ import { useSettings } from "@/hooks/use-settings";
 import { useToast } from "@/hooks/use-toast";
 import { useDeleteWithToast } from "@/hooks/use-delete-with-toast";
 import { useEditRecord } from "@/hooks/use-edit-record";
-import { useSyncLiquidGroup, fetchEntryGroup } from "@/hooks/use-composable-entry";
+import { useSyncLiquidEntrySubstances, fetchEntryGroup } from "@/hooks/use-composable-entry";
+import { useOptionalTrackerEnabled } from "@/lib/optional-trackers";
 import { cn, formatAmount, getLiquidTypeLabel } from "@/lib/utils";
 import { formatTimeOnly } from "@/lib/date-utils";
 import { type IntakeRecord } from "@/lib/db";
-import { standardDrinksFromAbv, abvFromStandardDrinks } from "@/lib/alcohol-units";
+import { abvFromStandardDrinks } from "@/lib/alcohol-units";
 
 const TAB_THEMES = {
   water: CARD_THEMES.water,
@@ -65,7 +66,8 @@ export function LiquidsCard() {
   const { toast } = useToast();
   const deleteMutation = useDeleteIntake();
   const updateMutation = useUpdateIntake();
-  const syncLiquidGroupMutation = useSyncLiquidGroup();
+  const syncLiquidSubstancesMutation = useSyncLiquidEntrySubstances();
+  const sugarEnabled = useOptionalTrackerEnabled("sugar");
   const { deletingId, handleDelete } = useDeleteWithToast(
     deleteMutation,
     "Water entry removed"
@@ -73,12 +75,9 @@ export function LiquidsCard() {
 
   const [editAmount, setEditAmount] = useState("");
   const [editBeverageName, setEditBeverageName] = useState("");
-  const [showBeverageNameField, setShowBeverageNameField] = useState(false);
-  const [editSubstance, setEditSubstance] = useState<{
-    type: "caffeine" | "alcohol";
-    description: string;
-  } | null>(null);
-  const [editSubstanceAmount, setEditSubstanceAmount] = useState("");
+  const [editCaffeineMg, setEditCaffeineMg] = useState("");
+  const [editAlcoholAbv, setEditAlcoholAbv] = useState("");
+  const [editSugarG, setEditSugarG] = useState("");
   // Token to discard stale fetchEntryGroup results when opening another record
   const openTokenRef = useRef(0);
 
@@ -96,34 +95,28 @@ export function LiquidsCard() {
       const token = ++openTokenRef.current;
       setEditAmount(record.amount.toString());
       setEditBeverageName("");
-      setShowBeverageNameField(false);
-      setEditSubstance(null);
-      setEditSubstanceAmount("");
+      setEditCaffeineMg("");
+      setEditAlcoholAbv("");
+      setEditSugarG("");
 
       const source = record.source ?? "";
       if (source.startsWith("beverage:")) {
-        setShowBeverageNameField(true);
         setEditBeverageName(source.slice("beverage:".length));
-      } else if (source === "beverage") {
-        setShowBeverageNameField(true);
       } else if (source.startsWith("preset:")) {
-        // Coffee/alcohol entries reference a preset by id. Look up the preset
-        // synchronously so the substance input shows even if the entry has no
-        // groupId (older records pre-v15) or fetchEntryGroup is slow.
+        // Coffee/alcohol entries reference a preset by id. Look up the
+        // preset synchronously so the substance values pre-fill even if the
+        // entry has no groupId (older records pre-v15) or fetchEntryGroup
+        // is slow. The async path below overrides with actual stored values.
         const presetId = source.slice("preset:".length);
         const preset = settings.liquidPresets.find((p) => p.id === presetId);
-        if (preset && (preset.tab === "coffee" || preset.tab === "alcohol")) {
-          const type = preset.tab === "coffee" ? "caffeine" : "alcohol";
-          setEditSubstance({ type, description: preset.name });
+        if (preset) {
           setEditBeverageName(preset.name);
-          setShowBeverageNameField(true);
-          // Pre-fill from preset's defaults; fetchEntryGroup will override
-          // with the actual logged amount if a SubstanceRecord exists.
-          if (type === "caffeine" && preset.caffeinePer100ml !== undefined) {
+          if (preset.caffeinePer100ml !== undefined && preset.caffeinePer100ml > 0) {
             const mg = Math.round((record.amount / 100) * preset.caffeinePer100ml);
-            setEditSubstanceAmount(mg.toString());
-          } else if (type === "alcohol" && preset.alcoholPer100ml !== undefined) {
-            setEditSubstanceAmount(preset.alcoholPer100ml.toString());
+            setEditCaffeineMg(mg.toString());
+          }
+          if (preset.alcoholPer100ml !== undefined && preset.alcoholPer100ml > 0) {
+            setEditAlcoholAbv(preset.alcoholPer100ml.toString());
           }
         }
       }
@@ -132,36 +125,39 @@ export function LiquidsCard() {
         void fetchEntryGroup(record.groupId).then((group) => {
           if (token !== openTokenRef.current) return;
           if (!group) return;
-          const substance = group.substances.find(
-            (s) => s.type === "caffeine" || s.type === "alcohol",
+          const caffeine = group.substances.find(
+            (s) => s.type === "caffeine" && s.deletedAt === null,
           );
-          if (!substance) return;
-          setEditSubstance({
-            type: substance.type,
-            description: substance.description,
-          });
-          setEditBeverageName(substance.description);
-          setShowBeverageNameField(true);
-          if (substance.type === "caffeine" && substance.amountMg !== undefined) {
-            setEditSubstanceAmount(substance.amountMg.toString());
-          } else if (substance.type === "alcohol") {
+          const alcohol = group.substances.find(
+            (s) => s.type === "alcohol" && s.deletedAt === null,
+          );
+          const sugar = group.intakes.find(
+            (i) => i.type === "sugar" && i.deletedAt === null,
+          );
+          if (caffeine?.description) setEditBeverageName(caffeine.description);
+          else if (alcohol?.description) setEditBeverageName(alcohol.description);
+          if (caffeine?.amountMg !== undefined) {
+            setEditCaffeineMg(caffeine.amountMg.toString());
+          }
+          if (alcohol) {
             // Prefer the stored ABV %; fall back to deriving it from the
             // legacy std-drinks value and the entry's volume for old records.
-            let abv = substance.abvPercent;
-            if (abv === undefined && substance.amountStandardDrinks !== undefined) {
-              const vol = substance.volumeMl ?? record.amount;
+            let abv = alcohol.abvPercent;
+            if (abv === undefined && alcohol.amountStandardDrinks !== undefined) {
+              const vol = alcohol.volumeMl ?? record.amount;
               if (vol > 0) {
                 const derived = abvFromStandardDrinks(
-                  substance.amountStandardDrinks,
+                  alcohol.amountStandardDrinks,
                   vol,
                 );
                 if (Number.isFinite(derived)) abv = derived;
               }
             }
             if (abv !== undefined) {
-              setEditSubstanceAmount(parseFloat(abv.toFixed(1)).toString());
+              setEditAlcoholAbv(parseFloat(abv.toFixed(1)).toString());
             }
           }
+          if (sugar) setEditSugarG(sugar.amount.toString());
         });
       }
     },
@@ -176,11 +172,12 @@ export function LiquidsCard() {
         timestamp,
         note,
       };
-      // Update IntakeRecord.source for plain beverage entries so the
-      // displayed name stays in sync. For coffee/alcohol entries the source
-      // is a `preset:<id>` / `substance:<id>` reference and the user-facing
-      // name lives on SubstanceRecord.description (synced separately below).
-      if (showBeverageNameField && !editSubstance) {
+      // Keep the displayed beverage name in sync for plain beverage entries
+      // (source `beverage:<name>`). For preset / substance-linked entries
+      // the user-facing name lives on SubstanceRecord.description and is
+      // synced separately below.
+      const source = editingRecord?.source ?? "";
+      if (source.startsWith("beverage:") || source === "beverage") {
         const trimmed = editBeverageName.trim();
         updates.source = trimmed ? `beverage:${trimmed}` : "beverage";
       }
@@ -188,36 +185,24 @@ export function LiquidsCard() {
     },
     mutateAsync: async ({ id, updates }) => {
       await updateMutation.mutateAsync({ id, updates });
-      // Sync linked substance records when editing a coffee/alcohol entry
-      if (editingRecord?.groupId && editSubstance) {
-        const u = updates as { amount: number; timestamp: number };
-        const rawSubstanceAmount = editSubstanceAmount.trim();
-        const parsedSubstanceAmount = rawSubstanceAmount
-          ? parseFloat(rawSubstanceAmount)
-          : NaN;
-        const hasSubstanceAmount =
-          rawSubstanceAmount !== "" &&
-          !isNaN(parsedSubstanceAmount) &&
-          parsedSubstanceAmount >= 0;
-        await syncLiquidGroupMutation(editingRecord.groupId, {
-          timestamp: u.timestamp,
-          description: editBeverageName.trim() || editSubstance.description,
-          volumeMl: u.amount,
-          // Only include the typed amount when the user supplied a value;
-          // otherwise leave the existing linked-record value intact.
-          ...(hasSubstanceAmount &&
-            editSubstance.type === "caffeine" && {
-              amountMg: Math.round(parsedSubstanceAmount),
-            }),
-          ...(hasSubstanceAmount &&
-            editSubstance.type === "alcohol" && {
-              abvPercent: parsedSubstanceAmount,
-              amountStandardDrinks: parseFloat(
-                standardDrinksFromAbv(parsedSubstanceAmount, u.amount).toFixed(2),
-              ),
-            }),
-        });
-      }
+      const u = updates as { amount: number; timestamp: number };
+      const parse = (raw: string): number | null => {
+        const trimmed = raw.trim();
+        if (trimmed === "") return 0; // user cleared → soft-delete any existing
+        const n = parseFloat(trimmed);
+        return Number.isFinite(n) && n >= 0 ? n : null;
+      };
+      const caffeineMg = parse(editCaffeineMg);
+      const alcoholAbv = parse(editAlcoholAbv);
+      const sugarG = sugarEnabled ? parse(editSugarG) : null;
+      await syncLiquidSubstancesMutation(id, {
+        timestamp: u.timestamp,
+        volumeMl: u.amount,
+        ...(editBeverageName.trim() && { description: editBeverageName.trim() }),
+        caffeineMg,
+        alcoholAbv,
+        sugarG,
+      });
     },
   });
 
@@ -358,35 +343,76 @@ export function LiquidsCard() {
             );
           }}
           renderEditForm={() => (
-            <InlineEditFormShell timestamp={editTimestamp} onTimestampChange={setEditTimestamp} note={editNote} onNoteChange={setEditNote} onSave={() => handleEditSubmit()} onCancel={closeEdit} buttonClassName={CARD_THEMES.water.buttonBg}>
+            <InlineEditFormShell
+              timestamp={editTimestamp}
+              onTimestampChange={setEditTimestamp}
+              note={editNote}
+              onNoteChange={setEditNote}
+              onSave={() => handleEditSubmit()}
+              onCancel={closeEdit}
+              buttonClassName={CARD_THEMES.water.buttonBg}
+              labeled
+              idPrefix="edit-liquid"
+            >
               <div className="space-y-1">
                 <Label htmlFor="edit-liquid-amount" className="text-xs text-muted-foreground">Amount (ml)</Label>
                 <Input id="edit-liquid-amount" type="number" value={editAmount} onChange={(e) => setEditAmount(e.target.value)} className="h-8 text-sm" />
               </div>
-              {showBeverageNameField && (
+              <div className="space-y-1">
+                <Label htmlFor="edit-liquid-beverage" className="text-xs text-muted-foreground">
+                  Beverage name <span className="font-normal">(optional)</span>
+                </Label>
+                <Input
+                  id="edit-liquid-beverage"
+                  type="text"
+                  value={editBeverageName}
+                  onChange={(e) => setEditBeverageName(e.target.value)}
+                  className="h-8 text-sm"
+                />
+              </div>
+              <div className="space-y-1">
+                <Label htmlFor="edit-liquid-caffeine" className="text-xs text-muted-foreground">
+                  Caffeine (mg) <span className="font-normal">(optional)</span>
+                </Label>
+                <Input
+                  id="edit-liquid-caffeine"
+                  type="number"
+                  min="0"
+                  step="1"
+                  inputMode="decimal"
+                  value={editCaffeineMg}
+                  onChange={(e) => setEditCaffeineMg(e.target.value)}
+                  className="h-8 text-sm"
+                />
+              </div>
+              <div className="space-y-1">
+                <Label htmlFor="edit-liquid-alcohol" className="text-xs text-muted-foreground">
+                  Alcohol (% ABV) <span className="font-normal">(optional)</span>
+                </Label>
+                <Input
+                  id="edit-liquid-alcohol"
+                  type="number"
+                  min="0"
+                  step="0.1"
+                  inputMode="decimal"
+                  value={editAlcoholAbv}
+                  onChange={(e) => setEditAlcoholAbv(e.target.value)}
+                  className="h-8 text-sm"
+                />
+              </div>
+              {sugarEnabled && (
                 <div className="space-y-1">
-                  <Label htmlFor="edit-liquid-beverage" className="text-xs text-muted-foreground">Beverage name</Label>
-                  <Input
-                    id="edit-liquid-beverage"
-                    type="text"
-                    value={editBeverageName}
-                    onChange={(e) => setEditBeverageName(e.target.value)}
-                    className="h-8 text-sm"
-                  />
-                </div>
-              )}
-              {editSubstance && (
-                <div className="space-y-1">
-                  <Label htmlFor="edit-liquid-substance" className="text-xs text-muted-foreground">
-                    {editSubstance.type === "caffeine" ? "Caffeine (mg)" : "Alcohol (% ABV)"}
+                  <Label htmlFor="edit-liquid-sugar" className="text-xs text-muted-foreground">
+                    Sugar (g) <span className="font-normal">(optional)</span>
                   </Label>
                   <Input
-                    id="edit-liquid-substance"
+                    id="edit-liquid-sugar"
                     type="number"
                     min="0"
-                    step={editSubstance.type === "alcohol" ? "0.1" : "1"}
-                    value={editSubstanceAmount}
-                    onChange={(e) => setEditSubstanceAmount(e.target.value)}
+                    step="1"
+                    inputMode="decimal"
+                    value={editSugarG}
+                    onChange={(e) => setEditSugarG(e.target.value)}
                     className="h-8 text-sm"
                   />
                 </div>

--- a/src/components/recent-entries-list.tsx
+++ b/src/components/recent-entries-list.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { ReactNode } from "react";
+import { ReactNode, useId } from "react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -38,8 +38,11 @@ export function InlineEditFormShell({
   labeled?: boolean;
   idPrefix?: string;
 }) {
-  const tsId = `${idPrefix}-timestamp`;
-  const noteId = `${idPrefix}-note`;
+  // Per-instance unique suffix so two shells mounted with the same idPrefix
+  // (e.g. the default "edit") don't produce colliding DOM ids.
+  const instanceId = useId();
+  const tsId = `${idPrefix}-${instanceId}-timestamp`;
+  const noteId = `${idPrefix}-${instanceId}-note`;
   return (
     <div className="space-y-2">
       {children}

--- a/src/components/recent-entries-list.tsx
+++ b/src/components/recent-entries-list.tsx
@@ -3,12 +3,17 @@
 import { ReactNode } from "react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
 import { Loader2, Trash2 } from "lucide-react";
 import { cn } from "@/lib/utils";
 
 /**
  * Shared shell for inline edit forms used by card components.
  * Renders domain-specific children, then timestamp, note, and Save/Cancel.
+ * When `labeled` is true, the timestamp and note inputs render visible
+ * `<Label>` elements above them; otherwise they fall back to placeholders
+ * + `aria-label` for backwards compatibility with cards that haven't been
+ * migrated.
  */
 export function InlineEditFormShell({
   children,
@@ -19,6 +24,8 @@ export function InlineEditFormShell({
   onSave,
   onCancel,
   buttonClassName,
+  labeled = false,
+  idPrefix = "edit",
 }: {
   children?: ReactNode;
   timestamp: string;
@@ -28,12 +35,35 @@ export function InlineEditFormShell({
   onSave: () => void;
   onCancel: () => void;
   buttonClassName?: string;
+  labeled?: boolean;
+  idPrefix?: string;
 }) {
+  const tsId = `${idPrefix}-timestamp`;
+  const noteId = `${idPrefix}-note`;
   return (
     <div className="space-y-2">
       {children}
-      <Input aria-label="Entry date and time" type="datetime-local" value={timestamp} onChange={(e) => onTimestampChange(e.target.value)} className="h-8 text-sm" />
-      <Input aria-label="Entry note" placeholder="Note (optional)" value={note} onChange={(e) => onNoteChange(e.target.value)} className="h-8 text-sm" />
+      {labeled ? (
+        <>
+          <div className="space-y-1">
+            <Label htmlFor={tsId} className="text-xs text-muted-foreground">
+              Date and time
+            </Label>
+            <Input id={tsId} type="datetime-local" value={timestamp} onChange={(e) => onTimestampChange(e.target.value)} className="h-8 text-sm" />
+          </div>
+          <div className="space-y-1">
+            <Label htmlFor={noteId} className="text-xs text-muted-foreground">
+              Note <span className="font-normal">(optional)</span>
+            </Label>
+            <Input id={noteId} value={note} onChange={(e) => onNoteChange(e.target.value)} className="h-8 text-sm" />
+          </div>
+        </>
+      ) : (
+        <>
+          <Input aria-label="Entry date and time" type="datetime-local" value={timestamp} onChange={(e) => onTimestampChange(e.target.value)} className="h-8 text-sm" />
+          <Input aria-label="Entry note" placeholder="Note (optional)" value={note} onChange={(e) => onNoteChange(e.target.value)} className="h-8 text-sm" />
+        </>
+      )}
       <div className="flex gap-2">
         <Button size="sm" className={cn("flex-1 h-8", buttonClassName)} onClick={onSave}>Save</Button>
         <Button size="sm" variant="outline" className="flex-1 h-8" onClick={onCancel}>Cancel</Button>

--- a/src/hooks/use-composable-entry.ts
+++ b/src/hooks/use-composable-entry.ts
@@ -10,7 +10,7 @@ import {
   deleteSingleGroupRecord,
   undoDeleteSingleRecord,
   syncEatingGroup,
-  syncLiquidGroup,
+  syncLiquidEntrySubstances,
   parseSodiumKindFromSource,
   type ComposableEntryInput,
   type ComposableEntryResult,
@@ -75,17 +75,17 @@ export function useSyncEatingGroup() {
 }
 
 /**
- * Mutation hook for syncing a liquid entry's linked substance records
- * (used by the inline edit form on the Liquids card for coffee/alcohol/preset
- * entries).
+ * Mutation hook for syncing a liquid entry's caffeine / alcohol / sugar
+ * records (used by the inline edit form on the Liquids card). Creates,
+ * updates, or soft-deletes the linked records to match the patch.
  */
-export function useSyncLiquidGroup() {
+export function useSyncLiquidEntrySubstances() {
   return useCallback(
     async (
-      groupId: string,
-      patch: Parameters<typeof syncLiquidGroup>[1],
+      intakeId: string,
+      patch: Parameters<typeof syncLiquidEntrySubstances>[1],
     ): Promise<void> => {
-      unwrap(await syncLiquidGroup(groupId, patch));
+      unwrap(await syncLiquidEntrySubstances(intakeId, patch));
     },
     [],
   );

--- a/src/lib/composable-entry-service.test.ts
+++ b/src/lib/composable-entry-service.test.ts
@@ -9,6 +9,7 @@ import {
   deleteSingleGroupRecord,
   undoDeleteSingleRecord,
   recalculateFromCurrentValues,
+  syncLiquidEntrySubstances,
   type ComposableEntryInput,
 } from "@/lib/composable-entry-service";
 
@@ -633,6 +634,165 @@ describe("composable-entry-service", () => {
   });
 
   // ─── recalculateFromCurrentValues (stub) ────────────────────────────
+
+  describe("syncLiquidEntrySubstances", () => {
+    it("creates caffeine substance + groupId when entry has none", async () => {
+      const intake = makeIntakeRecord({ type: "water", amount: 300, source: "manual" });
+      await db.intakeRecords.add(intake);
+
+      const result = await syncLiquidEntrySubstances(intake.id, {
+        timestamp: intake.timestamp,
+        volumeMl: 300,
+        description: "Cold brew",
+        caffeineMg: 150,
+        alcoholAbv: null,
+        sugarG: null,
+      });
+      expect(result.success).toBe(true);
+
+      const updated = await db.intakeRecords.get(intake.id);
+      expect(updated?.groupId).toBeTruthy();
+
+      const subs = await db.substanceRecords
+        .where("groupId")
+        .equals(updated!.groupId!)
+        .toArray();
+      expect(subs).toHaveLength(1);
+      expect(subs[0]?.type).toBe("caffeine");
+      expect(subs[0]?.amountMg).toBe(150);
+      expect(subs[0]?.description).toBe("Cold brew");
+      expect(subs[0]?.volumeMl).toBe(300);
+    });
+
+    it("updates an existing caffeine substance in the group", async () => {
+      const { groupId, intakeIds } = await seedComposableGroup({
+        intakes: [{ type: "water", amount: 250 }],
+        substance: { type: "caffeine", amountMg: 95, volumeMl: 250, description: "Coffee" },
+      });
+
+      const result = await syncLiquidEntrySubstances(intakeIds[0]!, {
+        timestamp: 1700000000000,
+        volumeMl: 400,
+        description: "Big coffee",
+        caffeineMg: 200,
+        alcoholAbv: null,
+        sugarG: null,
+      });
+      expect(result.success).toBe(true);
+
+      const subs = await db.substanceRecords
+        .where("groupId").equals(groupId).toArray();
+      const active = subs.filter((s) => s.deletedAt === null);
+      expect(active).toHaveLength(1);
+      expect(active[0]?.amountMg).toBe(200);
+      expect(active[0]?.description).toBe("Big coffee");
+      expect(active[0]?.volumeMl).toBe(400);
+    });
+
+    it("soft-deletes caffeine when patch sets it to 0", async () => {
+      const { groupId, intakeIds } = await seedComposableGroup({
+        intakes: [{ type: "water", amount: 250 }],
+        substance: { type: "caffeine", amountMg: 95, description: "Coffee" },
+      });
+
+      const result = await syncLiquidEntrySubstances(intakeIds[0]!, {
+        timestamp: 1700000000000,
+        volumeMl: 250,
+        caffeineMg: 0,
+        alcoholAbv: null,
+        sugarG: null,
+      });
+      expect(result.success).toBe(true);
+
+      const subs = await db.substanceRecords
+        .where("groupId").equals(groupId).toArray();
+      expect(subs).toHaveLength(1);
+      expect(subs[0]?.deletedAt).not.toBeNull();
+    });
+
+    it("creates an alcohol substance with derived standard drinks", async () => {
+      const intake = makeIntakeRecord({ type: "water", amount: 500, source: "manual" });
+      await db.intakeRecords.add(intake);
+
+      const result = await syncLiquidEntrySubstances(intake.id, {
+        timestamp: intake.timestamp,
+        volumeMl: 500,
+        caffeineMg: null,
+        alcoholAbv: 5,
+        sugarG: null,
+      });
+      expect(result.success).toBe(true);
+
+      const updated = await db.intakeRecords.get(intake.id);
+      const subs = await db.substanceRecords
+        .where("groupId").equals(updated!.groupId!).toArray();
+      expect(subs).toHaveLength(1);
+      expect(subs[0]?.type).toBe("alcohol");
+      expect(subs[0]?.abvPercent).toBe(5);
+      expect(subs[0]?.amountStandardDrinks).toBeGreaterThan(0);
+      expect(subs[0]?.volumeMl).toBe(500);
+    });
+
+    it("creates a sugar IntakeRecord linked by groupId", async () => {
+      const intake = makeIntakeRecord({ type: "water", amount: 330, source: "beverage:soda" });
+      await db.intakeRecords.add(intake);
+
+      const result = await syncLiquidEntrySubstances(intake.id, {
+        timestamp: intake.timestamp,
+        volumeMl: 330,
+        caffeineMg: null,
+        alcoholAbv: null,
+        sugarG: 35,
+      });
+      expect(result.success).toBe(true);
+
+      const updated = await db.intakeRecords.get(intake.id);
+      const groupIntakes = await db.intakeRecords
+        .where("groupId").equals(updated!.groupId!).toArray();
+      const sugar = groupIntakes.find((r) => r.type === "sugar");
+      expect(sugar?.amount).toBe(35);
+      expect(sugar?.source).toBe("manual:sugar");
+    });
+
+    it("leaves existing substance untouched when corresponding patch field is null", async () => {
+      const { groupId, intakeIds } = await seedComposableGroup({
+        intakes: [{ type: "water", amount: 250 }],
+        substance: { type: "caffeine", amountMg: 95, description: "Coffee" },
+      });
+
+      const result = await syncLiquidEntrySubstances(intakeIds[0]!, {
+        timestamp: 1700000000000,
+        volumeMl: 250,
+        caffeineMg: null, // leave caffeine alone
+        alcoholAbv: null,
+        sugarG: null,
+      });
+      expect(result.success).toBe(true);
+
+      const subs = await db.substanceRecords
+        .where("groupId").equals(groupId).toArray();
+      expect(subs).toHaveLength(1);
+      expect(subs[0]?.amountMg).toBe(95);
+      expect(subs[0]?.deletedAt).toBeNull();
+    });
+
+    it("does not generate a groupId when no substance/sugar values are supplied", async () => {
+      const intake = makeIntakeRecord({ type: "water", amount: 250, source: "manual" });
+      await db.intakeRecords.add(intake);
+
+      const result = await syncLiquidEntrySubstances(intake.id, {
+        timestamp: intake.timestamp,
+        volumeMl: 250,
+        caffeineMg: 0,
+        alcoholAbv: 0,
+        sugarG: 0,
+      });
+      expect(result.success).toBe(true);
+
+      const updated = await db.intakeRecords.get(intake.id);
+      expect(updated?.groupId).toBeUndefined();
+    });
+  });
 
   describe("recalculateFromCurrentValues", () => {
     it("Test 28: returns err with 'Not implemented' message and no side effects", async () => {

--- a/src/lib/composable-entry-service.ts
+++ b/src/lib/composable-entry-service.ts
@@ -4,6 +4,7 @@ import { ok, err, type ServiceResult } from "@/lib/service-result";
 import { syncFields } from "@/lib/utils";
 import { enqueueInsideTx } from "@/lib/sync-queue";
 import { schedulePush } from "@/lib/sync-engine";
+import { standardDrinksFromAbv } from "@/lib/alcohol-units";
 
 const COMPOSABLE_TABLES = [db.intakeRecords, db.eatingRecords, db.substanceRecords] as const;
 
@@ -578,61 +579,237 @@ export function parseSodiumKindFromSource(source: string | undefined): SodiumKin
   return "sodium";
 }
 
-// ─── syncLiquidGroup ──────────────────────────────────────────────────
+// ─── syncLiquidEntrySubstances ────────────────────────────────────────
 
 /**
- * Apply edits to the linked substance records of a liquid intake entry.
- * Used when editing a coffee/alcohol/preset entry inline — keeps the
- * substance amount (mg / std drinks) and description in sync with the
- * water IntakeRecord.
+ * Apply caffeine / alcohol / sugar edits to the group around a liquid
+ * IntakeRecord. Creates / updates / soft-deletes linked SubstanceRecords
+ * (caffeine, alcohol) and IntakeRecords (sugar) so the group reflects the
+ * patch.
  *
- * Pass `volumeMl` so any substance record that tracks liquid volume
- * stays consistent with the edited IntakeRecord amount.
+ * - If the intake has no groupId and the patch introduces any substance or
+ *   sugar, one is generated and assigned to the intake.
+ * - `caffeineMg` / `alcoholAbv` / `sugarG`:
+ *     - `null` ⇒ leave the field untouched (caller opted out, e.g. sugar
+ *       tracker disabled).
+ *     - `0` or negative ⇒ soft-delete any existing linked record of that
+ *       kind.
+ *     - `>0` ⇒ upsert.
+ * - `volumeMl` keeps the substance records' volume in sync with the edited
+ *   IntakeRecord amount; for alcohol it also drives the derived
+ *   `amountStandardDrinks` value.
  */
-export async function syncLiquidGroup(
-  groupId: string,
+export async function syncLiquidEntrySubstances(
+  intakeId: string,
   patch: {
     timestamp: number;
-    description?: string;
     volumeMl: number;
-    amountMg?: number;
-    amountStandardDrinks?: number;
-    abvPercent?: number;
+    description?: string;
+    caffeineMg: number | null;
+    alcoholAbv: number | null;
+    sugarG: number | null;
   },
 ): Promise<ServiceResult<void>> {
   try {
-    const now = Date.now();
+    const fields = syncFields();
+    const now = fields.updatedAt;
 
-    await db.transaction("rw", [db.substanceRecords], async () => {
-      const substances = await db.substanceRecords
-        .where("groupId")
-        .equals(groupId)
-        .toArray();
+    await db.transaction(
+      "rw",
+      [...COMPOSABLE_TABLES, db._syncQueue],
+      async () => {
+        const intake = await db.intakeRecords.get(intakeId);
+        if (!intake) throw new Error("Intake record not found");
 
-      for (const sub of substances) {
-        if (sub.deletedAt !== null) continue;
-        const updates: Partial<SubstanceRecord> = {
-          timestamp: patch.timestamp,
-          updatedAt: now,
-        };
-        if (patch.description !== undefined) updates.description = patch.description;
-        if (sub.volumeMl !== undefined) updates.volumeMl = patch.volumeMl;
-        if (sub.type === "caffeine" && patch.amountMg !== undefined) {
-          updates.amountMg = patch.amountMg;
-        }
-        if (sub.type === "alcohol" && patch.amountStandardDrinks !== undefined) {
-          updates.amountStandardDrinks = patch.amountStandardDrinks;
-        }
-        if (sub.type === "alcohol" && patch.abvPercent !== undefined) {
-          updates.abvPercent = patch.abvPercent;
-        }
-        await db.substanceRecords.update(sub.id, updates);
-      }
-    });
+        const needsGroup =
+          (patch.caffeineMg !== null && patch.caffeineMg > 0) ||
+          (patch.alcoholAbv !== null && patch.alcoholAbv > 0) ||
+          (patch.sugarG !== null && patch.sugarG > 0);
 
+        let groupId = intake.groupId;
+        if (!groupId && needsGroup) {
+          groupId = crypto.randomUUID();
+          await db.intakeRecords.update(intakeId, { groupId, updatedAt: now });
+          await enqueueInsideTx("intakeRecords", intakeId, "upsert");
+        }
+
+        if (!groupId) return; // nothing to sync
+
+        const groupIntakes = await db.intakeRecords
+          .where("groupId")
+          .equals(groupId)
+          .toArray();
+        const groupSubstances = await db.substanceRecords
+          .where("groupId")
+          .equals(groupId)
+          .toArray();
+
+        const groupSource = intake.groupSource;
+        const description = patch.description?.trim() || undefined;
+
+        // ── Caffeine ──
+        if (patch.caffeineMg !== null) {
+          const existingCaffeines = groupSubstances.filter(
+            (s) => s.type === "caffeine" && s.deletedAt === null,
+          );
+          const [existingCaffeine, ...extraCaffeines] = existingCaffeines;
+          if (patch.caffeineMg > 0) {
+            const amountMg = Math.round(patch.caffeineMg);
+            if (existingCaffeine) {
+              const updates: Partial<SubstanceRecord> = {
+                amountMg,
+                timestamp: patch.timestamp,
+                updatedAt: now,
+              };
+              if (description !== undefined) updates.description = description;
+              if (existingCaffeine.volumeMl !== undefined) {
+                updates.volumeMl = patch.volumeMl;
+              }
+              await db.substanceRecords.update(existingCaffeine.id, updates);
+              await enqueueInsideTx("substanceRecords", existingCaffeine.id, "upsert");
+            } else {
+              const record: SubstanceRecord = {
+                id: crypto.randomUUID(),
+                type: "caffeine",
+                amountMg,
+                volumeMl: patch.volumeMl,
+                description: description ?? "Drink",
+                source: "standalone",
+                timestamp: patch.timestamp,
+                groupId,
+                ...(groupSource !== undefined && { groupSource }),
+                ...fields,
+              };
+              await db.substanceRecords.add(record);
+              await enqueueInsideTx("substanceRecords", record.id, "upsert");
+            }
+          } else if (existingCaffeine) {
+            await db.substanceRecords.update(existingCaffeine.id, {
+              deletedAt: now,
+              updatedAt: now,
+            });
+            await enqueueInsideTx("substanceRecords", existingCaffeine.id, "upsert");
+          }
+          for (const dup of extraCaffeines) {
+            await db.substanceRecords.update(dup.id, {
+              deletedAt: now,
+              updatedAt: now,
+            });
+            await enqueueInsideTx("substanceRecords", dup.id, "upsert");
+          }
+        }
+
+        // ── Alcohol ──
+        if (patch.alcoholAbv !== null) {
+          const existingAlcohols = groupSubstances.filter(
+            (s) => s.type === "alcohol" && s.deletedAt === null,
+          );
+          const [existingAlcohol, ...extraAlcohols] = existingAlcohols;
+          if (patch.alcoholAbv > 0) {
+            const abvPercent = patch.alcoholAbv;
+            const amountStandardDrinks = parseFloat(
+              standardDrinksFromAbv(abvPercent, patch.volumeMl).toFixed(2),
+            );
+            if (existingAlcohol) {
+              const updates: Partial<SubstanceRecord> = {
+                abvPercent,
+                amountStandardDrinks,
+                timestamp: patch.timestamp,
+                updatedAt: now,
+              };
+              if (description !== undefined) updates.description = description;
+              if (existingAlcohol.volumeMl !== undefined) {
+                updates.volumeMl = patch.volumeMl;
+              }
+              await db.substanceRecords.update(existingAlcohol.id, updates);
+              await enqueueInsideTx("substanceRecords", existingAlcohol.id, "upsert");
+            } else {
+              const record: SubstanceRecord = {
+                id: crypto.randomUUID(),
+                type: "alcohol",
+                abvPercent,
+                amountStandardDrinks,
+                volumeMl: patch.volumeMl,
+                description: description ?? "Drink",
+                source: "standalone",
+                timestamp: patch.timestamp,
+                groupId,
+                ...(groupSource !== undefined && { groupSource }),
+                ...fields,
+              };
+              await db.substanceRecords.add(record);
+              await enqueueInsideTx("substanceRecords", record.id, "upsert");
+            }
+          } else if (existingAlcohol) {
+            await db.substanceRecords.update(existingAlcohol.id, {
+              deletedAt: now,
+              updatedAt: now,
+            });
+            await enqueueInsideTx("substanceRecords", existingAlcohol.id, "upsert");
+          }
+          for (const dup of extraAlcohols) {
+            await db.substanceRecords.update(dup.id, {
+              deletedAt: now,
+              updatedAt: now,
+            });
+            await enqueueInsideTx("substanceRecords", dup.id, "upsert");
+          }
+        }
+
+        // ── Sugar ──
+        if (patch.sugarG !== null) {
+          const existingSugars = groupIntakes.filter(
+            (r) =>
+              r.type === "sugar" &&
+              r.deletedAt === null &&
+              r.source === SUGAR_SOURCE,
+          );
+          const [existingSugar, ...extraSugars] = existingSugars;
+          if (patch.sugarG > 0) {
+            const amount = Math.round(patch.sugarG);
+            if (existingSugar) {
+              await db.intakeRecords.update(existingSugar.id, {
+                amount,
+                timestamp: patch.timestamp,
+                updatedAt: now,
+              });
+              await enqueueInsideTx("intakeRecords", existingSugar.id, "upsert");
+            } else {
+              const record: IntakeRecord = {
+                id: crypto.randomUUID(),
+                type: "sugar",
+                amount,
+                timestamp: patch.timestamp,
+                source: SUGAR_SOURCE,
+                groupId,
+                ...(groupSource !== undefined && { groupSource }),
+                ...fields,
+              };
+              await db.intakeRecords.add(record);
+              await enqueueInsideTx("intakeRecords", record.id, "upsert");
+            }
+          } else if (existingSugar) {
+            await db.intakeRecords.update(existingSugar.id, {
+              deletedAt: now,
+              updatedAt: now,
+            });
+            await enqueueInsideTx("intakeRecords", existingSugar.id, "upsert");
+          }
+          for (const dup of extraSugars) {
+            await db.intakeRecords.update(dup.id, {
+              deletedAt: now,
+              updatedAt: now,
+            });
+            await enqueueInsideTx("intakeRecords", dup.id, "upsert");
+          }
+        }
+      },
+    );
+
+    schedulePush();
     return ok(undefined);
   } catch (e) {
-    return err("Failed to sync liquid group", e);
+    return err("Failed to sync liquid entry substances", e);
   }
 }
 


### PR DESCRIPTION
The Liquids inline edit form only surfaced a substance input when the
entry already had a linked SubstanceRecord (coffee/alcohol presets) and
hid it for plain water/beverage rows, so there was no way to add or
correct caffeine/ABV/sugar for an existing drink. The form now always
renders Caffeine (mg), Alcohol (% ABV), and Sugar (g) inputs (sugar gated
by the optional tracker), each with a visible Label.

Saving routes through a new syncLiquidEntrySubstances service that
upserts the linked SubstanceRecord (caffeine/alcohol) or sugar
IntakeRecord, soft-deletes it when the user clears the field, and
generates a groupId on demand when the edited entry has none. Replaces
the old syncLiquidGroup which could only mutate pre-existing substances.

Also exposes a labeled prop on InlineEditFormShell so the shared
timestamp/note inputs render visible Labels (opted into by the Liquids
card; other cards keep the existing aria-label-only behavior).

https://claude.ai/code/session_01WJ3M5SyRcY5EgJz62zDknj

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Labeled edit mode with visible "Date and time" and "Note (optional)" labels for improved accessibility.

* **Refactor**
  * Editing UI now shows beverage name, caffeine (mg), and alcohol (ABV %) inputs always, and sugar (g) when sugar tracking is enabled; replaces previous consolidated substance input.

* **Tests**
  * Added tests covering liquid-to-substance synchronization behaviors (create/update/soft-delete cases).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/RyRy79261/intake-tracker/pull/175?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->