### PR TITLE
ci(repo): add the decoupled production migrator mechanism (phase 5c)

### DIFF
--- a/.github/workflows/migrate-prod.yml
+++ b/.github/workflows/migrate-prod.yml
@@ -1,0 +1,63 @@
+name: Migrate production database
+
+# Decoupled production migrator (Phase 5c). Applies committed Drizzle migrations
+# to the production Neon database via `drizzle-kit migrate` over the DIRECT
+# (unpooled) endpoint. This replaces the migration that `vercel-build` used to
+# run inline (apps/web/scripts/migrate.ts) — making the migration step visible
+# and independent of the deploy instead of buried in the build log.
+#
+# GATED on owner setup (see DEFERRED.md):
+#   1. Provision the `DATABASE_URL_UNPOOLED` repo secret = Neon's direct,
+#      non-pooler endpoint (host WITHOUT the `-pooler` segment).
+#   2. One-time validation on a Neon preview branch (a copy of prod history):
+#      confirm `drizzle-kit migrate` recognizes the existing __drizzle_migrations
+#      entries by hash (no re-apply) before this ever points at prod.
+#   3. Use the manual `workflow_dispatch` below to prove a green run on prod;
+#      verify __drizzle_migrations afterwards. ONLY THEN retire the inline
+#      vercel-build migrate step + apps/web/scripts/migrate.ts (separate PR).
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "packages/db/migrations/**"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+# Never cancel an in-flight migration: a half-applied migration is far worse
+# than a queued one. Serialize runs instead.
+concurrency:
+  group: migrate-prod
+  cancel-in-progress: false
+
+jobs:
+  migrate:
+    runs-on: ubuntu-latest
+    # Bound a hung migration (e.g. a stuck advisory lock) instead of letting it
+    # run to the 6h default. With cancel-in-progress:false this only times out
+    # the single in-flight job, never a half-applied migration mid-statement.
+    timeout-minutes: 10
+    steps:
+      - name: Harden runner (egress audit)
+        uses: step-security/harden-runner@v2
+        with:
+          egress-policy: audit
+      - uses: actions/checkout@v6
+      - uses: pnpm/action-setup@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: "22"
+          cache: "pnpm"
+      - run: pnpm install --frozen-lockfile
+      - name: Apply migrations to production (direct endpoint)
+        env:
+          DATABASE_URL_UNPOOLED: ${{ secrets.DATABASE_URL_UNPOOLED }}
+        run: |
+          set -euo pipefail
+          if [ -z "${DATABASE_URL_UNPOOLED:-}" ]; then
+            echo "::error::DATABASE_URL_UNPOOLED is not set. Provision Neon's DIRECT (non-pooler) endpoint as a repo secret before enabling production migrations — see DEFERRED.md."
+            exit 1
+          fi
+          pnpm --filter @intake/db db:migrate

--- a/DEFERRED.md
+++ b/DEFERRED.md
@@ -197,3 +197,71 @@ at every `@/components/ui/*` and `@/hooks/*` path (zero importer churn). Deferre
   `packages/ui` rather than the `apps/web` shim layer. Purely mechanical, no
   behaviour change. **Trigger:** the importer-rewrite sweep (low priority).
 
+## Phase 5 — mobile scaffold folded into Milestone M
+
+**Deferred (2026-06-13, owner decision).** The proposal's Phase 5 included an
+`apps/mobile` Capacitor scaffold + "burn the `cap-build.js` hack". A scoping
+spike found this can't be cleanly completed or verified outside the full mobile
+build, so **all mobile work moves to Milestone M** (the Android/Play rebuild),
+done as one coherent effort. Phase 5 is therefore just **5a** (CI finalize —
+done) + **5c** (migrator switch — owner-gated). Findings to carry into M:
+
+- **`output: "export"` is blocked by the `app/api/**` route handlers, not by
+  middleware.** A local `next build` with `output:export` and no stash fails on
+  the first dynamic route handler (`/api/ai/status`: *"export const dynamic =
+  force-static not configured with output: export"*). There is **no clean
+  per-route fix** — `export const dynamic` must be a static string literal, so it
+  can't be env-gated to `force-static` only for the mobile build. The mobile
+  shell never calls these routes (it uses the remote `NEXT_PUBLIC_API_BASE_URL`),
+  so excluding the whole `api/` dir is correct — but Next has no native
+  "exclude-this-dir-from-export" flag, which is exactly why `cap-build.js` renames
+  `api/` → the private `_api-server-only` folder during the export. The
+  camp-404 "no-rename" pattern assumed *no api routes in the mobile build*, which
+  doesn't hold here. **M must design a real api-exclusion mechanism** (crash-safe
+  stash, a dedicated mobile route tree, or a Next-native exclusion) and verify a
+  clean `output:export` build, **then** `cap add android` fresh + signed build +
+  on-device + Play.
+- **Next 16 demoted `middleware`** to a deprecation warning (use `proxy`); it is
+  no longer a hard `output:export` blocker. Consider migrating `middleware.ts` →
+  `proxy` as part of M (or its own small chore).
+- **Capacitor version drift:** `android/capacitor.settings.gradle` (a generated
+  DO-NOT-EDIT file) still references `@capacitor+android@8.3.4` while
+  `package.json` declares `^8.4.0`. A `cap sync` after the `android/` move
+  regenerates it with correct paths — do NOT hand-edit it.
+- Mobile-only deps to relocate to `apps/mobile` in M: `@capacitor/cli` +
+  `@capacitor/android` (native tooling). KEEP `@capacitor/{core,local-notifications,network}`
+  in `apps/web` — the web code imports them (×2 each).
+- Re-root `android-release.yml` paths to `apps/mobile` (the `node scripts/cap-build.js`
+  step at ~:56 is already broken post-phase-1, so it's not a working baseline).
+
+## Phase 5c — migrator cutover (gated on owner infra)
+
+**In progress (2026-06-13, draft PR).** The draft lands the *mechanism* only —
+`@intake/db db:migrate` = `drizzle-kit migrate`, the `DATABASE_URL_UNPOOLED ??
+DATABASE_URL` config fallback, and `migrate-prod.yml` (push:main on
+`packages/db/migrations/**` + `workflow_dispatch`, never-cancel concurrency,
+empty-secret hard-fail). It touches **no production path** — `vercel-build` still
+runs `apps/web/scripts/migrate.ts`, and CI still uses it via the root
+`db:migrate` passthrough. The **cutover** is deferred until the owner completes
+the gate, in this strict order:
+
+1. **OWNER:** provision `DATABASE_URL_UNPOOLED` (Neon's DIRECT/non-pooler
+   endpoint) as a GitHub Actions repo secret (and confirm it in the Vercel env).
+2. **OWNER:** one-time Neon **preview-branch** validation — copy prod history to
+   a preview branch, point `drizzle-kit migrate` at its unpooled URL, confirm it
+   recognizes the existing `__drizzle_migrations` (0000–0017) by hash (no
+   re-apply) then applies cleanly. NEVER `drizzle-kit push`.
+3. Merge the draft, then `workflow_dispatch` `migrate-prod.yml` to prove a green
+   run on prod; manually verify `SELECT * FROM __drizzle_migrations` shows
+   0017's hash (don't trust the success log).
+4. **ONLY THEN (separate cutover PR):** strip `apps/web` `vercel-build` to plain
+   `next build`; repoint `ci.yml` `db:migrate` call sites + the root passthrough
+   to `@intake/db`; **last**, delete `apps/web/scripts/migrate.ts`; update the
+   stale CLAUDE.md "Database Migrations" section. Deleting the legacy script or
+   stripping vercel-build *before* a proven migrate-prod run would let prod ship
+   against an un-migrated schema.
+
+The journal timestamp footgun is **past** (max `when ≈ 2026-06-07 < today`), so
+the migrator switch is orthogonal to it — but the cutover PR must still verify
+the next real prod migration actually applies.
+

--- a/packages/db/drizzle.config.ts
+++ b/packages/db/drizzle.config.ts
@@ -11,10 +11,15 @@ loadEnvConfig(process.cwd());
  *
  * Usage (from packages/db, e.g. `pnpm --filter @intake/db db:generate`):
  *   pnpm exec drizzle-kit generate  # emit SQL from schema.ts
+ *   pnpm exec drizzle-kit migrate   # apply pending migrations (Phase 5c)
  *
- * Production migrations are still applied by apps/web/scripts/migrate.ts
- * (drizzle-orm/neon-http migrator) reading this `out` folder — the migrator
- * switch to `drizzle-kit migrate` is a deferred follow-up.
+ * Phase 5c adds `db:migrate` = `drizzle-kit migrate`, run in production by the
+ * decoupled `migrate-prod.yml` workflow against `DATABASE_URL_UNPOOLED` (Neon's
+ * DIRECT endpoint — `drizzle-kit migrate` opens a TCP session for transactional
+ * DDL/advisory locks, which the pooled PgBouncer endpoint can't serve safely).
+ * The cutover (retiring apps/web/scripts/migrate.ts + the `vercel-build` migrate
+ * step) is gated on the owner provisioning the unpooled secret + a one-time Neon
+ * preview-branch validation — see DEFERRED.md.
  *
  * NEVER use `drizzle-kit push` in this project (D-14 in 42-CONTEXT.md).
  */
@@ -30,7 +35,12 @@ export default defineConfig({
   // driver: "neon-http" — removed per plan acceptance criteria grep check;
   // if operator needs to re-enable, pin drizzle-kit to 0.28.x or older.
   dbCredentials: {
-    url: process.env.DATABASE_URL!,
+    // Prefer Neon's DIRECT (unpooled) endpoint for `drizzle-kit migrate` —
+    // transactional DDL + advisory locks need a real session, not the pooled
+    // PgBouncer transaction-mode endpoint. Falls back to DATABASE_URL so CI
+    // (ephemeral Neon branches, which expose a direct URL as DATABASE_URL) and
+    // `drizzle-kit generate` (no connection) keep working unchanged.
+    url: process.env.DATABASE_URL_UNPOOLED ?? process.env.DATABASE_URL!,
   },
   verbose: true,
   strict: true,

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -11,7 +11,8 @@
   },
   "scripts": {
     "typecheck": "tsc --noEmit",
-    "db:generate": "drizzle-kit generate"
+    "db:generate": "drizzle-kit generate",
+    "db:migrate": "drizzle-kit migrate"
   },
   "dependencies": {
     "@neondatabase/serverless": "^1.1.0",


### PR DESCRIPTION
## Phase 5c — migrator switch (⛔ do not merge until owner gate)

> **Ready for review** (CodeRabbit + owner) — but **do not _merge_ until the owner gate below is complete.** This lands the migrator-switch **mechanism only** and touches **no production or CI path** — `vercel-build` still runs `apps/web/scripts/migrate.ts`, and CI still uses it via the root `db:migrate` passthrough. Verified by a 2-agent adversarial pass (prod-safety + workflow-correctness) = clean.

Retires the custom `apps/web/scripts/migrate.ts` (deferred from Phase 2) in favour of standard `drizzle-kit migrate` run by a decoupled workflow — making the prod migration **visible** instead of buried in the Vercel build log.

### What this draft adds
- **`@intake/db` `db:migrate`** = `drizzle-kit migrate`.
- **`drizzle.config.ts`** `url: DATABASE_URL_UNPOOLED ?? DATABASE_URL`. `drizzle-kit migrate` needs a real TCP session (transactional DDL + advisory locks) over Neon's **direct** endpoint; the pooled PgBouncer endpoint can't serve that safely. The fallback keeps CI (ephemeral Neon branches expose a direct URL as `DATABASE_URL`) and `drizzle-kit generate` (no connection) working unchanged.
- **`.github/workflows/migrate-prod.yml`** (new) — `push:main` on `packages/db/migrations/**` + `workflow_dispatch`; never-cancel concurrency; `contents: read`; `timeout-minutes: 10`; harden-runner; an **empty-secret hard-fail** so a missing `DATABASE_URL_UNPOOLED` can never silently no-op or fall back to a pooled URL.
- **`DEFERRED.md`** — the gated cutover steps + the Phase-5 mobile deferral to Milestone M (the `output:export`/api-route finding from the 5b spike).

### ⛔ Owner gate (in order)
1. **Provision `DATABASE_URL_UNPOOLED`** = Neon's direct/non-pooler endpoint (host without the `-pooler` segment) as a GitHub Actions repo secret (and confirm it in the Vercel env).
2. **One-time Neon preview-branch validation** — copy prod history to a preview branch, point `drizzle-kit migrate` at its unpooled URL, confirm it recognizes the existing `__drizzle_migrations` (0000–0017) by hash (no re-apply) then applies cleanly. **Never** `drizzle-kit push`.
3. Merge this draft, then `workflow_dispatch` `migrate-prod` to prove a green run on prod; manually `SELECT * FROM __drizzle_migrations` to confirm 0017's hash (don't trust the success log).
4. **Separate cutover PR** (only after step 3): strip `vercel-build` → `next build`; repoint `ci.yml` `db:migrate` + the root passthrough to `@intake/db`; **last**, delete `migrate.ts`; fix the CLAUDE.md migrations section.

⚠️ **Heads-up:** once merged, the *first future migration commit* to `main` fires `migrate-prod`. If the secret isn't provisioned by then it hard-fails (red ✗ on main, **no prod mutation** — by design). So provision the secret before the next schema change lands.

### Notes for the cutover PR
Consider tightening `migrate-prod`'s harden-runner from `audit` → `block` + a Neon-host allowlist once it's the live prod path.

This (plus 5a) completes **Phase 5**. Mobile is folded into **Milestone M**.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Established automated production database migration pipeline through CI/CD workflow to ensure reliable, consistent database deployments
  * Implemented comprehensive validation and safety mechanisms for production migration processes
  * Enhanced project documentation clarifying planned development phases and scope of deferred work

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
