### PR TITLE
chore(web): ratchet two clean ESLint rules to error + drop stale disables

### DIFF
--- a/apps/web/eslint.config.mjs
+++ b/apps/web/eslint.config.mjs
@@ -74,9 +74,9 @@ export default [
       ],
       "@typescript-eslint/no-explicit-any": "warn",
       "@typescript-eslint/no-require-imports": "warn",
-      "@typescript-eslint/no-empty-object-type": "warn",
+      "@typescript-eslint/no-empty-object-type": "error",
       "@typescript-eslint/no-unsafe-function-type": "warn",
-      "no-regex-spaces": "warn",
+      "no-regex-spaces": "error",
       "no-empty": "warn",
       // Promoted to error (May 2026 audit).
       "react-hooks/rules-of-hooks": "error",

--- a/apps/web/src/__tests__/day-in-the-life.flow.test.tsx
+++ b/apps/web/src/__tests__/day-in-the-life.flow.test.tsx
@@ -65,7 +65,6 @@ import { WeightCard } from "@/components/weight-card";
 import { UrinationCard } from "@/components/urination-card";
 import { DefecationCard } from "@/components/defecation-card";
 import { renderWithFixtures } from "@/__tests__/react-test-utils";
-// eslint-disable-next-line no-restricted-imports
 import { db } from "@/lib/db";
 
 const server = setupServer(

--- a/apps/web/src/lib/sync-engine.ts
+++ b/apps/web/src/lib/sync-engine.ts
@@ -388,7 +388,6 @@ export async function runPullCycle(): Promise<void> {
   useSyncStatusStore.setState({ isSyncing: true });
 
   try {
-    // eslint-disable-next-line no-constant-condition
     while (true) {
       const cursors: Record<string, { updatedAt: number; id: string }> = {};
       for (const tn of TABLE_PUSH_ORDER) {


### PR DESCRIPTION
First of the **post-migration tech-debt cleanup** PRs. An audit re-measured the DEFERRED.md backlog against current code and produced a verified, ordered sequence; this is the zero-risk opener.

## This PR
- Flip `no-regex-spaces` and `@typescript-eslint/no-empty-object-type` **warn → error** (`apps/web/eslint.config.mjs`). Both measure **0 violations** today, so this is a no-code-change ratchet that locks in cleanup already done.
- Remove the **2 stale `eslint-disable` directives** the linter flagged as unused (`day-in-the-life.flow.test.tsx` → `no-restricted-imports`; `sync-engine.ts` → `no-constant-condition`).

Verified: lint **0 errors** (116 warnings, down from 118), typecheck green across all 6 packages, full suite green. No source-behaviour change.

## The cleanup roadmap (each its own PR, this is #1)
1. ▶︎ **(this)** flip already-clean ESLint rules + drop stale disables
2. `refactor(zod)` clear deprecated v4 APIs (`.flatten`→`flattenError`, `url()/email()` collapse) — *note: the audit disproved the "z.url() is stricter" risk; the XSS guard is a runtime `isSafeHref`, untouched*
3. `chore(eslint)` autofix `consistent-type-imports` + flip
4. `refactor(eslint)` clear `no-empty` + `no-require-imports` + `no-unsafe-function-type` + flip
5. `refactor(eslint)` eliminate `no-unused-vars` (~30) + flip
6. `refactor(eslint)` replace `no-explicit-any` (~43, real types) + flip
7. `chore(deps)` prune now-indirect UI deps from apps/web
8. `refactor(imports)` repoint UI + hook shims → `@intake/ui`, delete shims, retarget `components.json`
9. `refactor(imports)` repoint pure `@/lib/*` shims → `@intake/{core,types,ai-prompts}`, delete
10. `test(sync)` four-list table set-equality guard + fix the live `insightReports` drift

Deferred further (net-new tooling / behavior-sensitive / app-entangled): the `@intake/types` table registry, dependency-cruiser boundary layering, prompt-text consolidation, `migrateSettings`.