### PR TITLE
feat: add data & account deletion flows with time-framed record wipe

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,6 +80,7 @@
     "react": "^19.2.6",
     "react-dom": "^19.2.6",
     "recharts": "2.15.4",
+    "server-only": "^0.0.1",
     "simple-statistics": "^7.8.8",
     "tailwind-merge": "^2.5.4",
     "tailwindcss-animate": "^1.0.7",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -164,6 +164,9 @@ importers:
       recharts:
         specifier: 2.15.4
         version: 2.15.4(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      server-only:
+        specifier: ^0.0.1
+        version: 0.0.1
       simple-statistics:
         specifier: ^7.8.8
         version: 7.8.8
@@ -6279,6 +6282,9 @@ packages:
   serve-static@2.2.1:
     resolution: {integrity: sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==}
     engines: {node: '>= 18'}
+
+  server-only@0.0.1:
+    resolution: {integrity: sha512-qepMx2JxAa5jjfzxG79yPPq+8BuFToHd1hm7kI+Z4zAq1ftQiP7HcxMhDDItrbtwVeLg/cY2JnKnrcFkmiswNA==}
 
   serwist@9.5.11:
     resolution: {integrity: sha512-Bq6uwJFd4ET60BWI77v3VbazKHv6k7lECOiiCFwKyBu/slaCn0GHJ5L5RfsuJUKrnbD9lYUCDo6sqaKRM5M2vA==}
@@ -13062,6 +13068,8 @@ snapshots:
       send: 1.2.1
     transitivePeerDependencies:
       - supports-color
+
+  server-only@0.0.1: {}
 
   serwist@9.5.11(browserslist@4.28.2)(typescript@5.9.3):
     dependencies:

--- a/src/app/api/account/delete/route.test.ts
+++ b/src/app/api/account/delete/route.test.ts
@@ -1,0 +1,67 @@
+/**
+ * Tests for POST /api/account/delete — scrubs all server-side data for the
+ * authenticated user. withAuth is mocked as a pass-through; the
+ * deleteAllUserData helper is mocked so we assert the route contract only.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+const mockDeleteAllUserData = vi.fn();
+vi.mock("@/lib/user-data-deletion", () => ({
+  deleteAllUserData: (...args: unknown[]) => mockDeleteAllUserData(...args),
+}));
+
+vi.mock("@/lib/auth-middleware", () => ({
+  withAuth:
+    (handler: (ctx: { request: NextRequest; auth: unknown }) => Promise<Response>) =>
+    async (request: NextRequest) =>
+      handler({
+        request,
+        auth: { success: true, userId: "user-test", email: "test@example.test" },
+      }),
+}));
+
+function makeRequest(): NextRequest {
+  return new NextRequest("http://localhost/api/account/delete", {
+    method: "POST",
+  });
+}
+
+async function callDelete() {
+  const { POST } = await import("@/app/api/account/delete/route");
+  return POST(makeRequest());
+}
+
+describe("POST /api/account/delete", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it("scrubs the authenticated user's data and returns the counts", async () => {
+    mockDeleteAllUserData.mockResolvedValue({
+      intakeRecords: 3,
+      pushSubscriptions: 1,
+      userApiKeys: 1,
+    });
+
+    const res = await callDelete();
+    expect(res.status).toBe(200);
+
+    const body = await res.json();
+    expect(mockDeleteAllUserData).toHaveBeenCalledWith("user-test");
+    expect(body.deleted).toEqual({
+      intakeRecords: 3,
+      pushSubscriptions: 1,
+      userApiKeys: 1,
+    });
+  });
+
+  it("returns 500 when deletion fails", async () => {
+    mockDeleteAllUserData.mockRejectedValue(new Error("db down"));
+
+    const res = await callDelete();
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(body.error).toMatch(/failed/i);
+  });
+});

--- a/src/app/api/account/delete/route.ts
+++ b/src/app/api/account/delete/route.ts
@@ -1,0 +1,34 @@
+/**
+ * POST /api/account/delete — scrub ALL server-side data for the authenticated
+ * user.
+ *
+ * Backs the "delete my account" flow. Deletes every user-scoped row across the
+ * synced data tables, push tables, AI keys/usage, key shares, async insight
+ * jobs, and MCP tables. The Neon Auth login identity itself is deleted
+ * client-side via the auth SDK (`/delete-user`) AFTER this succeeds — data must
+ * be scrubbed while the session is still valid.
+ */
+import { NextResponse } from "next/server";
+import { withAuth } from "@/lib/auth-middleware";
+import { deleteAllUserData } from "@/lib/user-data-deletion";
+
+export const maxDuration = 60;
+
+export const POST = withAuth(async ({ auth }) => {
+  try {
+    const deleted = await deleteAllUserData(auth.userId!);
+    console.log(
+      "[account/delete] Scrubbed user data: %s",
+      Object.entries(deleted)
+        .map(([t, n]) => `${t}=${n}`)
+        .join(", "),
+    );
+    return NextResponse.json({ deleted });
+  } catch (error) {
+    console.error("[account/delete] Error:", error);
+    return NextResponse.json(
+      { error: "Failed to delete account data" },
+      { status: 500 },
+    );
+  }
+});

--- a/src/app/api/sync/wipe/route.test.ts
+++ b/src/app/api/sync/wipe/route.test.ts
@@ -1,0 +1,55 @@
+/**
+ * Tests for POST /api/sync/wipe — deletes the authenticated user's cloud data
+ * mirror (synced tables + push subscriptions). withAuth is mocked as a
+ * pass-through; the wipeCloudData helper is mocked.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+const mockWipeCloudData = vi.fn();
+vi.mock("@/lib/user-data-deletion", () => ({
+  wipeCloudData: (...args: unknown[]) => mockWipeCloudData(...args),
+}));
+
+vi.mock("@/lib/auth-middleware", () => ({
+  withAuth:
+    (handler: (ctx: { request: NextRequest; auth: unknown }) => Promise<Response>) =>
+    async (request: NextRequest) =>
+      handler({
+        request,
+        auth: { success: true, userId: "user-test", email: "test@example.test" },
+      }),
+}));
+
+function makeRequest(): NextRequest {
+  return new NextRequest("http://localhost/api/sync/wipe", { method: "POST" });
+}
+
+async function callWipe() {
+  const { POST } = await import("@/app/api/sync/wipe/route");
+  return POST(makeRequest());
+}
+
+describe("POST /api/sync/wipe", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it("wipes the cloud copy for the authenticated user and returns counts", async () => {
+    mockWipeCloudData.mockResolvedValue({ intakeRecords: 5, pushSubscriptions: 1 });
+
+    const res = await callWipe();
+    expect(res.status).toBe(200);
+
+    const body = await res.json();
+    expect(mockWipeCloudData).toHaveBeenCalledWith("user-test");
+    expect(body.deleted).toEqual({ intakeRecords: 5, pushSubscriptions: 1 });
+  });
+
+  it("returns 500 when the wipe fails", async () => {
+    mockWipeCloudData.mockRejectedValue(new Error("db down"));
+
+    const res = await callWipe();
+    expect(res.status).toBe(500);
+  });
+});

--- a/src/app/api/sync/wipe/route.ts
+++ b/src/app/api/sync/wipe/route.ts
@@ -1,0 +1,32 @@
+/**
+ * POST /api/sync/wipe — delete the authenticated user's cloud data mirror.
+ *
+ * Backs the "switch back to local-only" flow: the client first pulls every
+ * server row down into IndexedDB, then calls this to remove the cloud copy
+ * (synced tables + push subscriptions) while keeping the account, login
+ * identity, and AI keys intact. Local data is untouched — it lives on-device.
+ */
+import { NextResponse } from "next/server";
+import { withAuth } from "@/lib/auth-middleware";
+import { wipeCloudData } from "@/lib/user-data-deletion";
+
+export const maxDuration = 60;
+
+export const POST = withAuth(async ({ auth }) => {
+  try {
+    const deleted = await wipeCloudData(auth.userId!);
+    console.log(
+      "[sync/wipe] Wiped cloud data: %s",
+      Object.entries(deleted)
+        .map(([t, n]) => `${t}=${n}`)
+        .join(", "),
+    );
+    return NextResponse.json({ deleted });
+  } catch (error) {
+    console.error("[sync/wipe] Error:", error);
+    return NextResponse.json(
+      { error: "Failed to wipe cloud data" },
+      { status: 500 },
+    );
+  }
+});

--- a/src/app/data-deletion/page.tsx
+++ b/src/app/data-deletion/page.tsx
@@ -1,0 +1,143 @@
+import type { Metadata } from "next";
+import type { ReactNode } from "react";
+import Link from "next/link";
+import { ArrowLeft, Database, UserX } from "lucide-react";
+
+export const metadata: Metadata = {
+  title: "Data & Account Deletion — Intake Tracker",
+  description:
+    "How to delete your data or your entire account in Intake Tracker, what is removed, and what is kept.",
+};
+
+// Public, unauthenticated instructions page that backs the Google Play Data
+// Safety form's "Delete account URL" (#account) and "Delete data URL" (#data)
+// fields. Keep the steps here in sync with the in-app Settings flows.
+
+const CONTACT_EMAIL = "meowzit.eth@gmail.com";
+
+function Section({
+  id,
+  icon,
+  title,
+  children,
+}: {
+  id: string;
+  icon: ReactNode;
+  title: string;
+  children: ReactNode;
+}) {
+  return (
+    <section id={id} className="scroll-mt-6 space-y-3">
+      <h2 className="flex items-center gap-2 text-base font-semibold text-foreground">
+        {icon}
+        {title}
+      </h2>
+      <div className="space-y-3 text-sm leading-relaxed text-muted-foreground">
+        {children}
+      </div>
+    </section>
+  );
+}
+
+export default function DataDeletionPage() {
+  return (
+    <div className="space-y-6 pb-16 pt-2">
+      <div>
+        <Link
+          href="/"
+          className="mb-3 inline-flex items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground"
+        >
+          <ArrowLeft className="h-4 w-4" />
+          Back to app
+        </Link>
+        <h1 className="text-xl font-bold text-foreground">
+          Data &amp; Account Deletion
+        </h1>
+        <p className="mt-1 text-sm text-muted-foreground">
+          Intake Tracker gives you full control over your data. You can delete
+          some of your data, all of it, or your entire account.
+        </p>
+      </div>
+
+      {/* ---- Delete some or all of your data, keep your account ---- */}
+      <Section id="data" icon={<Database className="h-5 w-5 text-sky-600" />} title="Delete your data">
+        <p>
+          To delete your logged data without deleting your account, in the app:
+        </p>
+        <ol className="ml-4 list-decimal space-y-1.5">
+          <li>
+            Open <strong>Settings → Storage</strong>.
+          </li>
+          <li>
+            Under <strong>Delete data</strong>, choose a time frame — for
+            example &ldquo;Older than 90 days&rdquo; or &ldquo;All data&rdquo; —
+            and confirm.
+          </li>
+        </ol>
+        <p>
+          <strong>What is deleted:</strong> the health and medication records
+          you logged within the time frame you choose (hydration, nutrition,
+          weight, blood pressure, bathroom logs, substances, medications, dose
+          history, and notes). In cloud-sync mode the matching cloud copy is
+          deleted too.
+        </p>
+        <p>
+          <strong>What is kept:</strong> your account and login, and any records
+          outside the selected time frame.
+        </p>
+        <p>
+          You can also switch back to local-only storage
+          (<strong>Settings → Storage → Switch to Local only</strong>), which
+          downloads your data to your device and then deletes the entire cloud
+          copy.
+        </p>
+      </Section>
+
+      {/* ---- Delete the whole account ---- */}
+      <Section id="account" icon={<UserX className="h-5 w-5 text-red-600" />} title="Delete your account">
+        <p>To permanently delete your account, in the app:</p>
+        <ol className="ml-4 list-decimal space-y-1.5">
+          <li>
+            Open <strong>Settings → Account</strong>.
+          </li>
+          <li>
+            Tap <strong>Delete Account</strong>, type <strong>DELETE</strong> to
+            confirm, and submit.
+          </li>
+        </ol>
+        <p>
+          <strong>What is deleted:</strong> all of your data on our servers
+          (every health and medication record, your medical profile, AI usage
+          and saved keys, notification subscriptions) and your login identity,
+          so the account no longer exists.
+        </p>
+        <p>
+          <strong>What is kept:</strong> the copy of your data already on your
+          device — the app switches to local-only mode and signs you out. To
+          remove that too, use <strong>Delete data → All data</strong> first, or
+          uninstall the app.
+        </p>
+      </Section>
+
+      {/* ---- Retention + contact ---- */}
+      <Section id="retention" icon={<Database className="h-5 w-5 text-muted-foreground" />} title="Timing & retention">
+        <p>
+          Deletions take effect immediately in our live database. Routine
+          encrypted operational backups are rotated and purged within 30 days,
+          after which no copy of the deleted data remains on our servers.
+        </p>
+        <p>
+          If you can&apos;t access the app and want your account or data deleted,
+          email{" "}
+          <a
+            className="underline underline-offset-2"
+            href={`mailto:${CONTACT_EMAIL}?subject=Delete%20my%20Intake%20Tracker%20data`}
+          >
+            {CONTACT_EMAIL}
+          </a>{" "}
+          from your account email and we&apos;ll process the request.
+        </p>
+      </Section>
+    </div>
+  );
+}

--- a/src/components/settings/account-section.tsx
+++ b/src/components/settings/account-section.tsx
@@ -1,14 +1,17 @@
 "use client";
 
+import { useState } from "react";
 import { useRouter } from "next/navigation";
 import { Button } from "@/components/ui/button";
-import { Loader2, LogIn, LogOut, Sparkles, Bell, CloudUpload } from "lucide-react";
+import { Loader2, LogIn, LogOut, Sparkles, Bell, CloudUpload, Trash2 } from "lucide-react";
 import { useAuth } from "@/components/auth-guard";
 import { handleSignOut } from "@/lib/sign-out";
+import { DeleteAccountDialog } from "@/components/settings/delete-account-dialog";
 
 export function AccountSection() {
   const { ready, authenticated, user } = useAuth();
   const router = useRouter();
+  const [deleteOpen, setDeleteOpen] = useState(false);
 
   if (!ready) {
     return (
@@ -70,6 +73,23 @@ export function AccountSection() {
         <LogOut className="w-4 h-4" />
         Sign Out
       </Button>
+
+      <div className="pt-2 mt-1 border-t">
+        <Button
+          variant="ghost"
+          className="w-full justify-start gap-2 text-muted-foreground hover:text-red-700 hover:bg-red-50 dark:hover:bg-red-950/30"
+          onClick={() => setDeleteOpen(true)}
+        >
+          <Trash2 className="w-4 h-4" />
+          Delete Account
+        </Button>
+        <p className="px-3 pt-1 text-xs text-muted-foreground">
+          Erases all your data from our servers and removes your login. The copy
+          on this device is kept.
+        </p>
+      </div>
+
+      <DeleteAccountDialog open={deleteOpen} onOpenChange={setDeleteOpen} />
     </div>
   );
 }

--- a/src/components/settings/delete-account-dialog.tsx
+++ b/src/components/settings/delete-account-dialog.tsx
@@ -1,0 +1,120 @@
+"use client";
+
+import { useState } from "react";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Loader2, Trash2 } from "lucide-react";
+import { useToast } from "@/hooks/use-toast";
+import { useAccountActions } from "@/hooks/use-account-actions";
+
+const CONFIRM_PHRASE = "DELETE";
+
+/**
+ * Type-to-confirm dialog for permanent account deletion. On success
+ * `deleteAccount` navigates away to /auth, so this component only has to handle
+ * the failure path (re-enable the form + toast).
+ */
+export function DeleteAccountDialog({
+  open,
+  onOpenChange,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}) {
+  const [confirmText, setConfirmText] = useState("");
+  const [busy, setBusy] = useState(false);
+  const { toast } = useToast();
+  const { deleteAccount } = useAccountActions();
+
+  const canDelete =
+    confirmText.trim().toUpperCase() === CONFIRM_PHRASE && !busy;
+
+  async function handleDelete() {
+    if (!canDelete) return;
+    setBusy(true);
+    try {
+      await deleteAccount(); // redirects to /auth on success
+    } catch {
+      setBusy(false);
+      toast({
+        variant: "destructive",
+        title: "Couldn't delete account",
+        description:
+          "Something went wrong and your account was not fully deleted. Please try again.",
+      });
+    }
+  }
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(next) => {
+        if (busy) return; // don't let the user dismiss mid-delete
+        setConfirmText("");
+        onOpenChange(next);
+      }}
+    >
+      <DialogContent className="sm:max-w-sm">
+        <DialogHeader>
+          <DialogTitle>Delete account</DialogTitle>
+          <DialogDescription>
+            This permanently deletes your account and erases all of your data
+            from our servers, including your login. This can&apos;t be undone.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-3">
+          <p className="text-sm text-muted-foreground">
+            The copy on <span className="font-medium">this device</span> is
+            kept — the app switches to local-only mode and signs you out.
+          </p>
+          <div className="space-y-1.5">
+            <Label htmlFor="confirm-delete">
+              Type {CONFIRM_PHRASE} to confirm
+            </Label>
+            <Input
+              id="confirm-delete"
+              value={confirmText}
+              onChange={(e) => setConfirmText(e.target.value)}
+              autoComplete="off"
+              disabled={busy}
+              placeholder={CONFIRM_PHRASE}
+            />
+          </div>
+        </div>
+
+        <DialogFooter className="gap-2 sm:gap-2">
+          <Button
+            variant="outline"
+            onClick={() => onOpenChange(false)}
+            disabled={busy}
+          >
+            Cancel
+          </Button>
+          <Button
+            variant="destructive"
+            className="gap-2"
+            onClick={handleDelete}
+            disabled={!canDelete}
+          >
+            {busy ? (
+              <Loader2 className="w-4 h-4 animate-spin" />
+            ) : (
+              <Trash2 className="w-4 h-4" />
+            )}
+            {busy ? "Deleting…" : "Delete account"}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/settings/delete-account-dialog.tsx
+++ b/src/components/settings/delete-account-dialog.tsx
@@ -43,13 +43,15 @@ export function DeleteAccountDialog({
     setBusy(true);
     try {
       await deleteAccount(); // redirects to /auth on success
-    } catch {
+    } catch (e) {
       setBusy(false);
       toast({
         variant: "destructive",
         title: "Couldn't delete account",
         description:
-          "Something went wrong and your account was not fully deleted. Please try again.",
+          e instanceof Error
+            ? e.message
+            : "Something went wrong and your account was not fully deleted. Please try again.",
       });
     }
   }

--- a/src/components/settings/delete-data-controls.tsx
+++ b/src/components/settings/delete-data-controls.tsx
@@ -13,9 +13,12 @@ import {
   AlertDialogHeader,
   AlertDialogTitle,
 } from "@/components/ui/alert-dialog";
-import { useDeleteDataInRange, type DeleteRange } from "@/hooks/use-data-deletion";
-
-const DAY_MS = 24 * 60 * 60 * 1000;
+import {
+  useDeleteDataInRange,
+  olderThanDays,
+  ALL_TIME,
+  type DeleteRange,
+} from "@/hooks/use-data-deletion";
 
 interface Preset {
   label: string;
@@ -28,22 +31,22 @@ interface Preset {
 const PRESETS: Preset[] = [
   {
     label: "Older than 1 year",
-    range: () => ({ from: null, to: Date.now() - 365 * DAY_MS }),
+    range: () => olderThanDays(365),
     describe: "all records logged more than a year ago",
   },
   {
     label: "Older than 90 days",
-    range: () => ({ from: null, to: Date.now() - 90 * DAY_MS }),
+    range: () => olderThanDays(90),
     describe: "all records logged more than 90 days ago",
   },
   {
     label: "Older than 30 days",
-    range: () => ({ from: null, to: Date.now() - 30 * DAY_MS }),
+    range: () => olderThanDays(30),
     describe: "all records logged more than 30 days ago",
   },
   {
     label: "All data",
-    range: () => ({ from: null, to: null }),
+    range: () => ALL_TIME,
     describe: "every record you've logged",
   },
 ];

--- a/src/components/settings/delete-data-controls.tsx
+++ b/src/components/settings/delete-data-controls.tsx
@@ -1,0 +1,127 @@
+"use client";
+
+import { useState } from "react";
+import { Trash2, Loader2 } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+import { useDeleteDataInRange, type DeleteRange } from "@/hooks/use-data-deletion";
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+interface Preset {
+  label: string;
+  /** Builds the time range for this preset, evaluated at click time. */
+  range: () => DeleteRange;
+  /** Human description used in the confirmation dialog. */
+  describe: string;
+}
+
+const PRESETS: Preset[] = [
+  {
+    label: "Older than 1 year",
+    range: () => ({ from: null, to: Date.now() - 365 * DAY_MS }),
+    describe: "all records logged more than a year ago",
+  },
+  {
+    label: "Older than 90 days",
+    range: () => ({ from: null, to: Date.now() - 90 * DAY_MS }),
+    describe: "all records logged more than 90 days ago",
+  },
+  {
+    label: "Older than 30 days",
+    range: () => ({ from: null, to: Date.now() - 30 * DAY_MS }),
+    describe: "all records logged more than 30 days ago",
+  },
+  {
+    label: "All data",
+    range: () => ({ from: null, to: null }),
+    describe: "every record you've logged",
+  },
+];
+
+/**
+ * "Delete data" controls for the Storage settings section: wipe logged records
+ * by time frame. Deletions are tombstoned and synced, so in cloud-sync mode
+ * they also remove the cloud copy.
+ */
+export function DeleteDataControls() {
+  const [pending, setPending] = useState<Preset | null>(null);
+  const mutation = useDeleteDataInRange();
+
+  function confirmDelete() {
+    if (!pending) return;
+    const preset = pending;
+    mutation.mutate(preset.range(), {
+      onSettled: () => setPending(null),
+    });
+  }
+
+  return (
+    <div className="space-y-2">
+      <div className="flex items-center gap-2">
+        <Trash2 className="w-4 h-4 text-muted-foreground" />
+        <p className="text-sm font-medium">Delete data</p>
+      </div>
+      <p className="text-xs text-muted-foreground">
+        Permanently delete logged records by time frame. In cloud-sync mode this
+        also removes the cloud copy.
+      </p>
+      <div className="flex flex-wrap gap-2">
+        {PRESETS.map((preset) => (
+          <Button
+            key={preset.label}
+            variant="outline"
+            size="sm"
+            disabled={mutation.isPending}
+            onClick={() => setPending(preset)}
+          >
+            {preset.label}
+          </Button>
+        ))}
+      </div>
+
+      <AlertDialog
+        open={pending !== null}
+        onOpenChange={(next) => {
+          if (!next && !mutation.isPending) setPending(null);
+        }}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Delete data?</AlertDialogTitle>
+            <AlertDialogDescription>
+              This permanently deletes {pending?.describe}. This can&apos;t be
+              undone.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel disabled={mutation.isPending}>
+              Cancel
+            </AlertDialogCancel>
+            <AlertDialogAction
+              onClick={(e) => {
+                e.preventDefault();
+                confirmDelete();
+              }}
+              disabled={mutation.isPending}
+            >
+              {mutation.isPending ? (
+                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+              ) : null}
+              {mutation.isPending ? "Deleting…" : "Delete"}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </div>
+  );
+}

--- a/src/components/settings/storage-info-section.tsx
+++ b/src/components/settings/storage-info-section.tsx
@@ -41,8 +41,12 @@ export function StorageInfoSection() {
   const [switchOpen, setSwitchOpen] = useState(false);
   const [switching, setSwitching] = useState(false);
   const { switchToLocalAndWipeCloud } = useAccountActions();
+  const canSwitchToLocal = initialSyncComplete && isOnline && !switching;
 
   async function handleSwitchToLocal() {
+    // Preconditions can flip after the dialog opens (e.g. going offline);
+    // re-check before starting the (destructive) wipe.
+    if (!initialSyncComplete || !isOnline || switching) return;
     setSwitching(true);
     try {
       await switchToLocalAndWipeCloud();
@@ -241,7 +245,7 @@ export function StorageInfoSection() {
                 e.preventDefault();
                 void handleSwitchToLocal();
               }}
-              disabled={switching}
+              disabled={!canSwitchToLocal}
             >
               {switching ? (
                 <Loader2 className="mr-2 h-4 w-4 animate-spin" />

--- a/src/components/settings/storage-info-section.tsx
+++ b/src/components/settings/storage-info-section.tsx
@@ -2,19 +2,33 @@
 
 import { useState, useEffect } from "react";
 import { useRouter } from "next/navigation";
-import { HardDrive, Cloud, CloudOff, Upload, LogIn, CheckCircle2, Loader2 } from "lucide-react";
+import { HardDrive, Cloud, CloudOff, Upload, LogIn, CheckCircle2, Loader2, Download } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
 import { useStorageInfo } from "@/hooks/use-storage-info";
 import { useSettingsStore } from "@/stores/settings-store";
 import { useSyncStatusStore } from "@/stores/sync-status-store";
 import { useAuth } from "@/components/auth-guard";
+import { useToast } from "@/hooks/use-toast";
+import { useAccountActions } from "@/hooks/use-account-actions";
 // eslint-disable-next-line no-restricted-imports
 import { checkInterruptedMigration } from "@/lib/migration-service";
 import { MigrationWizard } from "@/components/migration/migration-wizard";
+import { DeleteDataControls } from "@/components/settings/delete-data-controls";
 
 export function StorageInfoSection() {
   const router = useRouter();
+  const { toast } = useToast();
   const { ready, authenticated } = useAuth();
   const { storageUsage, storageQuota, totalRecords } = useStorageInfo();
   const storageMode = useSettingsStore((s) => s.storageMode);
@@ -24,6 +38,31 @@ export function StorageInfoSection() {
   const [wizardOpen, setWizardOpen] = useState(false);
   const [resumeMode, setResumeMode] = useState(false);
   const [hasInterrupted, setHasInterrupted] = useState(false);
+  const [switchOpen, setSwitchOpen] = useState(false);
+  const [switching, setSwitching] = useState(false);
+  const { switchToLocalAndWipeCloud } = useAccountActions();
+
+  async function handleSwitchToLocal() {
+    setSwitching(true);
+    try {
+      await switchToLocalAndWipeCloud();
+      setSwitchOpen(false);
+      toast({
+        title: "Switched to local-only",
+        description:
+          "Your data was downloaded to this device and the cloud copy was deleted.",
+      });
+    } catch {
+      toast({
+        variant: "destructive",
+        title: "Couldn't switch to local",
+        description:
+          "Your data was not changed. Check your connection and try again.",
+      });
+    } finally {
+      setSwitching(false);
+    }
+  }
 
   useEffect(() => {
     setHasInterrupted(checkInterruptedMigration());
@@ -84,6 +123,26 @@ export function StorageInfoSection() {
           <p className="text-xs text-muted-foreground">
             Last synced {new Date(lastPushedAt).toLocaleString()}
           </p>
+        )}
+
+        {storageMode === "cloud-sync" && (
+          <div className="space-y-1">
+            <Button
+              variant="outline"
+              size="sm"
+              className="gap-2"
+              disabled={!initialSyncComplete || !isOnline}
+              onClick={() => setSwitchOpen(true)}
+            >
+              <Download className="h-3 w-3" />
+              Switch to Local only
+            </Button>
+            <p className="text-xs text-muted-foreground">
+              {initialSyncComplete
+                ? "Keeps a full copy on this device and deletes the cloud copy."
+                : "Available once your full data has finished downloading."}
+            </p>
+          </div>
         )}
 
         {storageMode === "local" && ready && !authenticated && (
@@ -147,6 +206,10 @@ export function StorageInfoSection() {
             </p>
           </div>
         )}
+
+        <div className="pt-2 border-t">
+          <DeleteDataControls />
+        </div>
       </div>
 
       <MigrationWizard
@@ -154,6 +217,40 @@ export function StorageInfoSection() {
         onOpenChange={setWizardOpen}
         resume={resumeMode}
       />
+
+      <AlertDialog
+        open={switchOpen}
+        onOpenChange={(next) => {
+          if (!switching) setSwitchOpen(next);
+        }}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Switch to local-only?</AlertDialogTitle>
+            <AlertDialogDescription>
+              Your full dataset will be downloaded to this device, then the copy
+              stored in the cloud will be permanently deleted. Your account and
+              login stay active, and the data on this device is kept. You can
+              re-enable cloud sync later.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel disabled={switching}>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={(e) => {
+                e.preventDefault();
+                void handleSwitchToLocal();
+              }}
+              disabled={switching}
+            >
+              {switching ? (
+                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+              ) : null}
+              {switching ? "Switching…" : "Download & switch"}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
     </div>
   );
 }

--- a/src/hooks/use-account-actions.ts
+++ b/src/hooks/use-account-actions.ts
@@ -1,0 +1,17 @@
+"use client";
+
+import {
+  deleteAccount,
+  switchToLocalAndWipeCloud,
+} from "@/lib/account-service";
+
+/**
+ * Imperative account/storage lifecycle actions, exposed through a hook so
+ * components don't import the service layer directly (enforced by the
+ * no-restricted-imports lint rule). These are multi-step flows that navigate
+ * away on success, so they're plain async callbacks rather than React Query
+ * mutations.
+ */
+export function useAccountActions() {
+  return { deleteAccount, switchToLocalAndWipeCloud };
+}

--- a/src/hooks/use-data-deletion.ts
+++ b/src/hooks/use-data-deletion.ts
@@ -1,14 +1,18 @@
 "use client";
 
-import { useMutation } from "@tanstack/react-query";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
 import {
   deleteRecordsInRange,
+  olderThanDays,
+  ALL_TIME,
   type DeleteRange,
 } from "@/lib/data-deletion-service";
-import { queryClient } from "@/lib/query-client";
 import { unwrap } from "@/lib/service-result";
 import { useToast } from "@/hooks/use-toast";
 
+// Re-exported so components can build deletion presets without importing the
+// service layer directly (no-restricted-imports).
+export { olderThanDays, ALL_TIME };
 export type { DeleteRange };
 
 /**
@@ -17,6 +21,7 @@ export type { DeleteRange };
  */
 export function useDeleteDataInRange() {
   const { toast } = useToast();
+  const queryClient = useQueryClient();
   return useMutation({
     mutationFn: async (range: DeleteRange) =>
       unwrap(await deleteRecordsInRange(range)),

--- a/src/hooks/use-data-deletion.ts
+++ b/src/hooks/use-data-deletion.ts
@@ -1,0 +1,39 @@
+"use client";
+
+import { useMutation } from "@tanstack/react-query";
+import {
+  deleteRecordsInRange,
+  type DeleteRange,
+} from "@/lib/data-deletion-service";
+import { queryClient } from "@/lib/query-client";
+import { unwrap } from "@/lib/service-result";
+import { useToast } from "@/hooks/use-toast";
+
+export type { DeleteRange };
+
+/**
+ * Mutation for time-framed deletion of logged records. Invalidates all queries
+ * on success so any open data view reflects the removal.
+ */
+export function useDeleteDataInRange() {
+  const { toast } = useToast();
+  return useMutation({
+    mutationFn: async (range: DeleteRange) =>
+      unwrap(await deleteRecordsInRange(range)),
+    onSuccess: (count: number) => {
+      queryClient.invalidateQueries();
+      toast({
+        title: "Data deleted",
+        description: `${count.toLocaleString()} record${count === 1 ? "" : "s"} deleted.`,
+        variant: "success",
+      });
+    },
+    onError: (error: Error) => {
+      toast({
+        title: "Error",
+        description: `Failed to delete data: ${error.message}`,
+        variant: "destructive",
+      });
+    },
+  });
+}

--- a/src/lib/account-service.ts
+++ b/src/lib/account-service.ts
@@ -1,0 +1,81 @@
+/**
+ * Account & storage-mode lifecycle actions that span the sync engine, the
+ * server, and Neon Auth. Kept out of the React layer so the multi-step flows
+ * stay testable.
+ *
+ * Two flows:
+ *   - `switchToLocalAndWipeCloud` — download everything, then delete the cloud
+ *     copy and drop to local-only. On-device data is preserved.
+ *   - `deleteAccount` — scrub all server data, delete the Neon Auth identity,
+ *     keep the on-device copy in local-only mode, and sign out.
+ */
+import { db } from "@/lib/db";
+import { apiFetch } from "@/lib/api-fetch";
+import { runPullCycle, stopEngine } from "@/lib/sync-engine";
+import { useSettingsStore } from "@/stores/settings-store";
+import { useSyncStatusStore } from "@/stores/sync-status-store";
+import { authClient } from "@/lib/auth-client";
+import { handleSignOut } from "@/lib/sign-out";
+
+/**
+ * Drop all local sync bookkeeping (pending op-log + pull cursors) and return to
+ * local-only mode. Does NOT touch the user's data tables — those stay on the
+ * device. Resetting the cursors means a future re-enable of cloud sync starts a
+ * fresh full pull rather than resuming against a now-empty server.
+ */
+async function severSyncLink(): Promise<void> {
+  await db._syncQueue.clear();
+  await db._syncMeta.clear();
+  useSyncStatusStore.setState({
+    initialSyncComplete: false,
+    isSyncing: false,
+    queueDepth: 0,
+    lastError: null,
+  });
+  useSettingsStore.getState().setStorageMode("local");
+}
+
+/**
+ * Switch from cloud-sync back to local-only, wiping the server copy.
+ *
+ * Order matters: we pull the full dataset down BEFORE deleting it server-side,
+ * and stop the engine BEFORE the wipe so the deletion can't round-trip back and
+ * erase the local rows.
+ */
+export async function switchToLocalAndWipeCloud(): Promise<void> {
+  // 1. Ensure IndexedDB holds a complete copy of the cloud dataset.
+  await runPullCycle();
+  // 2. Stop syncing so the upcoming server wipe doesn't propagate to local.
+  stopEngine();
+  // 3. Delete the cloud copy (synced tables + push subscriptions).
+  const res = await apiFetch("/api/sync/wipe", { method: "POST" });
+  if (!res.ok) {
+    throw new Error("Failed to wipe cloud data");
+  }
+  // 4. Local data stays; just sever the sync link and go local-only.
+  await severSyncLink();
+}
+
+/**
+ * Permanently delete the account: scrub all server data, delete the Neon Auth
+ * login identity, keep this device's local copy, then sign out.
+ */
+export async function deleteAccount(): Promise<void> {
+  // 1. Stop syncing before we touch the server.
+  stopEngine();
+  // 2. Scrub all server-side data while the session is still valid.
+  const res = await apiFetch("/api/account/delete", { method: "POST" });
+  if (!res.ok) {
+    throw new Error("Failed to delete account data");
+  }
+  // 3. Delete the Neon Auth identity. Best-effort: the data is already gone, so
+  //    even if identity removal needs a follow-up it won't leave records behind.
+  try {
+    await authClient.deleteUser({});
+  } catch {
+    // Swallow — sign-out below still ends the session locally.
+  }
+  // 4. Keep local data in local-only mode, then sign out and leave to /auth.
+  await severSyncLink();
+  await handleSignOut();
+}

--- a/src/lib/account-service.ts
+++ b/src/lib/account-service.ts
@@ -11,7 +11,7 @@
  */
 import { db } from "@/lib/db";
 import { apiFetch } from "@/lib/api-fetch";
-import { runPullCycle, stopEngine } from "@/lib/sync-engine";
+import { runPullCycle, stopEngine, startEngine } from "@/lib/sync-engine";
 import { useSettingsStore } from "@/stores/settings-store";
 import { useSyncStatusStore } from "@/stores/sync-status-store";
 import { authClient } from "@/lib/auth-client";
@@ -47,9 +47,18 @@ export async function switchToLocalAndWipeCloud(): Promise<void> {
   await runPullCycle();
   // 2. Stop syncing so the upcoming server wipe doesn't propagate to local.
   stopEngine();
-  // 3. Delete the cloud copy (synced tables + push subscriptions).
-  const res = await apiFetch("/api/sync/wipe", { method: "POST" });
+  // 3. Delete the cloud copy (synced tables + push subscriptions). If the wipe
+  //    fails, nothing was deleted — restore cloud-sync before surfacing the
+  //    error so the app isn't stranded with the engine stopped.
+  let res: Response;
+  try {
+    res = await apiFetch("/api/sync/wipe", { method: "POST" });
+  } catch (e) {
+    startEngine();
+    throw e;
+  }
   if (!res.ok) {
+    startEngine();
     throw new Error("Failed to wipe cloud data");
   }
   // 4. Local data stays; just sever the sync link and go local-only.
@@ -63,19 +72,42 @@ export async function switchToLocalAndWipeCloud(): Promise<void> {
 export async function deleteAccount(): Promise<void> {
   // 1. Stop syncing before we touch the server.
   stopEngine();
-  // 2. Scrub all server-side data while the session is still valid.
-  const res = await apiFetch("/api/account/delete", { method: "POST" });
+  // 2. Scrub all server-side data while the session is still valid. If this
+  //    fails, nothing was deleted — restore cloud-sync and surface the error.
+  let res: Response;
+  try {
+    res = await apiFetch("/api/account/delete", { method: "POST" });
+  } catch (e) {
+    startEngine();
+    throw e;
+  }
   if (!res.ok) {
+    startEngine();
     throw new Error("Failed to delete account data");
   }
-  // 3. Delete the Neon Auth identity. Best-effort: the data is already gone, so
-  //    even if identity removal needs a follow-up it won't leave records behind.
+  // Server data is now gone. Do NOT restart the sync engine past this point —
+  // cloud-sync would push the still-present local copy back up to the server.
+
+  // 3. Delete the Neon Auth login identity. If this fails, the data is already
+  //    scrubbed but the account still exists, so surface it as a failure (the
+  //    user stays signed in and can retry — re-running is idempotent) instead
+  //    of silently reporting success.
+  let deleteResult: Awaited<ReturnType<typeof authClient.deleteUser>> | undefined;
   try {
-    await authClient.deleteUser({});
+    deleteResult = await authClient.deleteUser({});
   } catch {
-    // Swallow — sign-out below still ends the session locally.
+    throw new Error(
+      "Your data was deleted, but removing your login failed. Please try again.",
+    );
   }
-  // 4. Keep local data in local-only mode, then sign out and leave to /auth.
+  if (deleteResult?.error) {
+    throw new Error(
+      deleteResult.error.message ??
+        "Your data was deleted, but removing your login failed. Please try again.",
+    );
+  }
+
+  // 4. Identity removed. Keep local data in local-only mode, then sign out.
   await severSyncLink();
   await handleSignOut();
 }

--- a/src/lib/data-deletion-service.ts
+++ b/src/lib/data-deletion-service.ts
@@ -1,0 +1,76 @@
+/**
+ * Time-framed deletion of the user's logged records.
+ *
+ * Backs the "Delete data" controls in the Storage settings section: the user
+ * can wipe records created within a time window (e.g. "older than 90 days" or
+ * everything). Records are soft-deleted (tombstoned) and enqueued for sync, so
+ * the deletion propagates to the cloud copy when cloud-sync is on, exactly like
+ * deleting a single record. Local data on the device is updated in place.
+ *
+ * Scope: every synced record table EXCEPT `userProfile`, which holds account
+ * configuration (conditions, AI consent) rather than time-series records and
+ * therefore isn't a meaningful target for a "by time frame" wipe.
+ */
+import { db } from "@/lib/db";
+import { TABLE_PUSH_ORDER } from "@/lib/sync-topology";
+import { enqueueInsideTx } from "@/lib/sync-queue";
+import { ok, err, type ServiceResult } from "@/lib/service-result";
+
+const PROFILE_TABLE = "userProfile";
+const DELETABLE_TABLES = TABLE_PUSH_ORDER.filter((t) => t !== PROFILE_TABLE);
+
+export interface DeleteRange {
+  /** Inclusive lower bound on `createdAt` (Unix ms), or null for no lower bound. */
+  from: number | null;
+  /** Inclusive upper bound on `createdAt` (Unix ms), or null for no upper bound. */
+  to: number | null;
+}
+
+/** Build a range for "records older than `days` days ago". */
+export function olderThanDays(days: number): DeleteRange {
+  return { from: null, to: Date.now() - days * 24 * 60 * 60 * 1000 };
+}
+
+/** A range that matches every record. */
+export const ALL_TIME: DeleteRange = { from: null, to: null };
+
+function inRange(createdAt: number, { from, to }: DeleteRange): boolean {
+  if (from !== null && createdAt < from) return false;
+  if (to !== null && createdAt > to) return false;
+  return true;
+}
+
+/**
+ * Soft-delete every non-deleted record whose `createdAt` falls in `range`,
+ * across all deletable tables, enqueuing each for sync. Returns the number of
+ * records deleted.
+ */
+export async function deleteRecordsInRange(
+  range: DeleteRange,
+): Promise<ServiceResult<number>> {
+  try {
+    let total = 0;
+    for (const tableName of DELETABLE_TABLES) {
+      const table = db.table<{
+        id: string;
+        createdAt: number;
+        updatedAt: number;
+        deletedAt: number | null;
+      }>(tableName);
+      await db.transaction("rw", table, db._syncQueue, async () => {
+        const now = Date.now();
+        const rows = await table.toArray();
+        for (const row of rows) {
+          if (row.deletedAt !== null) continue;
+          if (!inRange(row.createdAt, range)) continue;
+          await table.update(row.id, { deletedAt: now, updatedAt: now });
+          await enqueueInsideTx(tableName, row.id, "delete");
+          total += 1;
+        }
+      });
+    }
+    return ok(total);
+  } catch (e) {
+    return err("Failed to delete records", e);
+  }
+}

--- a/src/lib/user-data-deletion.ts
+++ b/src/lib/user-data-deletion.ts
@@ -1,0 +1,141 @@
+/**
+ * Server-only helpers for deleting a user's data from Neon Postgres.
+ *
+ * Two entry points back the two product flows:
+ *   - `wipeCloudData`     — Feature: "switch back to local-only". Removes the
+ *     synced data mirror (and push subscriptions) but keeps the account,
+ *     login identity, and AI keys so the user can keep using server features.
+ *   - `deleteAllUserData` — Feature: "delete my account". Removes every
+ *     user-scoped row across every table. The Neon Auth login identity itself
+ *     is deleted client-side via the auth SDK (`/delete-user`); this module
+ *     only owns the application database.
+ *
+ * Never trust a client-supplied user id — callers pass `auth.userId!` from the
+ * `withAuth` middleware, which derives it from the verified session.
+ *
+ * IMPORTANT: import only from server code (API routes). It pulls in the
+ * Drizzle/Neon client.
+ */
+import { eq, or, type SQL } from "drizzle-orm";
+import { db } from "@/lib/drizzle";
+import { schemaByTableName, type TableName } from "@/lib/sync-payload";
+import {
+  pushSubscriptions,
+  pushSchedules,
+  pushSentLog,
+  pushSettings,
+  userApiKeys,
+  userKeyShares,
+  aiUsage,
+  insightJobs,
+  mcpAccessTokens,
+  mcpAuthCodes,
+  mcpAuditLog,
+} from "@/db/schema";
+
+/**
+ * FK-safe delete order for the 18 synced tables (children before parents).
+ * Mirrors `/api/sync/cleanup`'s order, with the two leaf tables it omits
+ * (`userProfile`, `insightReports`) appended — nothing references them.
+ */
+const SYNCED_DELETION_ORDER: TableName[] = [
+  "doseLogs",
+  "inventoryTransactions",
+  "inventoryItems",
+  "phaseSchedules",
+  "medicationPhases",
+  "titrationPlans",
+  "prescriptions",
+  "substanceRecords",
+  "auditLogs",
+  "dailyNotes",
+  "defecationRecords",
+  "urinationRecords",
+  "eatingRecords",
+  "bloodPressureRecords",
+  "weightRecords",
+  "intakeRecords",
+  "userProfile",
+  "insightReports",
+];
+
+// Drizzle's table refs are heavily generic; the cleanup route uses the same
+// `as any` shape to delete by `userId` across many tables.
+async function del(table: any, where: SQL | undefined): Promise<number> {
+  const result = await db.delete(table).where(where);
+  return result.rowCount ?? 0;
+}
+
+/** Delete the 18 synced "data mirror" tables for a user. */
+async function deleteSyncedData(userId: string): Promise<Record<string, number>> {
+  const deleted: Record<string, number> = {};
+  for (const name of SYNCED_DELETION_ORDER) {
+    const table = schemaByTableName[name] as any;
+    deleted[name] = await del(table, eq(table.userId, userId));
+  }
+  return deleted;
+}
+
+/** Delete the user's Web Push subscription, schedules, sent log, and settings. */
+async function deletePushData(userId: string): Promise<Record<string, number>> {
+  return {
+    pushSentLog: await del(pushSentLog, eq(pushSentLog.userId, userId)),
+    pushSchedules: await del(pushSchedules, eq(pushSchedules.userId, userId)),
+    pushSubscriptions: await del(
+      pushSubscriptions,
+      eq(pushSubscriptions.userId, userId),
+    ),
+    pushSettings: await del(pushSettings, eq(pushSettings.userId, userId)),
+  };
+}
+
+/** Delete account-level data: AI keys, key shares, AI usage, jobs, MCP rows. */
+async function deleteAccountLevelData(
+  userId: string,
+): Promise<Record<string, number>> {
+  return {
+    userApiKeys: await del(userApiKeys, eq(userApiKeys.userId, userId)),
+    userKeyShares: await del(
+      userKeyShares,
+      or(
+        eq(userKeyShares.grantorId, userId),
+        eq(userKeyShares.granteeId, userId),
+      ),
+    ),
+    aiUsage: await del(aiUsage, eq(aiUsage.userId, userId)),
+    insightJobs: await del(insightJobs, eq(insightJobs.userId, userId)),
+    mcpAccessTokens: await del(
+      mcpAccessTokens,
+      eq(mcpAccessTokens.userId, userId),
+    ),
+    mcpAuthCodes: await del(mcpAuthCodes, eq(mcpAuthCodes.userId, userId)),
+    mcpAuditLog: await del(mcpAuditLog, eq(mcpAuditLog.userId, userId)),
+  };
+}
+
+/**
+ * Feature: "switch back to local-only". Removes the cloud data mirror and push
+ * subscriptions; keeps the account, identity, and AI keys.
+ */
+export async function wipeCloudData(
+  userId: string,
+): Promise<Record<string, number>> {
+  return {
+    ...(await deleteSyncedData(userId)),
+    ...(await deletePushData(userId)),
+  };
+}
+
+/**
+ * Feature: "delete my account". Removes every user-scoped row. The Neon Auth
+ * identity is deleted separately, client-side, via the auth SDK.
+ */
+export async function deleteAllUserData(
+  userId: string,
+): Promise<Record<string, number>> {
+  return {
+    ...(await deleteSyncedData(userId)),
+    ...(await deletePushData(userId)),
+    ...(await deleteAccountLevelData(userId)),
+  };
+}

--- a/src/lib/user-data-deletion.ts
+++ b/src/lib/user-data-deletion.ts
@@ -16,6 +16,7 @@
  * IMPORTANT: import only from server code (API routes). It pulls in the
  * Drizzle/Neon client.
  */
+import "server-only";
 import { eq, or, type SQL } from "drizzle-orm";
 import { db } from "@/lib/drizzle";
 import { schemaByTableName, type TableName } from "@/lib/sync-payload";


### PR DESCRIPTION
## Summary

Implements comprehensive data deletion capabilities for users, including:
- A public-facing `/data-deletion` page documenting deletion options (backs Google Play Data Safety form)
- Time-framed deletion of logged records ("older than 90 days", "all data", etc.) via local tombstoning + sync
- "Switch to local-only" flow: download full cloud dataset, then wipe server copy while preserving on-device data
- Permanent account deletion: scrub all server data, delete Neon Auth identity, keep local copy in local-only mode

## Key Changes

**Public Documentation**
- `src/app/data-deletion/page.tsx` — Public, unauthenticated page explaining deletion options and what is/isn't removed. Anchored sections (`#data`, `#account`) back Google Play Data Safety form URLs.

**Server-Side Data Deletion**
- `src/lib/user-data-deletion.ts` — Server-only helpers for two flows:
  - `wipeCloudData()` — Delete synced tables + push subscriptions (keeps account & AI keys)
  - `deleteAllUserData()` — Delete every user-scoped row across all tables
- `src/app/api/sync/wipe/route.ts` — POST endpoint for "switch to local-only" (calls `wipeCloudData`)
- `src/app/api/account/delete/route.ts` — POST endpoint for "delete account" (calls `deleteAllUserData`)
- Tests for both routes with mocked auth and deletion helpers

**Client-Side Deletion**
- `src/lib/data-deletion-service.ts` — Time-framed record deletion via soft-delete (tombstoning) + sync queue. Supports presets ("older than 90 days", "all data") and custom ranges. Excludes `userProfile` (account config, not time-series data).
- `src/lib/account-service.ts` — Multi-step lifecycle flows:
  - `switchToLocalAndWipeCloud()` — Pull full dataset, stop engine, wipe server, sever sync link
  - `deleteAccount()` — Stop engine, scrub server data, delete auth identity, sever sync link, sign out
- `src/hooks/use-account-actions.ts` — Hook exposing account lifecycle actions
- `src/hooks/use-data-deletion.ts` — React Query mutation for time-framed deletion with toast feedback

**UI Components**
- `src/components/settings/delete-data-controls.tsx` — Preset buttons ("Older than 1 year", "All data", etc.) with confirmation dialog
- `src/components/settings/delete-account-dialog.tsx` — Type-to-confirm dialog for permanent account deletion
- `src/components/settings/storage-info-section.tsx` — Added "Switch to Local only" button + integrated `DeleteDataControls`
- `src/components/settings/account-section.tsx` — Added "Delete account" button opening `DeleteAccountDialog`

## Implementation Details

- **Deletion order:** FK-safe deletion respects foreign key constraints (children before parents), mirroring the sync cleanup route
- **Soft-delete pattern:** Records are tombstoned (`deletedAt` set) and enqueued for sync, so deletions propagate to cloud in cloud-sync mode exactly like single-record deletes
- **Session validity:** Account deletion scrubs server data while session is valid, then deletes the Neon Auth identity client-side, then signs out
- **Data preservation:** "Switch to local-only" and "delete account" both preserve on-device data; only server copies are removed
- **Sync engine coordination:** Both flows stop the sync engine before server operations to prevent round-trip propagation of deletions back to local
- **Retention policy:** Routine encrypted backups are rotated/purged within 30 days; documented on public page

https://claude.ai/code/session_01GHpFwF95xbxBHpJsbCEdcR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added account deletion page and secure confirmation flow with type-to-confirm protection
  * Added selective data deletion controls by time range (1 year, 90 days, 30 days, all data)
  * Added ability to switch from cloud sync to local-only mode with automatic cloud data wipe

* **Tests**
  * Added test coverage for account deletion and cloud data wiping endpoints

<!-- end of auto-generated comment: release notes by coderabbit.ai -->