### PR TITLE
ci(repo): finalize turbo-native CI — drop stacked-PR scaffolding, fix mutation paths (phase 5a)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,13 +2,9 @@ name: CI
 
 on:
   pull_request:
-    # Runs on PRs to main/staging AND to the stacked Turborepo migration branches
-    # so each phase in the stack is validated. The migration-branch trigger is
-    # temporary — drop it once the stack lands on main.
     branches:
       - main
       - staging
-      - "refactor/turborepo-monorepo-plan**"
 
 jobs:
   changes:
@@ -218,12 +214,8 @@ jobs:
   e2e:
     # Auth is Neon Auth (cookie session). E2E uses Playwright globalSetup to seed
     # a session via Neon Auth.
-    # Full browser e2e is an ~11-min, env/timing-sensitive smoke test. During the
-    # Turborepo migration it runs only on PRs that target main (the cutover) —
-    # the per-phase safety net is the green core (unit, integration, build,
-    # schema-migration). Drop the base_ref gate once the stack lands on main.
     needs: [changes, secrets-check, security]
-    if: needs.changes.outputs.src == 'true' && needs.secrets-check.outputs.neon == 'true' && github.base_ref == 'main'
+    if: needs.changes.outputs.src == 'true' && needs.secrets-check.outputs.neon == 'true'
     runs-on: ubuntu-latest
     steps:
       - name: Harden runner (egress audit)

--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -32,6 +32,12 @@ jobs:
   mutation:
     runs-on: ubuntu-latest
     timeout-minutes: 45
+    # Stryker config, the baseline script, and the .stryker-tmp report all live
+    # in apps/web after the Turborepo move, so run every step from there. (`uses:`
+    # steps like checkout/setup are unaffected — this only applies to `run:`.)
+    defaults:
+      run:
+        working-directory: apps/web
     steps:
       - uses: actions/checkout@v6
         with:
@@ -105,7 +111,7 @@ jobs:
         with:
           name: stryker-html-report
           path: |
-            .stryker-tmp/mutation/
-            stryker.log
+            apps/web/.stryker-tmp/mutation/
+            apps/web/stryker.log
           retention-days: 14
           if-no-files-found: warn

--- a/apps/web/src/__tests__/ci-workflow-structure.test.ts
+++ b/apps/web/src/__tests__/ci-workflow-structure.test.ts
@@ -62,12 +62,19 @@ function extractJobBlock(jobName: string, yaml: string): string {
 }
 
 describe("CI workflow gates PRs with required checks (CIPL-01)", () => {
-  it("workflow triggers on pull_request to main and staging (+ migration branches)", () => {
-    // Requirement: every PR to main or staging must be validated. (The Turborepo
-    // migration also temporarily triggers on the refactor/* stack branches.)
+  it("workflow triggers on pull_request to main and staging", () => {
+    // Requirement: every PR to main or staging must be validated.
     expect(raw).toContain("pull_request:");
     expect(raw).toContain("- main");
     expect(raw).toContain("- staging");
+  });
+
+  it("does NOT trigger on the temporary Turborepo migration branches", () => {
+    // The 'refactor/turborepo-monorepo-plan**' trigger was scaffolding for the
+    // stacked-PR migration; it was dropped in Phase 5a once the stack landed on
+    // main. This guard prevents it (or any refactor/* branch trigger) from being
+    // reintroduced, which would re-run full CI on every intra-stack push.
+    expect(raw).not.toContain("refactor/turborepo");
   });
 
   it("required check jobs are all present in the workflow", () => {
@@ -612,6 +619,16 @@ describe("Path filtering gates expensive jobs on src/bench changes (CIOP-01)", (
       e2eBlock,
       "e2e must gate on needs.changes.outputs.src == 'true'"
     ).toContain("needs.changes.outputs.src");
+  });
+
+  it("e2e job is NOT gated on base_ref (the temporary migration gate is gone)", () => {
+    // During the stacked migration, e2e ran only on PRs targeting main
+    // (`github.base_ref == 'main'`). That gate was dropped in Phase 5a so e2e
+    // runs on every src PR again. Guard against reintroducing the base_ref gate.
+    const e2eBlock = extractJobBlock("e2e", raw);
+    expect(e2eBlock, "e2e must not be gated on github.base_ref").not.toContain(
+      "base_ref"
+    );
   });
 
   it("benchmark job depends on changes and gates on bench output", () => {


### PR DESCRIPTION
## Phase 5a — CI finalize (code-only, zero infra)

First of the three Phase 5 sub-phases (5a CI cleanup → 5b mobile scaffold → 5c migrator switch). The stacked-PR Turborepo migration has landed on `main`, so this removes the temporary CI scaffolding and fixes a path drift left by the package moves.

### Changes
- **Drop the `refactor/turborepo-monorepo-plan**` PR branch trigger** (`ci.yml`) — CI is back to plain `main`/`staging` PRs.
- **Drop the `&& github.base_ref == 'main'` gate on the `e2e` job** — e2e was limited to cutover PRs during the migration; it now runs on every `src` PR again (the suite is green at ~4 min).
- **Fix `mutation.yml` path drift** — `stryker.conf.json`, the baseline script, and `.stryker-tmp` all moved to `apps/web`; the job now runs with `working-directory: apps/web` and the uploaded artifact paths are re-rooted.
- **Negative guards** in `ci-workflow-structure.test.ts` (symmetric with the existing no-`psql` guard) so neither the `refactor/*` trigger nor the `base_ref` e2e gate can be reintroduced.

### Verification
- YAML parses; `refactor/turborepo` + `base_ref` confirmed gone from `ci.yml`
- turbo typecheck (6 pkgs), **64 structural assertions** pass (+2 new guards), full unit suite (2032) green via pre-commit hook

Deferred (recommended): Turbo remote cache (`TURBO_TOKEN`/`TURBO_TEAM`) — low value for a single-dev repo. Owner-only Vercel "skip-unaffected" toggle rides with 5c.

Owner merges; **5b (`apps/mobile` scaffold)** next.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Refined CI trigger configuration to target `main` and `staging` branches.
  * Updated end-to-end test execution logic for broader source code change detection.
  * Configured mutation testing workflow with updated working directory paths.

* **Tests**
  * Enhanced CI workflow structure validation tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->