### PR TITLE
ci: add supply-chain security gate and gate Neon DB jobs on secret availability

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -152,7 +152,12 @@ jobs:
     # Phase 41: Privy is fully removed. Auth is Neon Auth (cookie session).
     # E2E tests use Playwright globalSetup to seed a session via Neon Auth.
     needs: [changes]
-    if: needs.changes.outputs.src == 'true'
+    # Dependabot PR runs are not granted the repository's Actions secrets, so
+    # secrets.NEON_API_KEY is empty and the Neon branch actions below fail with
+    # "Cannot run interactive auth in CI". Skip this secret-dependent job for
+    # Dependabot; dependency bumps are still covered by build + the static
+    # schema-parity/drizzle-freshness checks (typecheck, data-integrity).
+    if: needs.changes.outputs.src == 'true' && github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -228,6 +233,14 @@ jobs:
     # that static parity + freshness checks cannot (bad CHECK syntax,
     # cross-schema FK permissions, unreachable neon_auth.users_sync target).
     # Uses the same branch lifecycle pattern as the e2e job above.
+    #
+    # Dependabot PR runs are not granted the repository's Actions secrets, so
+    # secrets.NEON_API_KEY is empty and the Neon branch creation below fails
+    # ("Cannot run interactive auth in CI"). Skip for Dependabot — its bumps
+    # never touch src/db/schema.ts, and the static parity + drizzle-freshness
+    # checks (typecheck, data-integrity) still run. ci-pass treats a skipped
+    # schema-migration as acceptable.
+    if: github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -356,7 +369,6 @@ jobs:
           echo "build: ${{ needs.build.result }}"
           echo "data-integrity: ${{ needs.data-integrity.result }}"
           echo "supply-chain: ${{ needs.supply-chain.result }}"
-          echo "schema-migration: ${{ needs.schema-migration.result }}"
 
           # Unconditional jobs: must succeed
           if [[ "${{ needs.changes.result }}" != "success" ||
@@ -364,8 +376,7 @@ jobs:
                 "${{ needs.typecheck.result }}" != "success" ||
                 "${{ needs.build.result }}" != "success" ||
                 "${{ needs.data-integrity.result }}" != "success" ||
-                "${{ needs.supply-chain.result }}" != "success" ||
-                "${{ needs.schema-migration.result }}" != "success" ]]; then
+                "${{ needs.supply-chain.result }}" != "success" ]]; then
             echo "::error::Unconditional job failed"
             exit 1
           fi
@@ -375,6 +386,11 @@ jobs:
           echo "test-tz-de: ${{ needs.test-tz-de.result }}"
           echo "integration: ${{ needs.integration.result }}"
           echo "e2e: ${{ needs.e2e.result }}"
+          # schema-migration is gated rather than unconditional: it needs the
+          # Neon secrets, which Dependabot PR runs don't receive, so it is
+          # skipped (not failed) on those runs. Still required to succeed on
+          # all non-Dependabot PRs since it never gets skipped there.
+          echo "schema-migration: ${{ needs.schema-migration.result }}"
           echo "coverage: ${{ needs.coverage.result }}"
           echo "benchmark: ${{ needs.benchmark.result }}"
 
@@ -384,6 +400,7 @@ jobs:
             "${{ needs.test-tz-de.result }}" \
             "${{ needs.integration.result }}" \
             "${{ needs.e2e.result }}" \
+            "${{ needs.schema-migration.result }}" \
             "${{ needs.coverage.result }}" \
             "${{ needs.benchmark.result }}"; do
             if [[ "$result" != "success" && "$result" != "skipped" ]]; then

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,16 +35,19 @@ jobs:
               - 'src/lib/backup-service.ts'
 
   # The e2e and schema-migration jobs create an ephemeral Neon branch and
-  # therefore need NEON_API_KEY. Probe for it here so those jobs can gate on
-  # availability rather than on the actor: they run whenever the key is present
-  # (regular PRs always; Dependabot PRs once the Neon secrets are added to the
-  # Dependabot secrets store) and skip cleanly otherwise — instead of failing
-  # with "Cannot run interactive auth in CI" when the secret is an empty string.
+  # therefore need NEON_API_KEY. Probe for it here so those jobs gate on the
+  # secret's availability: they run whenever the key is present (human PRs and
+  # the release-please PR) and skip cleanly otherwise — instead of failing with
+  # "Cannot run interactive auth in CI" when the secret is an empty string.
   #
-  # GitHub withholds *Actions* secrets from Dependabot-triggered runs but does
-  # expose *Dependabot* secrets, so mirroring NEON_API_KEY (and the other Neon
-  # secrets the jobs use) into the Dependabot secrets store is what turns these
-  # tests on for Dependabot PRs.
+  # By design we do NOT give Dependabot the Neon secrets. GitHub already
+  # withholds Actions secrets from Dependabot-triggered runs, and we
+  # deliberately do not mirror them into the Dependabot secrets store: a
+  # compromised dependency bump would otherwise execute with our Neon
+  # credentials in scope (supply-chain exfiltration risk). Dependabot PRs
+  # therefore skip the DB-backed jobs and merge on the secret-free checks; the
+  # bumps get full DB + E2E coverage once they roll up into the release-please
+  # PR, which runs as a normal PR with the secrets available.
   secrets-check:
     runs-on: ubuntu-latest
     outputs:
@@ -58,7 +61,7 @@ jobs:
             echo "neon=true" >> "$GITHUB_OUTPUT"
           else
             echo "neon=false" >> "$GITHUB_OUTPUT"
-            echo "::notice::NEON_API_KEY unavailable — skipping DB-backed jobs (e2e, schema-migration). For Dependabot PRs, add the Neon secrets to the Dependabot secrets store to enable them."
+            echo "::notice::NEON_API_KEY unavailable — skipping DB-backed jobs (e2e, schema-migration). Expected on Dependabot PRs (no Neon secrets by design); these bumps get full DB coverage via the release-please PR after merge."
           fi
 
   lint:
@@ -179,10 +182,9 @@ jobs:
     # Phase 41: Privy is fully removed. Auth is Neon Auth (cookie session).
     # E2E tests use Playwright globalSetup to seed a session via Neon Auth.
     needs: [changes, secrets-check]
-    # Runs whenever the Neon API key is available (see secrets-check). On
-    # Dependabot PRs this means the job runs once the Neon secrets are mirrored
-    # into the Dependabot secrets store, and skips cleanly until then instead of
-    # failing with "Cannot run interactive auth in CI".
+    # Runs whenever the Neon API key is available (see secrets-check). Skips on
+    # Dependabot PRs, which intentionally don't get the Neon secrets; those
+    # bumps get full E2E coverage via the release-please PR after merge.
     if: needs.changes.outputs.src == 'true' && needs.secrets-check.outputs.neon == 'true'
     runs-on: ubuntu-latest
     steps:
@@ -260,11 +262,10 @@ jobs:
     # cross-schema FK permissions, unreachable neon_auth.users_sync target).
     # Uses the same branch lifecycle pattern as the e2e job above.
     #
-    # Runs whenever the Neon API key is available (see secrets-check). On
-    # Dependabot PRs this means the job runs once the Neon secrets are mirrored
-    # into the Dependabot secrets store, and skips cleanly until then instead of
-    # failing with "Cannot run interactive auth in CI". ci-pass treats a skipped
-    # schema-migration as acceptable.
+    # Runs whenever the Neon API key is available (see secrets-check). Skips on
+    # Dependabot PRs, which intentionally don't get the Neon secrets; ci-pass
+    # treats a skipped schema-migration as acceptable. Dependency bumps don't
+    # touch src/db/schema.ts and get full coverage via the release-please PR.
     needs: [secrets-check]
     if: needs.secrets-check.outputs.neon == 'true'
     runs-on: ubuntu-latest
@@ -416,8 +417,8 @@ jobs:
           echo "e2e: ${{ needs.e2e.result }}"
           # schema-migration is gated rather than unconditional: it needs the
           # Neon API key (see secrets-check), so it is skipped (not failed)
-          # when the key is unavailable — e.g. a Dependabot PR before the Neon
-          # secrets are mirrored into the Dependabot secrets store.
+          # when the key is unavailable — e.g. on Dependabot PRs, which by
+          # design don't receive the Neon secrets.
           echo "schema-migration: ${{ needs.schema-migration.result }}"
           echo "coverage: ${{ needs.coverage.result }}"
           echo "benchmark: ${{ needs.benchmark.result }}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,51 @@ jobs:
               - 'src/__tests__/integrity/**'
               - 'src/lib/backup-service.ts'
 
+  # Supply-chain gate. Runs *before* every job that installs or executes
+  # dependency code (they all `needs: [security]`), so a known-malicious or
+  # vulnerable dependency change — or a secret committed into the diff — stops
+  # the run before any project code executes. These steps analyse PR
+  # metadata/diff only and never run the project's dependencies, so they are
+  # safe to run first.
+  security:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      # EDR-style monitoring of the runner's network egress + file/process
+      # activity. Kept in `audit` mode for now (observe + report, don't block).
+      # ROLLOUT: after a few runs, read the per-run network log at
+      # app.stepsecurity.io, then flip egress-policy to `block` with an
+      # allowed-endpoints allowlist to actively prevent exfiltration. Do NOT set
+      # `block` before the allowlist is verified — a wrong list breaks CI.
+      - name: Harden runner (egress audit)
+        uses: step-security/harden-runner@v2
+        with:
+          egress-policy: audit
+      - uses: actions/checkout@v6
+        with:
+          # Full history so gitleaks can scan the PR's commit range.
+          fetch-depth: 0
+      # Fail the PR if it introduces a dependency carrying a known-malware or
+      # high/critical advisory. Public repo → no GitHub Advanced Security
+      # needed. allow-ghsas mirrors the accepted-risk advisories already
+      # documented in pnpm-workspace.yaml (auditConfig.ignoreCves) so this gate
+      # stays consistent with the `pnpm audit` step and doesn't re-flag the same
+      # reviewed transitive CVEs. License checks are off (this gate targets the
+      # malicious-dependency threat, not license compliance).
+      - name: Dependency review
+        uses: actions/dependency-review-action@v5
+        with:
+          fail-on-severity: high
+          license-check: false
+          allow-ghsas: GHSA-h25m-26qc-wcjf,GHSA-mw96-cpmx-2vgc,GHSA-3ppc-4f35-3m26,GHSA-7r86-cg39-jmmj,GHSA-23c5-xmqv-rm74,GHSA-c2c7-rcm5-vvqj
+      # Catch secrets accidentally committed in the diff. No license key needed
+      # for personal-account repos.
+      - name: Scan diff for committed secrets
+        uses: gitleaks/gitleaks-action@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
   # The e2e and schema-migration jobs create an ephemeral Neon branch and
   # therefore need NEON_API_KEY. Probe for it here so those jobs gate on the
   # secret's availability: they run whenever the key is present (human PRs and
@@ -65,6 +110,7 @@ jobs:
           fi
 
   lint:
+    needs: [security]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -77,6 +123,7 @@ jobs:
       - run: pnpm lint
 
   typecheck:
+    needs: [security]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -99,7 +146,7 @@ jobs:
           echo "drizzle/ is up-to-date with src/db/schema.ts"
 
   test-tz-sa:
-    needs: [changes]
+    needs: [changes, security]
     if: needs.changes.outputs.src == 'true'
     runs-on: ubuntu-latest
     steps:
@@ -114,7 +161,7 @@ jobs:
         run: pnpm test:tz:sa
 
   test-tz-de:
-    needs: [changes]
+    needs: [changes, security]
     if: needs.changes.outputs.src == 'true'
     runs-on: ubuntu-latest
     steps:
@@ -129,8 +176,13 @@ jobs:
         run: pnpm test:tz:de
 
   build:
+    needs: [security]
     runs-on: ubuntu-latest
     steps:
+      - name: Harden runner (egress audit)
+        uses: step-security/harden-runner@v2
+        with:
+          egress-policy: audit
       - uses: actions/checkout@v6
       - uses: pnpm/action-setup@v5
       - uses: actions/setup-node@v6
@@ -151,6 +203,7 @@ jobs:
         run: pnpm exec vitest run src/__tests__/bundle-security.test.ts
 
   data-integrity:
+    needs: [security]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -164,7 +217,7 @@ jobs:
         run: pnpm exec vitest run src/__tests__/integrity/
 
   integration:
-    needs: [changes]
+    needs: [changes, security]
     if: needs.changes.outputs.src == 'true'
     runs-on: ubuntu-latest
     steps:
@@ -181,13 +234,20 @@ jobs:
   e2e:
     # Phase 41: Privy is fully removed. Auth is Neon Auth (cookie session).
     # E2E tests use Playwright globalSetup to seed a session via Neon Auth.
-    needs: [changes, secrets-check]
+    needs: [changes, secrets-check, security]
     # Runs whenever the Neon API key is available (see secrets-check). Skips on
     # Dependabot PRs, which intentionally don't get the Neon secrets; those
     # bumps get full E2E coverage via the release-please PR after merge.
     if: needs.changes.outputs.src == 'true' && needs.secrets-check.outputs.neon == 'true'
     runs-on: ubuntu-latest
     steps:
+      # This job holds the Neon secrets while running dependency code, so it is
+      # the highest-value place to monitor egress. See the security job for the
+      # audit→block rollout.
+      - name: Harden runner (egress audit)
+        uses: step-security/harden-runner@v2
+        with:
+          egress-policy: audit
       - uses: actions/checkout@v6
       - uses: pnpm/action-setup@v5
       - uses: actions/setup-node@v6
@@ -266,10 +326,15 @@ jobs:
     # Dependabot PRs, which intentionally don't get the Neon secrets; ci-pass
     # treats a skipped schema-migration as acceptable. Dependency bumps don't
     # touch src/db/schema.ts and get full coverage via the release-please PR.
-    needs: [secrets-check]
+    needs: [secrets-check, security]
     if: needs.secrets-check.outputs.neon == 'true'
     runs-on: ubuntu-latest
     steps:
+      # Holds the Neon secrets while running dependency code — monitor egress.
+      - name: Harden runner (egress audit)
+        uses: step-security/harden-runner@v2
+        with:
+          egress-policy: audit
       - uses: actions/checkout@v6
       - uses: pnpm/action-setup@v5
       - uses: actions/setup-node@v6
@@ -309,6 +374,7 @@ jobs:
           branch: ci-schema-${{ github.run_id }}
 
   supply-chain:
+    needs: [security]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -346,7 +412,7 @@ jobs:
             --ignore GHSA-c2c7-rcm5-vvqj
 
   coverage:
-    needs: [changes]
+    needs: [changes, security]
     if: needs.changes.outputs.src == 'true'
     runs-on: ubuntu-latest
     permissions:
@@ -368,7 +434,7 @@ jobs:
           file-coverage-mode: none
 
   benchmark:
-    needs: [changes]
+    needs: [changes, security]
     if: needs.changes.outputs.bench == 'true'
     runs-on: ubuntu-latest
     steps:
@@ -384,7 +450,7 @@ jobs:
 
   ci-pass:
     if: always()
-    needs: [changes, secrets-check, lint, typecheck, test-tz-sa, test-tz-de, build, data-integrity, integration, e2e, schema-migration, supply-chain, coverage, benchmark]
+    needs: [changes, secrets-check, security, lint, typecheck, test-tz-sa, test-tz-de, build, data-integrity, integration, e2e, schema-migration, supply-chain, coverage, benchmark]
     runs-on: ubuntu-latest
     steps:
       - name: Check all jobs passed
@@ -392,6 +458,7 @@ jobs:
           echo "=== Unconditional jobs ==="
           echo "changes: ${{ needs.changes.result }}"
           echo "secrets-check: ${{ needs.secrets-check.result }}"
+          echo "security: ${{ needs.security.result }}"
           echo "lint: ${{ needs.lint.result }}"
           echo "typecheck: ${{ needs.typecheck.result }}"
           echo "build: ${{ needs.build.result }}"
@@ -401,6 +468,7 @@ jobs:
           # Unconditional jobs: must succeed
           if [[ "${{ needs.changes.result }}" != "success" ||
                 "${{ needs.secrets-check.result }}" != "success" ||
+                "${{ needs.security.result }}" != "success" ||
                 "${{ needs.lint.result }}" != "success" ||
                 "${{ needs.typecheck.result }}" != "success" ||
                 "${{ needs.build.result }}" != "success" ||

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,33 @@ jobs:
               - 'src/__tests__/integrity/**'
               - 'src/lib/backup-service.ts'
 
+  # The e2e and schema-migration jobs create an ephemeral Neon branch and
+  # therefore need NEON_API_KEY. Probe for it here so those jobs can gate on
+  # availability rather than on the actor: they run whenever the key is present
+  # (regular PRs always; Dependabot PRs once the Neon secrets are added to the
+  # Dependabot secrets store) and skip cleanly otherwise — instead of failing
+  # with "Cannot run interactive auth in CI" when the secret is an empty string.
+  #
+  # GitHub withholds *Actions* secrets from Dependabot-triggered runs but does
+  # expose *Dependabot* secrets, so mirroring NEON_API_KEY (and the other Neon
+  # secrets the jobs use) into the Dependabot secrets store is what turns these
+  # tests on for Dependabot PRs.
+  secrets-check:
+    runs-on: ubuntu-latest
+    outputs:
+      neon: ${{ steps.check.outputs.neon }}
+    steps:
+      - id: check
+        env:
+          NEON_API_KEY: ${{ secrets.NEON_API_KEY }}
+        run: |
+          if [ -n "${NEON_API_KEY}" ]; then
+            echo "neon=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "neon=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::NEON_API_KEY unavailable — skipping DB-backed jobs (e2e, schema-migration). For Dependabot PRs, add the Neon secrets to the Dependabot secrets store to enable them."
+          fi
+
   lint:
     runs-on: ubuntu-latest
     steps:
@@ -151,13 +178,12 @@ jobs:
   e2e:
     # Phase 41: Privy is fully removed. Auth is Neon Auth (cookie session).
     # E2E tests use Playwright globalSetup to seed a session via Neon Auth.
-    needs: [changes]
-    # Dependabot PR runs are not granted the repository's Actions secrets, so
-    # secrets.NEON_API_KEY is empty and the Neon branch actions below fail with
-    # "Cannot run interactive auth in CI". Skip this secret-dependent job for
-    # Dependabot; dependency bumps are still covered by build + the static
-    # schema-parity/drizzle-freshness checks (typecheck, data-integrity).
-    if: needs.changes.outputs.src == 'true' && github.actor != 'dependabot[bot]'
+    needs: [changes, secrets-check]
+    # Runs whenever the Neon API key is available (see secrets-check). On
+    # Dependabot PRs this means the job runs once the Neon secrets are mirrored
+    # into the Dependabot secrets store, and skips cleanly until then instead of
+    # failing with "Cannot run interactive auth in CI".
+    if: needs.changes.outputs.src == 'true' && needs.secrets-check.outputs.neon == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -234,13 +260,13 @@ jobs:
     # cross-schema FK permissions, unreachable neon_auth.users_sync target).
     # Uses the same branch lifecycle pattern as the e2e job above.
     #
-    # Dependabot PR runs are not granted the repository's Actions secrets, so
-    # secrets.NEON_API_KEY is empty and the Neon branch creation below fails
-    # ("Cannot run interactive auth in CI"). Skip for Dependabot — its bumps
-    # never touch src/db/schema.ts, and the static parity + drizzle-freshness
-    # checks (typecheck, data-integrity) still run. ci-pass treats a skipped
+    # Runs whenever the Neon API key is available (see secrets-check). On
+    # Dependabot PRs this means the job runs once the Neon secrets are mirrored
+    # into the Dependabot secrets store, and skips cleanly until then instead of
+    # failing with "Cannot run interactive auth in CI". ci-pass treats a skipped
     # schema-migration as acceptable.
-    if: github.actor != 'dependabot[bot]'
+    needs: [secrets-check]
+    if: needs.secrets-check.outputs.neon == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -357,13 +383,14 @@ jobs:
 
   ci-pass:
     if: always()
-    needs: [changes, lint, typecheck, test-tz-sa, test-tz-de, build, data-integrity, integration, e2e, schema-migration, supply-chain, coverage, benchmark]
+    needs: [changes, secrets-check, lint, typecheck, test-tz-sa, test-tz-de, build, data-integrity, integration, e2e, schema-migration, supply-chain, coverage, benchmark]
     runs-on: ubuntu-latest
     steps:
       - name: Check all jobs passed
         run: |
           echo "=== Unconditional jobs ==="
           echo "changes: ${{ needs.changes.result }}"
+          echo "secrets-check: ${{ needs.secrets-check.result }}"
           echo "lint: ${{ needs.lint.result }}"
           echo "typecheck: ${{ needs.typecheck.result }}"
           echo "build: ${{ needs.build.result }}"
@@ -372,6 +399,7 @@ jobs:
 
           # Unconditional jobs: must succeed
           if [[ "${{ needs.changes.result }}" != "success" ||
+                "${{ needs.secrets-check.result }}" != "success" ||
                 "${{ needs.lint.result }}" != "success" ||
                 "${{ needs.typecheck.result }}" != "success" ||
                 "${{ needs.build.result }}" != "success" ||
@@ -387,9 +415,9 @@ jobs:
           echo "integration: ${{ needs.integration.result }}"
           echo "e2e: ${{ needs.e2e.result }}"
           # schema-migration is gated rather than unconditional: it needs the
-          # Neon secrets, which Dependabot PR runs don't receive, so it is
-          # skipped (not failed) on those runs. Still required to succeed on
-          # all non-Dependabot PRs since it never gets skipped there.
+          # Neon API key (see secrets-check), so it is skipped (not failed)
+          # when the key is unavailable — e.g. a Dependabot PR before the Neon
+          # secrets are mirrored into the Dependabot secrets store.
           echo "schema-migration: ${{ needs.schema-migration.result }}"
           echo "coverage: ${{ needs.coverage.result }}"
           echo "benchmark: ${{ needs.benchmark.result }}"


### PR DESCRIPTION
## Summary

Introduces a multi-layered security checkpoint in the CI pipeline to prevent malicious or vulnerable dependencies and committed secrets from reaching downstream jobs. All jobs that install or execute dependency code now gate on a new `security` job that runs before any project dependencies are invoked.

## Key Changes

- **New `security` job**: Runs supply-chain threat analysis before any dependency installation
  - Hardens the runner with StepSecurity egress monitoring (audit mode, rollout path to block mode documented)
  - Runs `actions/dependency-review-action` to fail on high/critical CVE advisories, with allowlist for reviewed transitive CVEs matching `pnpm-workspace.yaml`
  - Runs `gitleaks/gitleaks-action` to scan diffs for accidentally committed secrets
  - Analyzes PR metadata/diff only; never executes project dependencies, so safe to run first

- **New `secrets-check` job**: Probes for `NEON_API_KEY` availability and gates DB-backed jobs
  - Outputs `neon=true/false` to conditionally run `e2e` and `schema-migration` jobs
  - Allows Dependabot PRs to skip DB-backed jobs cleanly (no secrets by design; full coverage via release-please PR after merge)
  - Prevents supply-chain exfiltration risk by intentionally withholding Neon credentials from Dependabot-triggered runs

- **Updated job dependencies**: All jobs that install/execute code now `needs: [security]`
  - `lint`, `typecheck`, `build`, `data-integrity`, `supply-chain`, `test-tz-sa`, `test-tz-de`, `integration`, `coverage`, `benchmark`
  - `e2e` and `schema-migration` additionally gate on `secrets-check` with conditional `if` statements

- **Hardened runner steps**: Added StepSecurity egress monitoring to `build`, `e2e`, and `schema-migration` jobs (highest-value places for secret/dependency monitoring)

- **Updated `ci-pass` gate**: Now checks `secrets-check` and `security` as unconditional jobs; treats `schema-migration` as conditional (skipped when Neon key unavailable, not failed)

## Implementation Details

- Dependency review allowlist mirrors existing `pnpm-workspace.yaml` audit config to avoid re-flagging reviewed CVEs
- Gitleaks runs with full git history (`fetch-depth: 0`) to scan the PR's commit range
- Egress policy set to `audit` mode with documented rollout path: after observing network logs at `app.stepsecurity.io`, flip to `block` with verified allowlist
- `ci-pass` job logic updated to accept `skipped` result for conditional jobs while requiring `success` for unconditional ones

https://claude.ai/code/session_01SswEZQkmNAMnqgdpYHVore