### PR TITLE
refactor(repo): extract the @intake/types package (phase 3a)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,7 @@ jobs:
               - '.github/**'
             bench:
               - 'apps/web/src/lib/db.ts'
+              - 'packages/types/src/records.ts'
               - 'apps/web/src/__tests__/migration/**'
               - 'apps/web/src/__tests__/integrity/**'
               - 'apps/web/src/lib/backup-service.ts'

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,9 +10,10 @@ The server schema (`src/db/schema.ts`) is mirrored to Neon Postgres through
 numbered Drizzle migrations in `drizzle/`. Generate with `pnpm db:generate`,
 apply with `pnpm db:migrate`. Never run `drizzle-kit push`.
 
-`src/db/schema.ts` must stay field-for-field in parity with the Dexie
-interfaces in `src/lib/db.ts` — `src/__tests__/schema-parity.test.ts` fails
-the build otherwise.
+`@intake/db/schema` (`packages/db/src/schema.ts`) must stay field-for-field in
+parity with the Dexie record interfaces in `@intake/types/records`
+(`packages/types/src/records.ts`) — `apps/web/src/__tests__/schema-parity.test.ts`
+fails the build otherwise.
 
 ### The timestamp footgun
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,7 +28,7 @@ When adding a new Dexie version, you must repeat all existing store definitions 
 
 ### Database Migrations (Drizzle / Neon Postgres)
 
-The sync engine mirrors every Dexie table to Neon Postgres. The server schema lives in `src/db/schema.ts` and must stay field-for-field in parity with the Dexie interfaces in `src/lib/db.ts` — `src/__tests__/schema-parity.test.ts` fails the build otherwise.
+The sync engine mirrors every Dexie table to Neon Postgres. The server schema lives in `@intake/db/schema` (`packages/db/src/schema.ts`) and must stay field-for-field in parity with the Dexie record interfaces in `@intake/types/records` (`packages/types/src/records.ts`) — `apps/web/src/__tests__/schema-parity.test.ts` fails the build otherwise.
 
 Workflow: edit `src/db/schema.ts`, run `pnpm db:generate` (emits a numbered SQL file + snapshot under `drizzle/`), commit the generated files. `pnpm db:migrate` applies them. **Never** run `drizzle-kit push`.
 

--- a/apps/web/next.config.mjs
+++ b/apps/web/next.config.mjs
@@ -46,7 +46,7 @@ const nextConfig = {
   reactStrictMode: true,
   // Internal @intake/* packages are consumed as raw TS source (JIT). Grows as
   // core, ui, ai-prompts are extracted in later phases.
-  transpilePackages: ["@intake/db"],
+  transpilePackages: ["@intake/db", "@intake/types"],
   // Pin the Turbopack root to the monorepo root so module resolution + the
   // version require above are scoped correctly (silences the inferred-root warning).
   turbopack: {

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -33,6 +33,7 @@
     "@capacitor/local-notifications": "^8.1.0",
     "@capacitor/network": "^8.0.1",
     "@intake/db": "workspace:*",
+    "@intake/types": "workspace:*",
     "@modelcontextprotocol/sdk": "1.29.0",
     "@neondatabase/auth": "0.4.1-beta",
     "@neondatabase/serverless": "^1.1.0",

--- a/apps/web/src/__tests__/dexie-schema-extractor.ts
+++ b/apps/web/src/__tests__/dexie-schema-extractor.ts
@@ -1,9 +1,11 @@
 /**
  * Dexie schema extractor — TypeScript compiler API walker.
  *
- * Reads src/lib/db.ts without executing it and extracts:
- *   - The canonical Dexie table name list (from db.version(...).stores({...}))
+ * Reads the Dexie record interfaces (packages/types/src/records.ts) without
+ * executing them and extracts:
  *   - Per-table interface field lists (property names only, no type info)
+ *   (The canonical Dexie table NAME list still comes from the static
+ *    TABLE_TO_INTERFACE map below — the stores({...}) blocks stay in db.ts.)
  *
  * Used by src/__tests__/schema-parity.test.ts to drive the Dexie ↔ Drizzle
  * field comparison. Zero runtime exposure — test-only module.
@@ -36,8 +38,9 @@ export interface DexieTableSchema {
  * Static mapping from Dexie table name (camelCase, as keyed in db.version().stores())
  * to the TypeScript interface name (PascalCase singular) exported from db.ts.
  *
- * Must be kept in sync with src/lib/db.ts. If the extractor throws on a new table,
- * add the mapping here AND add the corresponding Drizzle table in src/db/schema.ts.
+ * Must be kept in sync with the record interfaces in @intake/types/records. If the
+ * extractor throws on a new table, add the mapping here AND add the corresponding
+ * Drizzle table in @intake/db/schema.
  */
 const TABLE_TO_INTERFACE: Record<string, string> = {
   intakeRecords: "IntakeRecord",
@@ -60,17 +63,25 @@ const TABLE_TO_INTERFACE: Record<string, string> = {
   insightReports: "InsightReport",
 };
 
-/** Default path to db.ts — resolved relative to this file's location in src/__tests__/ */
-// process.cwd() in Vitest is the project root; from there db.ts is at src/lib/db.ts.
-// We prefer cwd() over __dirname/import.meta because Vitest may transform the file
-// and change the effective __dirname. The project root is always the anchor.
-const DB_TS_DEFAULT_PATH = path.resolve(process.cwd(), "src/lib/db.ts");
+/**
+ * Default path to the Dexie record interfaces. They moved out of `src/lib/db.ts`
+ * into `@intake/types/records` in Phase 3a (the Dexie runtime stayed in db.ts),
+ * so the extractor parses the records file directly. process.cwd() in Vitest is
+ * the app project root (apps/web); the package sits two levels up. We prefer
+ * cwd() over __dirname/import.meta because Vitest may transform the file and
+ * change the effective __dirname — the project root is always the anchor.
+ */
+const DB_TS_DEFAULT_PATH = path.resolve(
+  process.cwd(),
+  "../../packages/types/src/records.ts",
+);
 
 /**
- * Walk src/lib/db.ts using the TypeScript compiler API and return one
- * DexieTableSchema per table declared in the static TABLE_TO_INTERFACE mapping.
+ * Walk the records file (packages/types/src/records.ts) using the TypeScript
+ * compiler API and return one DexieTableSchema per table declared in the static
+ * TABLE_TO_INTERFACE mapping.
  *
- * @param dbTsPath - Optional override for the path to db.ts.
+ * @param dbTsPath - Optional override for the path to the records file.
  * @throws Error with format "Cannot resolve Dexie interface for table '<tableName>'..."
  *   when the expected interface is absent from the parsed file.
  */

--- a/apps/web/src/__tests__/schema-parity.test.ts
+++ b/apps/web/src/__tests__/schema-parity.test.ts
@@ -2,8 +2,8 @@
  * Schema parity gate — Dexie ↔ Drizzle drift detector.
  *
  * This test runs as part of `pnpm test` and therefore in every CI run. It fails
- * when Dexie (src/lib/db.ts v15 interfaces) and Drizzle (src/db/schema.ts) fall
- * out of sync — which is the moment a future phase adds a field to one side
+ * when Dexie (@intake/types/records interfaces) and Drizzle (@intake/db/schema)
+ * fall out of sync — which is the moment a future phase adds a field to one side
  * without the other.
  *
  * The comparator is STRUCTURAL (field name presence) — not type-based. Union
@@ -48,7 +48,7 @@ function getDrizzleColumnNames(table: Table): string[] {
 // ─────────────────────────────────────────────────────────────────────────
 
 describe("Dexie schema extractor sanity", () => {
-  it("extracts exactly 18 Dexie tables from src/lib/db.ts", () => {
+  it("extracts exactly 18 Dexie tables from @intake/types/records", () => {
     expect(DEXIE_TABLES).toHaveLength(18);
   });
 
@@ -121,7 +121,7 @@ describe("Dexie ↔ Drizzle schema parity", () => {
       const drizzleTable = getDrizzleTable(tableName);
       expect(
         drizzleTable,
-        `Missing Drizzle export: drizzleSchema.${tableName} — add pgTable("...") to src/db/schema.ts`,
+        `Missing Drizzle export: drizzleSchema.${tableName} — add pgTable("...") to @intake/db/schema`,
       ).toBeDefined();
     },
   );
@@ -142,7 +142,7 @@ describe("Dexie ↔ Drizzle schema parity", () => {
         `${tableName}: Dexie field(s) missing from Drizzle columns. ` +
           `Missing: [${missing.join(", ")}]. ` +
           `Drizzle has: [${Array.from(drizzleCols).join(", ")}]. ` +
-          `Fix: add the missing column(s) to src/db/schema.ts and run pnpm db:generate`,
+          `Fix: add the missing column(s) to @intake/db/schema and run pnpm db:generate`,
       ).toEqual([]);
     },
   );
@@ -164,8 +164,8 @@ describe("Dexie ↔ Drizzle schema parity", () => {
         extras,
         `${tableName}: Drizzle has column(s) not in Dexie interface and not in the exemption list ` +
           `(only 'userId' is exempt). Extra: [${extras.join(", ")}]. ` +
-          `Fix: add the field to the Dexie interface in src/lib/db.ts ` +
-          `OR remove the column from src/db/schema.ts`,
+          `Fix: add the field to the Dexie interface in @intake/types/records ` +
+          `OR remove the column from @intake/db/schema`,
       ).toEqual([]);
     },
   );

--- a/apps/web/src/lib/db.ts
+++ b/apps/web/src/lib/db.ts
@@ -4,423 +4,66 @@ import {
   getTimezoneForTimestamp,
   localHHMMStringToUTCMinutes,
 } from "@/lib/timezone";
-
-export interface IntakeRecord {
-  id: string;
-  type: "water" | "salt" | "sugar" | "potassium";
-  amount: number; // ml for water, mg for salt, g for sugar, mg for potassium
-  timestamp: number; // Unix timestamp in milliseconds
-  source?: string; // "manual", "food:apple", "voice", etc.
-  note?: string; // Optional note for the entry
-  createdAt: number; // Unix ms — set once on creation
-  updatedAt: number; // Unix ms — updated on every mutation
-  deletedAt: number | null; // null = active, number = soft-deleted timestamp
-  deviceId: string; // device identifier for sync conflict resolution
-  timezone: string; // IANA timezone, e.g. "Europe/Berlin"
-  groupId?: string; // shared key linking records in a composable group
-  originalInputText?: string; // stored on primary record only, for AI re-run
-  groupSource?: string; // "ai_food_parse" | "ai_substance_lookup" | "manual"
-}
-
-export type AuditAction =
-  | "ai_parse_request"
-  | "ai_parse_success"
-  | "ai_parse_error"
-  | "data_export"
-  | "data_import"
-  | "data_clear"
-  | "settings_change"
-  | "api_key_set"
-  | "api_key_clear"
-  | "pin_set"
-  | "pin_verify_success"
-  | "pin_verify_failure"
-  | "dose_taken"
-  | "dose_skipped"
-  | "dose_rescheduled"
-  | "dose_time_edited"
-  | "prescription_added"
-  | "prescription_updated"
-  | "inventory_adjusted"
-  | "phase_activated"
-  | "validation_error"
-  | "dose_untaken"
-  | "prescription_deleted"
-  | "phase_completed"
-  | "phase_started"
-  | "stock_recalculated"
-  | "inventory_added"
-  | "inventory_deleted"
-  | "titration_plan_updated"
-  | "timezone_adjusted";
-
-export interface AuditLog {
-  id: string;
-  timestamp: number;
-  action: AuditAction;
-  details?: string;
-  createdAt: number;
-  updatedAt: number;
-  deletedAt: number | null;
-  deviceId: string;
-  timezone: string;
-}
-
-export interface WeightRecord {
-  id: string;
-  weight: number; // in kg
-  timestamp: number;
-  note?: string;
-  createdAt: number;
-  updatedAt: number;
-  deletedAt: number | null;
-  deviceId: string;
-  timezone: string;
-}
-
-export interface BloodPressureRecord {
-  id: string;
-  systolic: number; // top number (mmHg)
-  diastolic: number; // bottom number (mmHg)
-  heartRate?: number; // BPM (optional)
-  irregularHeartbeat?: boolean; // optional flag for irregular heartbeat
-  position: "standing" | "sitting";
-  arm: "left" | "right";
-  timestamp: number;
-  note?: string;
-  createdAt: number;
-  updatedAt: number;
-  deletedAt: number | null;
-  deviceId: string;
-  timezone: string;
-}
-
-export interface EatingRecord {
-  id: string;
-  timestamp: number;
-  grams?: number; // optional weight in grams
-  note?: string;
-  createdAt: number;
-  updatedAt: number;
-  deletedAt: number | null;
-  deviceId: string;
-  timezone: string;
-  groupId?: string; // shared key linking records in a composable group
-  originalInputText?: string; // stored on primary record only, for AI re-run
-  groupSource?: string; // "ai_food_parse" | "ai_substance_lookup" | "manual"
-}
-
-export interface UrinationRecord {
-  id: string;
-  timestamp: number;
-  amountEstimate?: string;
-  note?: string;
-  createdAt: number;
-  updatedAt: number;
-  deletedAt: number | null;
-  deviceId: string;
-  timezone: string;
-}
-
-export interface DefecationRecord {
-  id: string;
-  timestamp: number;
-  amountEstimate?: string; // "small" | "medium" | "large"
-  note?: string;
-  createdAt: number;
-  updatedAt: number;
-  deletedAt: number | null;
-  deviceId: string;
-  timezone: string;
-}
-
-export type PillShape = "round" | "oval" | "capsule" | "diamond" | "tablet";
-export type FoodInstruction = "before" | "after" | "none";
-export type DoseStatus = "taken" | "skipped" | "rescheduled" | "pending";
+import type {
+  AuditLog,
+  BloodPressureRecord,
+  DailyNote,
+  DefecationRecord,
+  DoseLog,
+  EatingRecord,
+  ErrorLogEntry,
+  InsightReport,
+  IntakeRecord,
+  InventoryItem,
+  InventoryTransaction,
+  MedicationPhase,
+  PhaseSchedule,
+  Prescription,
+  SubstanceRecord,
+  SyncMetaRow,
+  SyncQueueRow,
+  TitrationPlan,
+  UrinationRecord,
+  UserProfile,
+  WeightRecord,
+} from "@intake/types/records";
 
 /**
- * One active ingredient of a combination drug, with its per-pill (or
- * per-reference-dose) strength. Combination tablets like Entresto/Vymada
- * carry two: e.g. `{ name: "Sacubitril", strength: 49 }` +
- * `{ name: "Valsartan", strength: 51 }` for a "Vymada 100" tablet.
- * The unit is shared with the parent record's `unit` field (normally "mg").
+ * The record/data-model types live in `@intake/types/records` (moved there in
+ * Phase 3a; the Dexie runtime below stays in the app). Re-export the full
+ * surface so existing `@/lib/db` type importers keep resolving unchanged.
  */
-export interface CompoundStrength {
-  name: string;
-  strength: number;
-}
-
-export interface Prescription {
-  id: string;
-  genericName: string;
-  indication: string;
-  notes?: string;
-  contraindications?: string[];
-  warnings?: string[];
-  /**
-   * Active ingredients for a combination drug. Absent ⇒ single-compound
-   * prescription (the common case). When present (length ≥ 2) the strengths
-   * describe one standard reference dose and fix the compound ratio used to
-   * label doses. Non-indexed — no Dexie version bump required.
-   */
-  compounds?: CompoundStrength[];
-  isActive: boolean;
-  createdAt: number;
-  updatedAt: number;
-  deletedAt: number | null;
-  deviceId: string;
-}
-
-export type PhaseType = "maintenance" | "titration";
-
-export interface MedicationPhase {
-  id: string;
-  prescriptionId: string;
-  type: PhaseType;
-  unit: string;
-  startDate: number;
-  endDate?: number;
-  foodInstruction: FoodInstruction;
-  foodNote?: string;
-  notes?: string;
-  status: "active" | "completed" | "cancelled" | "pending";
-  titrationPlanId?: string; // links titration phases to their parent plan
-  createdAt: number;
-  updatedAt: number;
-  deletedAt: number | null;
-  deviceId: string;
-}
-
-export type TitrationPlanStatus = "draft" | "active" | "completed" | "cancelled";
-
-export interface TitrationPlan {
-  id: string;
-  title: string;
-  conditionLabel: string; // e.g. "Heart failure", managed as unique labels
-  recommendedStartDate?: number;
-  status: TitrationPlanStatus;
-  notes?: string;
-  warnings?: string[]; // warning signs to look out for
-  createdAt: number;
-  updatedAt: number;
-  deletedAt: number | null;
-  deviceId: string;
-}
-
-export interface PhaseSchedule {
-  id: string;
-  phaseId: string;
-  /** @deprecated Use scheduleTimeUTC. Kept for v10 DB record compatibility. */
-  time: string;
-  scheduleTimeUTC: number; // minutes from midnight UTC (integer)
-  anchorTimezone: string; // IANA timezone when schedule was created
-  dosage: number;
-  daysOfWeek: number[];
-  enabled: boolean;
-  unit?: string; // dosage unit for display, e.g. "mg"
-  createdAt: number;
-  updatedAt: number;
-  deletedAt: number | null;
-  deviceId: string;
-}
-
-export interface InventoryItem {
-  id: string;
-  prescriptionId: string;
-  brandName: string;
-  /** @deprecated Use inventoryTransactions sum. Will be removed in Phase 3. */
-  currentStock?: number;
-  /** Sum of `compounds` strengths for a combination tablet; the single
-   *  per-pill strength otherwise. Always the pill-math denominator. */
-  strength: number;
-  /**
-   * Per-pill breakdown for a combination tablet (e.g. Vymada 100 ⇒
-   * Sacubitril 49 + Valsartan 51). Absent ⇒ single-compound pill.
-   * `strength` stays authoritative for dose math; this is descriptive.
-   */
-  compounds?: CompoundStrength[];
-  unit: string;
-  pillShape: PillShape;
-  pillColor: string;
-  visualIdentification?: string;
-  refillAlertDays?: number;
-  refillAlertPills?: number;
-  isActive: boolean;
-  isArchived?: boolean;
-  createdAt: number;
-  updatedAt: number;
-  deletedAt: number | null;
-  deviceId: string;
-  timezone: string;
-}
-
-export interface InventoryTransaction {
-  id: string;
-  inventoryItemId: string;
-  timestamp: number;
-  amount: number;
-  note?: string;
-  type: "refill" | "consumed" | "adjusted" | "initial";
-  doseLogId?: string; // links consumed transaction to the dose that caused it
-  createdAt: number;
-  updatedAt: number;
-  deletedAt: number | null;
-  deviceId: string;
-  timezone: string;
-}
-
-export interface DailyNote {
-  id: string;
-  date: string; // YYYY-MM-DD
-  prescriptionId?: string;
-  doseLogId?: string;
-  note: string;
-  createdAt: number;
-  updatedAt: number;
-  deletedAt: number | null;
-  deviceId: string;
-  timezone: string;
-}
-
-export interface DoseLog {
-  id: string;
-  prescriptionId: string;
-  phaseId: string;
-  scheduleId: string;
-  inventoryItemId?: string;
-  scheduledDate: string;
-  scheduledTime: string;
-  status: DoseStatus;
-  actionTimestamp?: number;
-  rescheduledTo?: string;
-  skipReason?: string;
-  note?: string;
-  timezone: string; // IANA timezone string, e.g. "Africa/Johannesburg"
-  createdAt: number;
-  updatedAt: number;
-  deletedAt: number | null;
-  deviceId: string;
-}
-
-export interface SubstanceRecord {
-  id: string;
-  type: 'caffeine' | 'alcohol';
-  amountMg?: number;           // caffeine mg
-  amountStandardDrinks?: number; // alcohol: metric standard drinks (derived from abvPercent + volumeMl)
-  abvPercent?: number;          // alcohol: alcohol by volume %, the user-entered input value
-  volumeMl?: number;            // liquid volume for fluid balance linking
-  description: string;
-  source: 'water_intake' | 'eating' | 'standalone';
-  sourceRecordId?: string;      // links to original intake record if migrated
-  aiEnriched?: boolean;         // true if AI has refined the estimate
-  timestamp: number;
-  createdAt: number;
-  updatedAt: number;
-  deletedAt: number | null;
-  deviceId: string;
-  timezone: string;
-  groupId?: string; // shared key linking records in a composable group
-  originalInputText?: string; // stored on primary record only, for AI re-run
-  groupSource?: string; // "ai_food_parse" | "ai_substance_lookup" | "manual"
-}
-
-/** Sync queue op-log row (Dexie v16+, Phase 43 D-01).
- *  `id` is auto-increment (++id). `op: 'delete'` exists for future hard-delete paths
- *  but is unused in the P43 pilot (soft-deletes go through upsert with deletedAt set). */
-export interface SyncQueueRow {
-  id?: number;
-  tableName: string;
-  recordId: string;
-  op: "upsert" | "delete";
-  enqueuedAt: number;
-  attempts: number;
-}
-
-/** Per-table pull cursor (Dexie v16+, Phase 43 D-07). Singleton per tableName. */
-export interface SyncMetaRow {
-  tableName: string;
-  lastPulledUpdatedAt: number;
-  /**
-   * Tiebreaker for the keyset cursor — the `id` of the last row consumed at
-   * `lastPulledUpdatedAt`. Pagination orders by `(updatedAt, id)` so that a
-   * page boundary landing inside a run of rows that share one `updatedAt`
-   * (e.g. the v11 migration stamped every record with a single timestamp)
-   * cannot strand the rows after the boundary. Absent on cursors written by
-   * pre-keyset clients — readers default it to `""` (sorts before any id).
-   */
-  lastPulledId?: string;
-}
-
-/** Source of a captured error/warning. Device-local debug data, never synced. */
-export type ErrorLogSource =
-  | "window-error"
-  | "unhandled-rejection"
-  | "error-boundary"
-  | "console-error"
-  | "console-warn"
-  | "api-error";
-
-/** Captured error/warning. Local-only (Dexie v17+); not part of backup or sync. */
-export interface ErrorLogEntry {
-  id: string;
-  timestamp: number;
-  source: ErrorLogSource;
-  message: string;
-  stack?: string;
-  componentStack?: string;
-  route?: string;
-  userAgent?: string;
-  appVersion?: string;
-}
-
-/**
- * Single-user medical profile (Dexie v18). Holds user-reported medical
- * conditions that give AI analytics insights clinical context (e.g. why the
- * sodium and fluid limits matter). The app treats it as a singleton — the
- * service layer reads the most-recently-updated active row — but each row
- * carries a globally-unique `id` so it backs up and cloud-syncs through the
- * standard record-oriented engine alongside every other table.
- */
-export interface UserProfile {
-  id: string;
-  conditions: string[]; // user-reported medical conditions, e.g. "HFrEF"
-  shareConditionsWithAI: boolean; // opt-in: include conditions in AI insights
-  shareMedicationsWithAI: boolean; // opt-in: include active medications in AI insights
-  aiInsightsConsentAt: number | null; // when the user first consented; null = never
-  createdAt: number;
-  updatedAt: number;
-  deletedAt: number | null;
-  deviceId: string;
-}
-
-/**
- * A cached AI analytics insight report (Dexie v19). Each row is one generated
- * "AI Insights" summary — the narrative and observations the model produced
- * for a rolling analysis window. Persisting them gives the user a history of
- * past assessments and lets a fresh analysis optionally compare against the
- * previous one. Synced and backed up like every other record-oriented table.
- */
-export interface InsightReport {
-  id: string;
-  generatedAt: number; // when the AI produced this report (Unix ms)
-  rangeStart: number; // analysis window start (Unix ms)
-  rangeEnd: number; // analysis window end (Unix ms)
-  narrative: string; // plain-language summary
-  observations: string[]; // specific factual observations
-  // URLs the model cited via web_search (deep mode only). Optional —
-  // fast-mode reports and legacy rows from before sources were tracked
-  // leave this undefined.
-  sources?: string[];
-  personalised: boolean; // whether the user's medical profile fed the analysis
-  // "fast" = sync Sonnet summary; "deep" = async Opus + web-search deep
-  // research. Optional for rows written before the two-tier rollout — the
-  // client treats `undefined` as "fast".
-  mode?: "fast" | "deep";
-  createdAt: number;
-  updatedAt: number;
-  deletedAt: number | null;
-  deviceId: string;
-}
+export type {
+  AuditAction,
+  AuditLog,
+  BloodPressureRecord,
+  CompoundStrength,
+  DailyNote,
+  DefecationRecord,
+  DoseLog,
+  DoseStatus,
+  EatingRecord,
+  ErrorLogEntry,
+  ErrorLogSource,
+  FoodInstruction,
+  InsightReport,
+  IntakeRecord,
+  InventoryItem,
+  InventoryTransaction,
+  MedicationPhase,
+  PhaseSchedule,
+  PhaseType,
+  PillShape,
+  Prescription,
+  SubstanceRecord,
+  SyncMetaRow,
+  SyncQueueRow,
+  TitrationPlan,
+  TitrationPlanStatus,
+  UrinationRecord,
+  UserProfile,
+  WeightRecord,
+} from "@intake/types/records";
 
 export type AppDatabase = Dexie & {
   intakeRecords: EntityTable<IntakeRecord, "id">;

--- a/apps/web/src/lib/optional-trackers.ts
+++ b/apps/web/src/lib/optional-trackers.ts
@@ -11,8 +11,8 @@
  *
  * Adding a new optional tracker requires:
  *   1. Add the key to `OptionalTrackerKey` and an entry to `OPTIONAL_TRACKERS`.
- *   2. Add the tracker's `IntakeRecord` `type` to `src/lib/db.ts`,
- *      `src/db/schema.ts`, and a Drizzle migration.
+ *   2. Add the tracker's `IntakeRecord` `type` to `@intake/types/records`,
+ *      `@intake/db/schema`, and a Drizzle migration.
  *   3. Gate every UI / analytics surface on `useOptionalTrackerEnabled(key)`.
  *   4. Seed the default in the settings-store migration.
  */

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -1,7 +1,7 @@
 /**
  * Postgres schema — single source of truth for all 29 tables.
  *
- * Mirrors src/lib/db.ts Dexie interfaces exactly (18 app tables),
+ * Mirrors the @intake/types/records Dexie interfaces exactly (18 app tables),
  * includes 4 push notification tables that replace scripts/push-migration.sql,
  * 3 server-only AI tables (user_api_keys, user_key_shares, ai_usage), and
  * 4 server-only MCP-connector tables (mcp_oauth_clients, mcp_auth_codes,
@@ -306,7 +306,7 @@ export const prescriptions = pgTable(
     // Combination-drug active ingredients (mirrors Dexie CompoundStrength[]).
     compounds: jsonb("compounds").$type<{ name: string; strength: number }[]>(),
     isActive: boolean("is_active").notNull(),
-    // NOTE: no timezone column — Prescription interface in src/lib/db.ts omits it.
+    // NOTE: no timezone column — Prescription interface in @intake/types/records omits it.
     createdAt: bigint("created_at", { mode: "number" }).notNull(),
     updatedAt: bigint("updated_at", { mode: "number" }).notNull(),
     deletedAt: bigint("deleted_at", { mode: "number" }),
@@ -509,7 +509,7 @@ export const doseLogs = pgTable(
     rescheduledTo: text("rescheduled_to"),
     skipReason: text("skip_reason"),
     note: text("note"),
-    // DoseLog DOES have a timezone column (line 269 of src/lib/db.ts).
+    // DoseLog DOES have a timezone column (see the DoseLog interface in @intake/types/records).
     timezone: text("timezone").notNull(),
     createdAt: bigint("created_at", { mode: "number" }).notNull(),
     updatedAt: bigint("updated_at", { mode: "number" }).notNull(),
@@ -615,7 +615,7 @@ export const auditLogs = pgTable(
     timezone: text("timezone").notNull(),
   },
   (t) => ({
-    // All 29 AuditAction values copied verbatim from src/lib/db.ts lines 24-54.
+    // All 29 AuditAction values copied verbatim from the AuditAction type in @intake/types/records.
     actionCheck: check(
       "audit_logs_action_check",
       sql`${t.action} IN (
@@ -638,7 +638,7 @@ export const auditLogs = pgTable(
 );
 
 // ─────────────────────────────────────────────────────────────────────────
-// User medical profile — mirrors the UserProfile interface in src/lib/db.ts.
+// User medical profile — mirrors the UserProfile interface in @intake/types/records.
 // Treated as a per-user singleton by the app, but stored as a normal synced
 // table (globally-unique `id`). No `timezone` column — UserProfile omits it.
 // ─────────────────────────────────────────────────────────────────────────
@@ -672,7 +672,7 @@ export const userProfile = pgTable(
 
 // ─────────────────────────────────────────────────────────────────────────
 // Cached AI analytics insight reports — mirrors the InsightReport interface
-// in src/lib/db.ts. One row per generated "AI Insights" summary. No
+// in @intake/types/records. One row per generated "AI Insights" summary. No
 // `timezone` column — InsightReport omits it.
 // ─────────────────────────────────────────────────────────────────────────
 

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@intake/types",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts",
+    "./records": "./src/records.ts"
+  },
+  "scripts": {
+    "typecheck": "tsc --noEmit"
+  },
+  "devDependencies": {
+    "@intake/typescript-config": "workspace:*",
+    "typescript": "^6.0.3"
+  }
+}

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -1,0 +1,16 @@
+/**
+ * @intake/types — the dependency-root package: isomorphic, runtime-free shared
+ * types for the intake-tracker monorepo.
+ *
+ * No `client-only` / `server-only`, no React, no Dexie — safe to import from any
+ * layer (the Next app, API route handlers, and the other `@intake/*` packages).
+ * It must stay free of runtime so it can sit at the bottom of the dependency
+ * graph (`types ← core ← ui ← apps`, with `db` + `core` siblings on `types`).
+ *
+ * Subpath exports:
+ *   "@intake/types/records" — the Dexie record / data-shape interfaces plus
+ *     their enums and unions (the canonical client data model). Mirrored
+ *     field-for-field by `@intake/db/schema`; the parity is enforced by
+ *     apps/web's `schema-parity.test.ts` (its extractor parses this very file).
+ */
+export * from "./records";

--- a/packages/types/src/records.ts
+++ b/packages/types/src/records.ts
@@ -1,0 +1,439 @@
+/**
+ * Canonical client data-model record types for intake-tracker.
+ *
+ * Moved verbatim out of `apps/web/src/lib/db.ts` in Phase 3a so the type root
+ * lives in `@intake/types` (the Dexie runtime — the `new Dexie()` instance, the
+ * `AppDatabase` type and the `version().stores()` migration blocks — stays in
+ * the app). `db.ts` re-exports every symbol here, so existing `@/lib/db` type
+ * importers are unaffected.
+ *
+ * PARITY COUPLING (do not break):
+ *   - These interfaces are mirrored field-for-field by the Drizzle tables in
+ *     `@intake/db/schema`. `apps/web/src/__tests__/schema-parity.test.ts` fails
+ *     the build if they drift. When you add/rename a field here, update
+ *     `@intake/db/schema` in the same change.
+ *   - `apps/web/src/__tests__/dexie-schema-extractor.ts` parses THIS file as
+ *     text (single-file `ts.createSourceFile`) and requires every Dexie table
+ *     interface it checks (the 18 in its TABLE_TO_INTERFACE map) to be declared
+ *     here. Keep every record interface in this one file — do not split them
+ *     across modules, or the single-file parse will miss them.
+ *
+ * This module is pure types (zero runtime, zero imports) — keep it that way.
+ */
+
+export interface IntakeRecord {
+  id: string;
+  type: "water" | "salt" | "sugar" | "potassium";
+  amount: number; // ml for water, mg for salt, g for sugar, mg for potassium
+  timestamp: number; // Unix timestamp in milliseconds
+  source?: string; // "manual", "food:apple", "voice", etc.
+  note?: string; // Optional note for the entry
+  createdAt: number; // Unix ms — set once on creation
+  updatedAt: number; // Unix ms — updated on every mutation
+  deletedAt: number | null; // null = active, number = soft-deleted timestamp
+  deviceId: string; // device identifier for sync conflict resolution
+  timezone: string; // IANA timezone, e.g. "Europe/Berlin"
+  groupId?: string; // shared key linking records in a composable group
+  originalInputText?: string; // stored on primary record only, for AI re-run
+  groupSource?: string; // "ai_food_parse" | "ai_substance_lookup" | "manual"
+}
+
+export type AuditAction =
+  | "ai_parse_request"
+  | "ai_parse_success"
+  | "ai_parse_error"
+  | "data_export"
+  | "data_import"
+  | "data_clear"
+  | "settings_change"
+  | "api_key_set"
+  | "api_key_clear"
+  | "pin_set"
+  | "pin_verify_success"
+  | "pin_verify_failure"
+  | "dose_taken"
+  | "dose_skipped"
+  | "dose_rescheduled"
+  | "dose_time_edited"
+  | "prescription_added"
+  | "prescription_updated"
+  | "inventory_adjusted"
+  | "phase_activated"
+  | "validation_error"
+  | "dose_untaken"
+  | "prescription_deleted"
+  | "phase_completed"
+  | "phase_started"
+  | "stock_recalculated"
+  | "inventory_added"
+  | "inventory_deleted"
+  | "titration_plan_updated"
+  | "timezone_adjusted";
+
+export interface AuditLog {
+  id: string;
+  timestamp: number;
+  action: AuditAction;
+  details?: string;
+  createdAt: number;
+  updatedAt: number;
+  deletedAt: number | null;
+  deviceId: string;
+  timezone: string;
+}
+
+export interface WeightRecord {
+  id: string;
+  weight: number; // in kg
+  timestamp: number;
+  note?: string;
+  createdAt: number;
+  updatedAt: number;
+  deletedAt: number | null;
+  deviceId: string;
+  timezone: string;
+}
+
+export interface BloodPressureRecord {
+  id: string;
+  systolic: number; // top number (mmHg)
+  diastolic: number; // bottom number (mmHg)
+  heartRate?: number; // BPM (optional)
+  irregularHeartbeat?: boolean; // optional flag for irregular heartbeat
+  position: "standing" | "sitting";
+  arm: "left" | "right";
+  timestamp: number;
+  note?: string;
+  createdAt: number;
+  updatedAt: number;
+  deletedAt: number | null;
+  deviceId: string;
+  timezone: string;
+}
+
+export interface EatingRecord {
+  id: string;
+  timestamp: number;
+  grams?: number; // optional weight in grams
+  note?: string;
+  createdAt: number;
+  updatedAt: number;
+  deletedAt: number | null;
+  deviceId: string;
+  timezone: string;
+  groupId?: string; // shared key linking records in a composable group
+  originalInputText?: string; // stored on primary record only, for AI re-run
+  groupSource?: string; // "ai_food_parse" | "ai_substance_lookup" | "manual"
+}
+
+export interface UrinationRecord {
+  id: string;
+  timestamp: number;
+  amountEstimate?: string;
+  note?: string;
+  createdAt: number;
+  updatedAt: number;
+  deletedAt: number | null;
+  deviceId: string;
+  timezone: string;
+}
+
+export interface DefecationRecord {
+  id: string;
+  timestamp: number;
+  amountEstimate?: string; // "small" | "medium" | "large"
+  note?: string;
+  createdAt: number;
+  updatedAt: number;
+  deletedAt: number | null;
+  deviceId: string;
+  timezone: string;
+}
+
+export type PillShape = "round" | "oval" | "capsule" | "diamond" | "tablet";
+export type FoodInstruction = "before" | "after" | "none";
+export type DoseStatus = "taken" | "skipped" | "rescheduled" | "pending";
+
+/**
+ * One active ingredient of a combination drug, with its per-pill (or
+ * per-reference-dose) strength. Combination tablets like Entresto/Vymada
+ * carry two: e.g. `{ name: "Sacubitril", strength: 49 }` +
+ * `{ name: "Valsartan", strength: 51 }` for a "Vymada 100" tablet.
+ * The unit is shared with the parent record's `unit` field (normally "mg").
+ */
+export interface CompoundStrength {
+  name: string;
+  strength: number;
+}
+
+export interface Prescription {
+  id: string;
+  genericName: string;
+  indication: string;
+  notes?: string;
+  contraindications?: string[];
+  warnings?: string[];
+  /**
+   * Active ingredients for a combination drug. Absent ⇒ single-compound
+   * prescription (the common case). When present (length ≥ 2) the strengths
+   * describe one standard reference dose and fix the compound ratio used to
+   * label doses. Non-indexed — no Dexie version bump required.
+   */
+  compounds?: CompoundStrength[];
+  isActive: boolean;
+  createdAt: number;
+  updatedAt: number;
+  deletedAt: number | null;
+  deviceId: string;
+}
+
+export type PhaseType = "maintenance" | "titration";
+
+export interface MedicationPhase {
+  id: string;
+  prescriptionId: string;
+  type: PhaseType;
+  unit: string;
+  startDate: number;
+  endDate?: number;
+  foodInstruction: FoodInstruction;
+  foodNote?: string;
+  notes?: string;
+  status: "active" | "completed" | "cancelled" | "pending";
+  titrationPlanId?: string; // links titration phases to their parent plan
+  createdAt: number;
+  updatedAt: number;
+  deletedAt: number | null;
+  deviceId: string;
+}
+
+export type TitrationPlanStatus = "draft" | "active" | "completed" | "cancelled";
+
+export interface TitrationPlan {
+  id: string;
+  title: string;
+  conditionLabel: string; // e.g. "Heart failure", managed as unique labels
+  recommendedStartDate?: number;
+  status: TitrationPlanStatus;
+  notes?: string;
+  warnings?: string[]; // warning signs to look out for
+  createdAt: number;
+  updatedAt: number;
+  deletedAt: number | null;
+  deviceId: string;
+}
+
+export interface PhaseSchedule {
+  id: string;
+  phaseId: string;
+  /** @deprecated Use scheduleTimeUTC. Kept for v10 DB record compatibility. */
+  time: string;
+  scheduleTimeUTC: number; // minutes from midnight UTC (integer)
+  anchorTimezone: string; // IANA timezone when schedule was created
+  dosage: number;
+  daysOfWeek: number[];
+  enabled: boolean;
+  unit?: string; // dosage unit for display, e.g. "mg"
+  createdAt: number;
+  updatedAt: number;
+  deletedAt: number | null;
+  deviceId: string;
+}
+
+export interface InventoryItem {
+  id: string;
+  prescriptionId: string;
+  brandName: string;
+  /** @deprecated Use inventoryTransactions sum. Will be removed in Phase 3. */
+  currentStock?: number;
+  /** Sum of `compounds` strengths for a combination tablet; the single
+   *  per-pill strength otherwise. Always the pill-math denominator. */
+  strength: number;
+  /**
+   * Per-pill breakdown for a combination tablet (e.g. Vymada 100 ⇒
+   * Sacubitril 49 + Valsartan 51). Absent ⇒ single-compound pill.
+   * `strength` stays authoritative for dose math; this is descriptive.
+   */
+  compounds?: CompoundStrength[];
+  unit: string;
+  pillShape: PillShape;
+  pillColor: string;
+  visualIdentification?: string;
+  refillAlertDays?: number;
+  refillAlertPills?: number;
+  isActive: boolean;
+  isArchived?: boolean;
+  createdAt: number;
+  updatedAt: number;
+  deletedAt: number | null;
+  deviceId: string;
+  timezone: string;
+}
+
+export interface InventoryTransaction {
+  id: string;
+  inventoryItemId: string;
+  timestamp: number;
+  amount: number;
+  note?: string;
+  type: "refill" | "consumed" | "adjusted" | "initial";
+  doseLogId?: string; // links consumed transaction to the dose that caused it
+  createdAt: number;
+  updatedAt: number;
+  deletedAt: number | null;
+  deviceId: string;
+  timezone: string;
+}
+
+export interface DailyNote {
+  id: string;
+  date: string; // YYYY-MM-DD
+  prescriptionId?: string;
+  doseLogId?: string;
+  note: string;
+  createdAt: number;
+  updatedAt: number;
+  deletedAt: number | null;
+  deviceId: string;
+  timezone: string;
+}
+
+export interface DoseLog {
+  id: string;
+  prescriptionId: string;
+  phaseId: string;
+  scheduleId: string;
+  inventoryItemId?: string;
+  scheduledDate: string;
+  scheduledTime: string;
+  status: DoseStatus;
+  actionTimestamp?: number;
+  rescheduledTo?: string;
+  skipReason?: string;
+  note?: string;
+  timezone: string; // IANA timezone string, e.g. "Africa/Johannesburg"
+  createdAt: number;
+  updatedAt: number;
+  deletedAt: number | null;
+  deviceId: string;
+}
+
+export interface SubstanceRecord {
+  id: string;
+  type: 'caffeine' | 'alcohol';
+  amountMg?: number;           // caffeine mg
+  amountStandardDrinks?: number; // alcohol: metric standard drinks (derived from abvPercent + volumeMl)
+  abvPercent?: number;          // alcohol: alcohol by volume %, the user-entered input value
+  volumeMl?: number;            // liquid volume for fluid balance linking
+  description: string;
+  source: 'water_intake' | 'eating' | 'standalone';
+  sourceRecordId?: string;      // links to original intake record if migrated
+  aiEnriched?: boolean;         // true if AI has refined the estimate
+  timestamp: number;
+  createdAt: number;
+  updatedAt: number;
+  deletedAt: number | null;
+  deviceId: string;
+  timezone: string;
+  groupId?: string; // shared key linking records in a composable group
+  originalInputText?: string; // stored on primary record only, for AI re-run
+  groupSource?: string; // "ai_food_parse" | "ai_substance_lookup" | "manual"
+}
+
+/** Sync queue op-log row (Dexie v16+, Phase 43 D-01).
+ *  `id` is auto-increment (++id). `op: 'delete'` exists for future hard-delete paths
+ *  but is unused in the P43 pilot (soft-deletes go through upsert with deletedAt set). */
+export interface SyncQueueRow {
+  id?: number;
+  tableName: string;
+  recordId: string;
+  op: "upsert" | "delete";
+  enqueuedAt: number;
+  attempts: number;
+}
+
+/** Per-table pull cursor (Dexie v16+, Phase 43 D-07). Singleton per tableName. */
+export interface SyncMetaRow {
+  tableName: string;
+  lastPulledUpdatedAt: number;
+  /**
+   * Tiebreaker for the keyset cursor — the `id` of the last row consumed at
+   * `lastPulledUpdatedAt`. Pagination orders by `(updatedAt, id)` so that a
+   * page boundary landing inside a run of rows that share one `updatedAt`
+   * (e.g. the v11 migration stamped every record with a single timestamp)
+   * cannot strand the rows after the boundary. Absent on cursors written by
+   * pre-keyset clients — readers default it to `""` (sorts before any id).
+   */
+  lastPulledId?: string;
+}
+
+/** Source of a captured error/warning. Device-local debug data, never synced. */
+export type ErrorLogSource =
+  | "window-error"
+  | "unhandled-rejection"
+  | "error-boundary"
+  | "console-error"
+  | "console-warn"
+  | "api-error";
+
+/** Captured error/warning. Local-only (Dexie v17+); not part of backup or sync. */
+export interface ErrorLogEntry {
+  id: string;
+  timestamp: number;
+  source: ErrorLogSource;
+  message: string;
+  stack?: string;
+  componentStack?: string;
+  route?: string;
+  userAgent?: string;
+  appVersion?: string;
+}
+
+/**
+ * Single-user medical profile (Dexie v18). Holds user-reported medical
+ * conditions that give AI analytics insights clinical context (e.g. why the
+ * sodium and fluid limits matter). The app treats it as a singleton — the
+ * service layer reads the most-recently-updated active row — but each row
+ * carries a globally-unique `id` so it backs up and cloud-syncs through the
+ * standard record-oriented engine alongside every other table.
+ */
+export interface UserProfile {
+  id: string;
+  conditions: string[]; // user-reported medical conditions, e.g. "HFrEF"
+  shareConditionsWithAI: boolean; // opt-in: include conditions in AI insights
+  shareMedicationsWithAI: boolean; // opt-in: include active medications in AI insights
+  aiInsightsConsentAt: number | null; // when the user first consented; null = never
+  createdAt: number;
+  updatedAt: number;
+  deletedAt: number | null;
+  deviceId: string;
+}
+
+/**
+ * A cached AI analytics insight report (Dexie v19). Each row is one generated
+ * "AI Insights" summary — the narrative and observations the model produced
+ * for a rolling analysis window. Persisting them gives the user a history of
+ * past assessments and lets a fresh analysis optionally compare against the
+ * previous one. Synced and backed up like every other record-oriented table.
+ */
+export interface InsightReport {
+  id: string;
+  generatedAt: number; // when the AI produced this report (Unix ms)
+  rangeStart: number; // analysis window start (Unix ms)
+  rangeEnd: number; // analysis window end (Unix ms)
+  narrative: string; // plain-language summary
+  observations: string[]; // specific factual observations
+  // URLs the model cited via web_search (deep mode only). Optional —
+  // fast-mode reports and legacy rows from before sources were tracked
+  // leave this undefined.
+  sources?: string[];
+  personalised: boolean; // whether the user's medical profile fed the analysis
+  // "fast" = sync Sonnet summary; "deep" = async Opus + web-search deep
+  // research. Optional for rows written before the two-tier rollout — the
+  // client treats `undefined` as "fast".
+  mode?: "fast" | "deep";
+  createdAt: number;
+  updatedAt: number;
+  deletedAt: number | null;
+  deviceId: string;
+}

--- a/packages/types/tsconfig.json
+++ b/packages/types/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "@intake/typescript-config/base.json",
+  "compilerOptions": {
+    "noEmit": true
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["node_modules"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -72,6 +72,9 @@ importers:
       '@intake/db':
         specifier: workspace:*
         version: link:../../packages/db
+      '@intake/types':
+        specifier: workspace:*
+        version: link:../../packages/types
       '@modelcontextprotocol/sdk':
         specifier: 1.29.0
         version: 1.29.0(zod@4.4.3)
@@ -389,6 +392,15 @@ importers:
       typescript-eslint:
         specifier: ^8.60.1
         version: 8.60.1(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3)
+
+  packages/types:
+    devDependencies:
+      '@intake/typescript-config':
+        specifier: workspace:*
+        version: link:../typescript-config
+      typescript:
+        specifier: ^6.0.3
+        version: 6.0.3
 
   packages/typescript-config: {}
 


### PR DESCRIPTION
## Phase 3a — extract `@intake/types`

First half of Phase 3 (`types+core`). Per the agreed scope (**split + defer**), this PR is **types only**; `@intake/core` (clean + partial-split pure fns) lands next as PR 3b, and the wall-clock `now`/`tz` injection refactor of the 2 analytics functions is deferred to Phase 3.1.

### What moved
The **29 Dexie record/data-model type declarations** (the 18 table interfaces + their enums/unions) move out of `apps/web/src/lib/db.ts` into a new dependency-root package **`@intake/types`** (`packages/types/src/records.ts`), consumed as raw TS via `transpilePackages`.

The Dexie **runtime stays in `db.ts`** — the `new Dexie()` instance, the `AppDatabase` type, every `version().stores()` migration block, `DB_SCHEMA_VERSION`, and the preview helpers. `db.ts` **re-exports** the record types, so all **~164 `@/lib/db` importers resolve unchanged** (zero importer churn — only ~12 files actually change).

`@intake/types` is **isomorphic** (no `client-only`/`server-only`/react/dexie) so it sits at the bottom of the dependency graph and is safe to import from server API routes and the client alike.

### The headline gotcha (handled)
`schema-parity.test.ts`'s extractor parses the record interfaces as **text** via single-file `ts.createSourceFile` — it does *not* import them. Moving the interfaces would silently break it. Fix: repoint `dexie-schema-extractor.ts`'s `DB_TS_DEFAULT_PATH` → `packages/types/src/records.ts`, keeping **all 18 table interfaces in that one file** (single-file parse).

### Wiring
- `@intake/types` → `apps/web` deps + `next.config.mjs` `transpilePackages`
- `packages/types/src/records.ts` added to the `ci.yml` `bench` paths-filter (record-shape changes still trigger the migration-sensitive job)
- Parity-rule docs updated to the new source of truth: `CLAUDE.md`, `AGENTS.md`, `@intake/db/schema` comments, `optional-trackers.ts`

### Verification (all green locally)
| Gate | Result |
|---|---|
| `turbo typecheck` (3 pkgs) | ✓ |
| `turbo lint` | ✓ 0 errors |
| parity + journal + integrity | ✓ 95 tests |
| full unit suite | ✓ **2017 tests** (208 files) |
| integration — testcontainers/Docker | ✓ 33 tests |
| production build | ✓ (JIT transpile + `client-only` boundary holds) |
| bundle-security scan | ✓ 3 tests, no leaks |
| re-export completeness | ✓ 34/34 imported `@/lib/db` symbols provided |

Integration suite run locally with Docker specifically because that's the CI-only path that bit #215. A 3-reviewer adversarial pass (CI-completeness / boundary-correctness / docs) found **no blockers** — the move is byte-faithful and boundary-clean; its doc findings are folded into this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)