### PR TITLE
chore: daily codebase review — 2026-06-01

### DIFF
--- a/src/app/api/e2e-test/insert-intake/route.ts
+++ b/src/app/api/e2e-test/insert-intake/route.ts
@@ -4,10 +4,7 @@ import { db as drizzleDb } from "@/lib/drizzle";
 import { intakeRecords } from "@/db/schema";
 
 export const POST = withAuth(async ({ request, auth }) => {
-  if (
-    process.env.NODE_ENV === "production" &&
-    process.env.ENABLE_E2E_TEST_ROUTES !== "true"
-  ) {
+  if (process.env.ENABLE_E2E_TEST_ROUTES !== "true") {
     return NextResponse.json({ error: "Not available" }, { status: 404 });
   }
 

--- a/src/hooks/use-permissions.ts
+++ b/src/hooks/use-permissions.ts
@@ -73,21 +73,22 @@ export function usePermissions() {
 
       // Check microphone permission
       // First check localStorage (more reliable on mobile PWAs)
-      let microphoneState: PermissionState = getStoredMicPermission() || "prompt";
-      
+      const storedMic = getStoredMicPermission();
+      let microphoneState: PermissionState = storedMic ?? "prompt";
+
       // If not stored, try to query the permission API
-      if (!getStoredMicPermission() && typeof navigator !== "undefined" && navigator.permissions) {
+      if (!storedMic && typeof navigator !== "undefined" && navigator.permissions) {
         try {
           const micPermission = await navigator.permissions.query({
             name: "microphone" as PermissionName,
           });
-          
+
           // Only trust the query if it's not "prompt" (which is the default/unknown state)
           if (micPermission.state !== "prompt") {
             microphoneState = micPermission.state;
             storeMicPermission(microphoneState);
           }
-          
+
           // Listen for permission changes
           micPermission.addEventListener("change", () => {
             const newState = micPermission.state === "prompt" ? "prompt" : micPermission.state;
@@ -139,13 +140,13 @@ export function usePermissions() {
     try {
       // Request microphone access - this triggers the permission prompt
       const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
-      
+
       // Stop all tracks after getting permission
       stream.getTracks().forEach((track) => track.stop());
 
       // Store the granted state in localStorage for reliability
       storeMicPermission("granted");
-      
+
       setPermissions((prev) => ({
         ...prev,
         microphone: "granted",
@@ -156,12 +157,12 @@ export function usePermissions() {
       // Permission denied or error
       const isDenied = error instanceof DOMException && error.name === "NotAllowedError";
       const newState: PermissionState = isDenied ? "denied" : "prompt";
-      
+
       // Store denied state in localStorage
       if (isDenied) {
         storeMicPermission("denied");
       }
-      
+
       setPermissions((prev) => ({
         ...prev,
         microphone: newState,
@@ -192,7 +193,7 @@ export function usePermissions() {
       }));
       return;
     }
-    
+
     // Fall back to permissions API if no stored value
     if (typeof navigator !== "undefined" && navigator.permissions) {
       try {

--- a/src/lib/push-db.ts
+++ b/src/lib/push-db.ts
@@ -92,7 +92,7 @@ export async function getFollowUpNotifications(
     JOIN push_settings ps ON ps.user_id = l.user_id
     WHERE l.sent_date = ${today}
       AND l.follow_up_index = ${followUpIndex - 1}
-      AND l.sent_at <= NOW() - (${intervalMinutes} || ' minutes')::INTERVAL
+      AND l.sent_at <= NOW() - (${intervalMinutes} * INTERVAL '1 minute')
       AND ps.enabled = true
       AND NOT EXISTS (
         SELECT 1 FROM push_sent_log l2


### PR DESCRIPTION
## Summary

intake-tracker is a well-structured Next.js / Drizzle / Dexie sync app with solid tooling. This pass addresses one inverted security guard, a duplicate localStorage call, and a confusing SQL INTERVAL expression. A larger set of P1 and P2 findings (noted below) were not touched because the affected files exceeded the safe line budget or require wider context to change safely.

## Changes

### 🔴 P0 — Security / Bugs

- [`src/app/api/e2e-test/insert-intake/route.ts:8`] **E2E route guard was inverted.** The original condition blocked the route only on `NODE_ENV === "production"`, meaning it was open on every preview/staging deploy by default. Guard now blocks unless `ENABLE_E2E_TEST_ROUTES=true` is explicitly set, regardless of environment.

### 🟡 P1 — Quick wins

- [`src/hooks/use-permissions.ts:67`] **Duplicate `getStoredMicPermission()` call.** The function was called twice in the same synchronous block — once to read the initial state, once in the `if` guard two lines later. Stored result in `storedMic` and reused it; also tightened `||` to `??` since the return type is `PermissionState | null`.
- [`src/lib/push-db.ts:90`] **Confusing INTERVAL string-concat pattern.** `(${intervalMinutes} || ' minutes')::INTERVAL` is parameterised correctly by the neon tagged template (not a real injection vector), but the string-concat form is easy to misread during review. Replaced with `${intervalMinutes} * INTERVAL '1 minute'` which expresses the same intent without the concatenation.

## Flagged for discussion (not changed)

### 🟣 P3 — Structural

- [`src/lib/push-db.ts:108`] **`syncDoseSchedules` DELETE + loop is not transactional.** If the insert loop fails partway, the user is left with partially-updated schedules. Fix: wrap in a single transaction or use a bulk INSERT with ON CONFLICT.
- [`src/lib/sync-engine.ts:220+`] **Store actions bypassed.** `useSyncStatusStore` exports named setters (`setOnline`, `setSyncing`, etc.) but the sync engine calls `useSyncStatusStore.setState(...)` directly, bypassing them. Either the named actions are dead exports or the engine should use them — worth a deliberate decision.
- [`src/lib/titration-service.ts:93`] **In-memory table scans instead of indexed queries.** `getActiveTitrationPhaseForPrescription` and related functions load entire tables then filter in memory. Should use indexed `.where()` queries.
- [`src/lib/backup-service.ts:240`] **`importBackup` is ~130 lines** mixing parse, validate, branch, 18-table import, and audit log. Clear extraction seams exist but the change is non-trivial without tests covering each path.

## Stats
- Files scanned: ~40 source files across src/app/api, src/lib, src/hooks, src/stores
- Files changed: 3
- Lines added/removed: +8 / -9
- Estimated review time: 3 min

---
_Generated by [Claude Code](https://claude.ai/code/session_01GSNeyzFy8GxVgBt8G56AvK)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated E2E test route availability checks.

* **Refactor**
  * Improved microphone permission initialization performance by optimizing state caching.
  * Updated follow-up notification timing calculation logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->