### PR TITLE
ci(android): sign release builds and auto-publish AAB to Google Play

### DIFF
--- a/.github/workflows/android-release.yml
+++ b/.github/workflows/android-release.yml
@@ -3,14 +3,28 @@ name: Android Release
 on:
   release:
     types: [published]
+  # Allow manual re-runs (e.g. to retry a Play upload) against an existing tag.
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Existing release tag to (re)build, e.g. v1.28.0"
+        required: true
+        type: string
 
 jobs:
-  build-apk:
+  build-and-publish:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+    env:
+      # Default Play track; override by setting a repository variable PLAY_TRACK
+      # to one of: internal | alpha (closed testing) | beta (open testing) | production
+      PLAY_TRACK: ${{ vars.PLAY_TRACK || 'beta' }}
+      PACKAGE_NAME: dev.ryanjnoble.intaketracker
     steps:
       - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.inputs.tag || github.event.release.tag_name }}
 
       - uses: pnpm/action-setup@v5
       - uses: actions/setup-node@v6
@@ -54,17 +68,79 @@ jobs:
       - name: Setup Android SDK
         uses: android-actions/setup-android@v3
 
-      - name: Build debug APK
-        working-directory: android
-        run: ./gradlew assembleDebug
-
-      - name: Rename APK
+      - name: Decode upload keystore
+        id: keystore
+        env:
+          ANDROID_KEYSTORE_BASE64: ${{ secrets.ANDROID_KEYSTORE_BASE64 }}
         run: |
-          mv android/app/build/outputs/apk/debug/app-debug.apk \
-             android/app/build/outputs/apk/debug/intake-tracker-v${{ steps.version.outputs.version }}.apk
+          if [ -z "$ANDROID_KEYSTORE_BASE64" ]; then
+            echo "::error::ANDROID_KEYSTORE_BASE64 secret is not set — cannot produce a signed release. See docs/android-release.md"
+            exit 1
+          fi
+          echo "$ANDROID_KEYSTORE_BASE64" | base64 -d > "$RUNNER_TEMP/upload-keystore.jks"
+          echo "path=$RUNNER_TEMP/upload-keystore.jks" >> "$GITHUB_OUTPUT"
 
-      - name: Attach APK to release
+      - name: Build signed AAB and APK
+        working-directory: android
+        env:
+          ANDROID_KEYSTORE_FILE: ${{ steps.keystore.outputs.path }}
+          ANDROID_KEYSTORE_PASSWORD: ${{ secrets.ANDROID_KEYSTORE_PASSWORD }}
+          ANDROID_KEY_ALIAS: ${{ secrets.ANDROID_KEY_ALIAS }}
+          ANDROID_KEY_PASSWORD: ${{ secrets.ANDROID_KEY_PASSWORD }}
+        run: ./gradlew bundleRelease assembleRelease --no-daemon
+
+      - name: Rename artifacts
+        id: artifacts
+        run: |
+          VERSION=${{ steps.version.outputs.version }}
+          AAB_SRC=android/app/build/outputs/bundle/release/app-release.aab
+          APK_SRC=android/app/build/outputs/apk/release/app-release.apk
+          AAB_OUT="android/app/build/outputs/bundle/release/intake-tracker-v${VERSION}.aab"
+          APK_OUT="android/app/build/outputs/apk/release/intake-tracker-v${VERSION}.apk"
+          mv "$AAB_SRC" "$AAB_OUT"
+          mv "$APK_SRC" "$APK_OUT"
+          echo "aab=$AAB_OUT" >> "$GITHUB_OUTPUT"
+          echo "apk=$APK_OUT" >> "$GITHUB_OUTPUT"
+
+      - name: Attach artifacts to GitHub release
+        if: github.event_name == 'release'
         uses: softprops/action-gh-release@v2
         with:
           tag_name: ${{ github.event.release.tag_name }}
-          files: android/app/build/outputs/apk/debug/intake-tracker-v${{ steps.version.outputs.version }}.apk
+          files: |
+            ${{ steps.artifacts.outputs.aab }}
+            ${{ steps.artifacts.outputs.apk }}
+
+      # ---------------------------------------------------------------------
+      # Upload the signed AAB to Google Play.
+      #
+      # Requires the PLAY_SERVICE_ACCOUNT_JSON secret (a Google Cloud
+      # service-account key with the Play Developer API enabled and access
+      # granted in the Play Console). The step is skipped if the secret is
+      # absent, so the GitHub release still succeeds before Play is wired up.
+      #
+      # NOTE: the FIRST release of a brand-new app must be uploaded manually
+      # in the Play Console — the API cannot create the app listing. Every
+      # release after that one is automated by this step.
+      # ---------------------------------------------------------------------
+      - name: Check Play credentials
+        id: play
+        env:
+          PLAY_SERVICE_ACCOUNT_JSON: ${{ secrets.PLAY_SERVICE_ACCOUNT_JSON }}
+        run: |
+          if [ -n "$PLAY_SERVICE_ACCOUNT_JSON" ]; then
+            echo "enabled=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "enabled=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::PLAY_SERVICE_ACCOUNT_JSON not set — skipping Play upload. See docs/android-release.md"
+          fi
+
+      - name: Upload to Google Play (${{ env.PLAY_TRACK }})
+        if: steps.play.outputs.enabled == 'true'
+        uses: r0adkll/upload-google-play@v1
+        with:
+          serviceAccountJsonPlainText: ${{ secrets.PLAY_SERVICE_ACCOUNT_JSON }}
+          packageName: ${{ env.PACKAGE_NAME }}
+          releaseFiles: ${{ steps.artifacts.outputs.aab }}
+          track: ${{ env.PLAY_TRACK }}
+          status: completed

--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,14 @@
 .DS_Store
 *.pem
 
+# Android signing — NEVER commit keystores or their passwords
+*.jks
+*.keystore
+*.jks.base64.txt
+upload-keystore.*
+android/keystore.properties
+play-service-account*.json
+
 # Debug
 npm-debug.log*
 yarn-debug.log*

--- a/README.md
+++ b/README.md
@@ -195,9 +195,16 @@ CI guarantees per PR ([`.github/workflows/ci.yml`](.github/workflows/ci.yml)):
 
 ### Android
 
+Install as a PWA:
+
 1. Open the app in Chrome
 2. Tap the menu (three dots)
 3. Select "Add to Home Screen"
+
+Or install the native build from the Google Play Store (Capacitor wrapper). The
+signed release pipeline is documented in
+[`docs/android-release.md`](docs/android-release.md) — publishing a GitHub
+release builds a signed AAB and uploads it to Play automatically.
 
 ### iOS
 

--- a/android/.gitignore
+++ b/android/.gitignore
@@ -52,10 +52,10 @@ captures/
 # Comment next line if keeping position of elements in Navigation Editor is relevant for you
 .idea/navEditor.xml
 
-# Keystore files
-# Uncomment the following lines if you do not want to check your keystore files in.
-#*.jks
-#*.keystore
+# Keystore files — NEVER commit these (see docs/android-release.md)
+*.jks
+*.keystore
+keystore.properties
 
 # External native build folder generated in Android Studio 2.2 and later
 .externalNativeBuild

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -10,6 +10,40 @@ if (versionPropsFile.canRead()) {
     appVersionName = versionProps['VERSION_NAME'] ?: "1.0.0"
 }
 
+// Release signing configuration.
+//
+// Reads from a local `android/keystore.properties` file when present (local
+// release builds), otherwise from environment variables (CI). Never commit the
+// keystore or its passwords — see docs/android-release.md.
+//
+// Supported keys / env vars:
+//   storeFile      / ANDROID_KEYSTORE_FILE     path to the .jks keystore
+//   storePassword  / ANDROID_KEYSTORE_PASSWORD keystore password
+//   keyAlias       / ANDROID_KEY_ALIAS         signing key alias
+//   keyPassword    / ANDROID_KEY_PASSWORD      signing key password
+def keystorePropertiesFile = file('keystore.properties')
+def keystoreProperties = new Properties()
+def hasKeystoreProps = keystorePropertiesFile.canRead()
+if (hasKeystoreProps) {
+    keystoreProperties.load(new FileInputStream(keystorePropertiesFile))
+}
+
+def resolveSigning = { String propKey, String envKey ->
+    def value = hasKeystoreProps ? keystoreProperties[propKey] : System.getenv(envKey)
+    return (value != null && !value.toString().trim().isEmpty()) ? value.toString() : null
+}
+
+def releaseStoreFile = resolveSigning('storeFile', 'ANDROID_KEYSTORE_FILE')
+def releaseStorePassword = resolveSigning('storePassword', 'ANDROID_KEYSTORE_PASSWORD')
+def releaseKeyAlias = resolveSigning('keyAlias', 'ANDROID_KEY_ALIAS')
+def releaseKeyPassword = resolveSigning('keyPassword', 'ANDROID_KEY_PASSWORD')
+
+def hasReleaseSigning = releaseStoreFile != null &&
+        releaseStorePassword != null &&
+        releaseKeyAlias != null &&
+        releaseKeyPassword != null &&
+        file(releaseStoreFile).exists()
+
 android {
     namespace = "dev.ryanjnoble.intaketracker"
     compileSdk = rootProject.ext.compileSdkVersion
@@ -26,10 +60,30 @@ android {
             ignoreAssetsPattern = '!.svn:!.git:!.ds_store:!*.scc:.*:!CVS:!thumbs.db:!picasa.ini:!*~'
         }
     }
+    signingConfigs {
+        if (hasReleaseSigning) {
+            release {
+                storeFile file(releaseStoreFile)
+                storePassword releaseStorePassword
+                keyAlias releaseKeyAlias
+                keyPassword releaseKeyPassword
+                // App Bundles for Play default to v1+v2; v2 also satisfies APK installs.
+                enableV1Signing true
+                enableV2Signing true
+            }
+        }
+    }
     buildTypes {
         release {
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+            if (hasReleaseSigning) {
+                signingConfig signingConfigs.release
+            } else {
+                // No upload keystore available (e.g. local dev). The artifact will be
+                // unsigned / debug-signed and is NOT uploadable to Google Play.
+                project.logger.warn('android: no release keystore configured — release artifacts will be unsigned. See docs/android-release.md')
+            }
         }
     }
 }

--- a/docs/android-release.md
+++ b/docs/android-release.md
@@ -1,0 +1,190 @@
+# Android Release & Google Play Publishing
+
+This document describes how Intake Tracker is built, signed, and shipped to the
+Google Play Store.
+
+The app is a Next.js PWA wrapped in [Capacitor](https://capacitorjs.com/). The
+`android/` directory is the native Android project. CI builds a **signed Android
+App Bundle (`.aab`)** and uploads it to Google Play on every published GitHub
+release.
+
+- **Application ID:** `dev.ryanjnoble.intaketracker`
+- **Workflow:** [`.github/workflows/android-release.yml`](../.github/workflows/android-release.yml)
+- **Signing config:** [`android/app/build.gradle`](../android/app/build.gradle)
+
+---
+
+## Overview of the pipeline
+
+On every published GitHub release the `Android Release` workflow:
+
+1. Builds the static web export (`scripts/cap-build.js`) and syncs it into the
+   Android project (`npx cap sync android`).
+2. Derives `versionCode`/`versionName` from `package.json`
+   (`major*10000 + minor*100 + patch`).
+3. Decodes the upload keystore from the `ANDROID_KEYSTORE_BASE64` secret.
+4. Builds a **signed AAB** (`bundleRelease`) and a **signed APK**
+   (`assembleRelease`).
+5. Attaches both artifacts to the GitHub release.
+6. Uploads the AAB to Google Play on the configured track (default `beta`).
+
+You can also re-run it manually via **Actions → Android Release → Run workflow**
+against an existing tag (useful for retrying a failed Play upload).
+
+---
+
+## One-time setup
+
+### 1. Generate an upload keystore
+
+With **Google Play App Signing** (recommended and the default for new apps),
+the key you generate here is only an *upload key*. Google holds the real
+app-signing key; if you ever lose the upload key you can reset it from the Play
+Console.
+
+Run the helper script from the repo root:
+
+```bash
+./scripts/generate-upload-keystore.sh
+```
+
+It will:
+
+- Prompt for a keystore password and a key password (**use the same value for
+  both** — CI assumes they match).
+- Write `upload-keystore.jks` (git-ignored).
+- Write `upload-keystore.jks.base64.txt` (the base64 blob for the GitHub
+  secret).
+- Print exactly which secrets to set.
+
+Keep `upload-keystore.jks` somewhere safe (a password manager or encrypted
+vault) and **never commit it**. The repo's `.gitignore` already blocks `*.jks`,
+`*.keystore`, `keystore.properties`, and the base64 file.
+
+### 2. Add the signing secrets to GitHub
+
+**Settings → Secrets and variables → Actions → New repository secret:**
+
+| Secret | Value |
+| --- | --- |
+| `ANDROID_KEYSTORE_BASE64` | Contents of `upload-keystore.jks.base64.txt` |
+| `ANDROID_KEYSTORE_PASSWORD` | The keystore password you entered |
+| `ANDROID_KEY_ALIAS` | `upload` (default alias from the script) |
+| `ANDROID_KEY_PASSWORD` | The key password you entered |
+
+Once the secrets are in GitHub, delete the local base64 file:
+
+```bash
+rm upload-keystore.jks.base64.txt
+```
+
+### 3. Create the app in the Play Console (manual, one time)
+
+The Play Developer API **cannot create a new app listing** — the first bundle
+must be uploaded by hand:
+
+1. In the [Play Console](https://play.google.com/console), create a new app with
+   package name `dev.ryanjnoble.intaketracker`.
+2. Make sure **Play App Signing** is enabled (default for new apps).
+3. Build a bundle locally (see [Local release builds](#local-release-builds)) or
+   download the `.aab` from the GitHub release, then upload it once to your
+   chosen track and complete the store listing / content rating / data-safety
+   forms.
+
+After this first manual upload, every subsequent GitHub release is uploaded
+automatically by CI.
+
+### 4. Create a Play service account for automated uploads
+
+1. In the Play Console: **Setup → API access** → link or create a Google Cloud
+   project.
+2. Create a **service account** in Google Cloud, then grant it access in the
+   Play Console (**Users and permissions → Invite new users**) with at least the
+   *Release to testing tracks* / *Release apps to production* permissions for
+   this app.
+3. Create a JSON key for the service account and download it.
+4. Add it to GitHub as the secret **`PLAY_SERVICE_ACCOUNT_JSON`** (paste the full
+   JSON contents).
+
+The Google Play Android Developer API must be enabled in the Cloud project.
+
+If `PLAY_SERVICE_ACCOUNT_JSON` is absent, the workflow still builds and signs the
+artifacts and attaches them to the release — it just skips the Play upload step.
+
+### 5. (Optional) Choose the release track
+
+The workflow defaults to the **`beta`** (open testing) track. To change it, set a
+repository **variable** (not secret) named `PLAY_TRACK`:
+
+**Settings → Secrets and variables → Actions → Variables → New repository variable**
+
+| Variable | Allowed values |
+| --- | --- |
+| `PLAY_TRACK` | `internal`, `alpha` (closed testing), `beta` (open testing), `production` |
+
+---
+
+## Cutting a release
+
+1. Bump the version and merge (release-please manages this — see
+   `release-please-config.json`).
+2. Publish the GitHub release for the new tag.
+3. The `Android Release` workflow runs automatically:
+   - Signed `intake-tracker-vX.Y.Z.aab` + `.apk` are attached to the release.
+   - The AAB is uploaded to the `PLAY_TRACK` track and rolled out (`status:
+     completed`).
+
+`versionCode` is derived from the semver, so it always increases as long as the
+version bumps — Play rejects re-uploads of an existing `versionCode`.
+
+---
+
+## Local release builds
+
+To produce a signed bundle locally, create `android/keystore.properties`
+(git-ignored):
+
+```properties
+storeFile=/absolute/path/to/upload-keystore.jks
+storePassword=your-keystore-password
+keyAlias=upload
+keyPassword=your-key-password
+```
+
+Then:
+
+```bash
+node scripts/cap-build.js     # build + export web assets
+npx cap sync android
+cd android
+./gradlew bundleRelease       # -> app/build/outputs/bundle/release/app-release.aab
+./gradlew assembleRelease     # -> app/build/outputs/apk/release/app-release.apk
+```
+
+If no keystore is configured, `build.gradle` logs a warning and the release
+artifacts are left unsigned (not uploadable to Play). Debug builds
+(`./gradlew assembleDebug`) are unaffected.
+
+---
+
+## Troubleshooting
+
+- **`ANDROID_KEYSTORE_BASE64 secret is not set`** — add the four signing secrets
+  (step 2).
+- **Play upload step skipped** — `PLAY_SERVICE_ACCOUNT_JSON` is missing (step 4).
+- **`APK specifies a version code that has already been used`** — bump the app
+  version; `versionCode` is computed from the semver.
+- **`The caller does not have permission` on upload** — the service account
+  hasn't been granted access to this app in the Play Console, or the API isn't
+  enabled in the Cloud project (steps in §4).
+- **First upload fails via API** — expected; the very first bundle for a new app
+  must be uploaded manually (step 3).
+
+## Security notes
+
+- The upload keystore and all passwords live only in GitHub Actions secrets and
+  your local machine — never in the repo.
+- `.gitignore` blocks `*.jks`, `*.keystore`, `keystore.properties`,
+  `upload-keystore.*`, and `play-service-account*.json`.
+- Rotate the service-account key periodically; revoke it in Google Cloud if it
+  is ever exposed.

--- a/scripts/generate-upload-keystore.sh
+++ b/scripts/generate-upload-keystore.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+#
+# generate-upload-keystore.sh
+#
+# Creates an Android *upload* keystore for signing release builds of Intake
+# Tracker, then prints the values you need to paste into GitHub repository
+# secrets so CI can sign the AAB it ships to Google Play.
+#
+# With Google Play App Signing (recommended), THIS key is only your *upload*
+# key. Google holds the real app-signing key. If you ever lose this upload key
+# you can reset it from the Play Console — but keep it safe regardless.
+#
+# Usage:
+#   ./scripts/generate-upload-keystore.sh [output-path]
+#
+# Default output: ./upload-keystore.jks (git-ignored). Move it somewhere safe
+# (a password manager / encrypted vault) once you've captured the secrets.
+
+set -euo pipefail
+
+KEYSTORE_PATH="${1:-upload-keystore.jks}"
+KEY_ALIAS="${KEY_ALIAS:-upload}"
+VALIDITY_DAYS="${VALIDITY_DAYS:-10950}" # ~30 years; Play requires a long validity
+
+if ! command -v keytool >/dev/null 2>&1; then
+  echo "error: 'keytool' not found. Install a JDK (e.g. Temurin 21) and retry." >&2
+  exit 1
+fi
+
+if [[ -e "$KEYSTORE_PATH" ]]; then
+  echo "error: '$KEYSTORE_PATH' already exists. Refusing to overwrite." >&2
+  echo "       Pass a different path or remove the existing file first." >&2
+  exit 1
+fi
+
+echo "==> Generating upload keystore: $KEYSTORE_PATH"
+echo "    alias=$KEY_ALIAS  validity=${VALIDITY_DAYS} days  algorithm=RSA 2048"
+echo
+echo "You'll be prompted for a keystore password and a key password."
+echo "TIP: use the SAME value for both — the CI build assumes they match."
+echo
+
+# -dname can be customised; Play does not require accurate values for an upload key.
+DNAME="${DNAME:-CN=Intake Tracker, OU=Mobile, O=ryanjnoble.dev, L=, ST=, C=}"
+
+keytool -genkeypair \
+  -v \
+  -keystore "$KEYSTORE_PATH" \
+  -alias "$KEY_ALIAS" \
+  -keyalg RSA \
+  -keysize 2048 \
+  -validity "$VALIDITY_DAYS" \
+  -dname "$DNAME"
+
+echo
+echo "==> Done. Keystore written to: $KEYSTORE_PATH"
+echo
+
+BASE64_FILE="${KEYSTORE_PATH}.base64.txt"
+base64 < "$KEYSTORE_PATH" | tr -d '\n' > "$BASE64_FILE"
+
+cat <<EOF
+======================================================================
+Add these as GitHub repository secrets
+(Settings → Secrets and variables → Actions → New repository secret):
+======================================================================
+
+  ANDROID_KEYSTORE_BASE64    -> contents of: ${BASE64_FILE}
+  ANDROID_KEYSTORE_PASSWORD  -> the keystore password you just entered
+  ANDROID_KEY_ALIAS          -> ${KEY_ALIAS}
+  ANDROID_KEY_PASSWORD       -> the key password you just entered
+
+To copy the base64 to your clipboard:
+  macOS:  pbcopy < ${BASE64_FILE}
+  Linux:  xclip -selection clipboard < ${BASE64_FILE}
+
+======================================================================
+NEXT: also add the Play upload secret + variable (see docs):
+  PLAY_SERVICE_ACCOUNT_JSON  -> Google Cloud service-account JSON
+  PLAY_TRACK (variable)      -> internal | alpha | beta | production
+See docs/android-release.md for the full walkthrough.
+======================================================================
+
+SECURITY: keep '${KEYSTORE_PATH}' safe and OUT of git. Once the secrets are
+in GitHub, delete the local base64 file:  rm ${BASE64_FILE}
+EOF


### PR DESCRIPTION
Wires up the Google Play release pipeline:

- Add a release signingConfig to android/app/build.gradle that reads the
  upload keystore from android/keystore.properties (local) or env vars
  (CI), falling back to an unsigned build with a warning when absent so
  debug/dev builds are unaffected.
- Rework .github/workflows/android-release.yml to decode the keystore from
  ANDROID_KEYSTORE_BASE64, build a signed AAB (bundleRelease) and APK
  (assembleRelease), attach both to the GitHub release, and upload the AAB
  to Google Play via r0adkll/upload-google-play (default track: beta,
  override with the PLAY_TRACK repo variable). The Play step is skipped
  when PLAY_SERVICE_ACCOUNT_JSON is unset. Adds workflow_dispatch for
  manual re-runs against an existing tag.
- Add scripts/generate-upload-keystore.sh to create an upload keystore and
  print the GitHub secrets to set.
- Ignore keystores / keystore.properties / service-account JSON in git.
- Document the full setup in docs/android-release.md and link it from the
  README.

https://claude.ai/code/session_01ViHrvFNYHgC5jZ5h45urV6