### PR TITLE
chore(web): ratchet no-explicit-any / no-unused-vars / consistent-type-imports to error (tech-debt B2)

### DIFF
--- a/apps/web/eslint.config.mjs
+++ b/apps/web/eslint.config.mjs
@@ -67,12 +67,12 @@ export default [
       // Next.js rules (from @next/eslint-plugin-next, ESLint-10 native).
       ...nextPlugin.configs.recommended.rules,
       ...nextPlugin.configs["core-web-vitals"].rules,
-      // Deferred strict rules — ride at warn pending a cleanup pass (DEFERRED.md).
+      // Promoted to error (B2 cleanup pass, June 2026 — DEFERRED.md).
       "@typescript-eslint/no-unused-vars": [
-        "warn",
+        "error",
         { argsIgnorePattern: "^_", varsIgnorePattern: "^_" },
       ],
-      "@typescript-eslint/no-explicit-any": "warn",
+      "@typescript-eslint/no-explicit-any": "error",
       "@typescript-eslint/no-require-imports": "error",
       "@typescript-eslint/no-empty-object-type": "error",
       "@typescript-eslint/no-unsafe-function-type": "error",

--- a/apps/web/src/__tests__/a11y/components-a11y.test.tsx
+++ b/apps/web/src/__tests__/a11y/components-a11y.test.tsx
@@ -46,6 +46,7 @@
  */
 import { describe, it, expect, vi, beforeAll } from "vitest";
 import axe from "axe-core";
+import type * as AuthGuardModule from "@/components/auth-guard";
 
 beforeAll(() => {
   if (!Element.prototype.hasPointerCapture) {
@@ -64,7 +65,7 @@ beforeAll(() => {
 
 // Auth gate open for the food card so the AI input renders too.
 vi.mock("@/components/auth-guard", async (importActual) => {
-  const actual = await importActual<typeof import("@/components/auth-guard")>();
+  const actual = await importActual<typeof AuthGuardModule>();
   return { ...actual, useAuthGate: () => true };
 });
 

--- a/apps/web/src/__tests__/auth-guard.test.ts
+++ b/apps/web/src/__tests__/auth-guard.test.ts
@@ -22,6 +22,7 @@
  * stack (zero Privy / PIN imports).
  */
 import { describe, it, expect, vi, beforeEach } from "vitest";
+import type * as ReactModule from "react";
 
 type SessionUser = { id: string; email?: string; name?: string };
 type SessionResult = {
@@ -46,7 +47,7 @@ vi.mock("@/lib/auth-client", () => ({
 }));
 
 vi.mock("react", async (importOriginal) => {
-  const actual = await importOriginal<typeof import("react")>();
+  const actual = await importOriginal<typeof ReactModule>();
   return {
     ...actual,
     useState: (init: unknown) => [init, vi.fn()],

--- a/apps/web/src/__tests__/integration/mcp-oauth-integration.test.ts
+++ b/apps/web/src/__tests__/integration/mcp-oauth-integration.test.ts
@@ -27,10 +27,12 @@ import {
   type TestDbContext,
 } from "@/__tests__/helpers/test-db";
 import * as schema from "@intake/db/schema";
+import type * as OauthMod from "@/lib/mcp/oauth";
+import type * as TokensMod from "@/lib/mcp/tokens";
 
 let ctx: TestDbContext;
-let oauth: typeof import("@/lib/mcp/oauth");
-let tokens: typeof import("@/lib/mcp/tokens");
+let oauth: typeof OauthMod;
+let tokens: typeof TokensMod;
 
 beforeAll(async () => {
   ctx = await setupTestDb();

--- a/apps/web/src/__tests__/integration/mcp-rotation-race.test.ts
+++ b/apps/web/src/__tests__/integration/mcp-rotation-race.test.ts
@@ -29,9 +29,10 @@ import {
   type TestDbContext,
 } from "@/__tests__/helpers/test-db";
 import * as schema from "@intake/db/schema";
+import type * as OAuthMod from "@/lib/mcp/oauth";
 
 let ctx: TestDbContext;
-let oauth: typeof import("@/lib/mcp/oauth");
+let oauth: typeof OAuthMod;
 
 beforeAll(async () => {
   ctx = await setupTestDb();

--- a/apps/web/src/__tests__/integrity/backup-round-trip.test.ts
+++ b/apps/web/src/__tests__/integrity/backup-round-trip.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, beforeEach } from "vitest";
+import { type Table } from "dexie";
 import { db } from "@/lib/db";
 import { exportBackup, importBackup, type BackupData } from "@/lib/backup-service";
 import {
@@ -48,7 +49,7 @@ describe("backup round-trip: deep field equality", () => {
     const invItem = makeInventoryItem(prescription.id);
 
     // Build records map -- intakeRecords has 2 records (water + salt) to verify multi-record survival
-    const fixtures: Record<string, { records: unknown[]; table: any }> = {
+    const fixtures: Record<string, { records: unknown[]; table: Table<unknown> }> = {
       intakeRecords: { records: [makeIntakeRecord(), makeIntakeRecord({ type: "salt", amount: 500 })], table: db.intakeRecords },
       weightRecords: { records: [makeWeightRecord()], table: db.weightRecords },
       bloodPressureRecords: { records: [makeBloodPressureRecord()], table: db.bloodPressureRecords },
@@ -96,7 +97,7 @@ describe("backup round-trip: deep field equality", () => {
       const restored = await table.toArray();
       for (const original of originals) {
         const originalWithId = original as { id: string };
-        const match = restored.find((r: any) => r.id === originalWithId.id);
+        const match = restored.find((r) => (r as { id: string }).id === originalWithId.id);
         expect(match, [
           `x [Backup Round-Trip]: Record ${originalWithId.id} missing from ${tableName} after round-trip`,
           `  Fix: Check exportBackup() and importBackup() in src/lib/backup-service.ts`,
@@ -131,7 +132,7 @@ describe("backup round-trip: deep field equality", () => {
 
     // Our fixture record should exist by ID
     const restored = await db.auditLogs.toArray();
-    const match = restored.find((r: any) => r.id === fixtureAuditLog.id);
+    const match = restored.find((r) => r.id === fixtureAuditLog.id);
     expect(match, [
       `x [Backup Round-Trip]: Fixture audit log ${fixtureAuditLog.id} missing after round-trip`,
       `  Fix: Audit log export/import may be filtering records incorrectly`,
@@ -173,7 +174,7 @@ describe("backup round-trip: deep field equality", () => {
 
     // Verify each by ID with deep equality
     for (const original of [water, salt]) {
-      const match = restored.find((r: any) => r.id === original.id);
+      const match = restored.find((r) => r.id === original.id);
       expect(match, [
         `x [Backup Round-Trip]: Record ${original.id} (type=${original.type}) missing from intakeRecords`,
         `  Fix: Check exportBackup() handles multiple records per table correctly`,

--- a/apps/web/src/__tests__/migration/v10-migration.test.ts
+++ b/apps/web/src/__tests__/migration/v10-migration.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach } from "vitest";
+import { describe, it, expect } from "vitest";
 import { db } from "@/lib/db";
 import {
   makeIntakeRecord,
@@ -77,7 +77,7 @@ describe("SCHM-03: event-sourced inventory", () => {
     const rx = makePrescription({ id: "rx-stock-1" });
     const item = makeInventoryItem(rx.id, { id: "item-stock-1" });
     // Ensure currentStock is not set
-    const { currentStock, ...itemWithoutStock } = item as any;
+    const { currentStock: _currentStock, ...itemWithoutStock } = item;
     await db.prescriptions.add(rx);
     await db.inventoryItems.add(itemWithoutStock);
     const retrieved = await db.inventoryItems.get("item-stock-1");

--- a/apps/web/src/__tests__/migration/v15-migration.test.ts
+++ b/apps/web/src/__tests__/migration/v15-migration.test.ts
@@ -1,10 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { db } from "@/lib/db";
-import {
-  makeIntakeRecord,
-  makeEatingRecord,
-  makeSubstanceRecord,
-} from "@/__tests__/fixtures/db-fixtures";
+import { makeIntakeRecord } from "@/__tests__/fixtures/db-fixtures";
 
 describe("v15 migration: groupId index on intakeRecords, eatingRecords, substanceRecords", () => {
   it("existing v14 intakeRecords survive v15 upgrade with all data intact", async () => {

--- a/apps/web/src/__tests__/smoke.test.ts
+++ b/apps/web/src/__tests__/smoke.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { db } from "@/lib/db";
+import { db, type IntakeRecord } from "@/lib/db";
 
 describe("test infrastructure", () => {
   it("can open and read an empty database", async () => {
@@ -13,7 +13,7 @@ describe("test infrastructure", () => {
       type: "water",
       amount: 250,
       timestamp: Date.now(),
-    } as any);
+    } as unknown as IntakeRecord);
     const record = await db.intakeRecords.get("smoke-test-id");
     expect(record).toBeDefined();
     expect(record?.amount).toBe(250);

--- a/apps/web/src/__tests__/sync-conflict.property.test.ts
+++ b/apps/web/src/__tests__/sync-conflict.property.test.ts
@@ -97,7 +97,7 @@ vi.mock("@intake/db/client", () => {
         where: () => Promise.resolve(Object.values(existingRows)),
       }),
     }),
-    insert: (table: unknown) => ({
+    insert: (_table: unknown) => ({
       values: (v: ServerRow) => ({
         onConflictDoUpdate: async ({ set }: { target: unknown; set: Partial<ServerRow> }) => {
           // Mirror Postgres' ON CONFLICT DO UPDATE: prefer `set` values

--- a/apps/web/src/__tests__/sync-push-route.test.ts
+++ b/apps/web/src/__tests__/sync-push-route.test.ts
@@ -28,15 +28,12 @@ import { NextRequest } from "next/server";
 // Controllable stubs driving the drizzle mock
 // ────────────────────────────────────────────────────────────────────────
 
-type ServerRow = {
-  id: string;
-  userId: string;
-  updatedAt: number;
-  deletedAt: number | null;
-} | undefined;
-
-let existingRows: Record<string, any> = {};
-const insertCalls: { table: unknown; values: any; set: any }[] = [];
+let existingRows: Record<string, Record<string, unknown>> = {};
+const insertCalls: {
+  table: unknown;
+  values: Record<string, unknown>;
+  set: Record<string, unknown>;
+}[] = [];
 
 function resetDbState() {
   existingRows = {};
@@ -73,10 +70,15 @@ vi.mock("@intake/db/client", () => {
       }),
     }),
     insert: (table: unknown) => ({
-      values: (v: any) => ({
-        onConflictDoUpdate: async ({ set }: { target: unknown; set: any }) => {
+      values: (v: Record<string, unknown>) => ({
+        onConflictDoUpdate: async ({
+          set,
+        }: {
+          target: unknown;
+          set: Record<string, unknown>;
+        }) => {
           insertCalls.push({ table, values: v, set });
-          existingRows[v.id] = { ...v };
+          existingRows[v.id as string] = { ...v };
           return undefined;
         },
         onConflictDoNothing: async () => undefined,

--- a/apps/web/src/__tests__/sync-service-tier2.test.ts
+++ b/apps/web/src/__tests__/sync-service-tier2.test.ts
@@ -9,7 +9,6 @@ import {
   addSubstanceRecord,
   deleteSubstanceRecord,
   updateSubstanceRecord,
-  getSubstanceRecords,
 } from "@/lib/substance-service";
 import {
   addComposableEntry,
@@ -17,7 +16,6 @@ import {
   undoDeleteEntryGroup,
   deleteSingleGroupRecord,
   undoDeleteSingleRecord,
-  getEntryGroup,
 } from "@/lib/composable-entry-service";
 import {
   addSchedule,

--- a/apps/web/src/app/api/ai/voice-transcribe/route.test.ts
+++ b/apps/web/src/app/api/ai/voice-transcribe/route.test.ts
@@ -15,6 +15,7 @@
  */
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { NextRequest } from "next/server";
+import type * as AiKeyResolverMod from "@/lib/ai-key-resolver";
 
 vi.mock("@/lib/auth-middleware", () => ({
   withAuth: (
@@ -35,7 +36,7 @@ vi.mock("@/lib/auth-middleware", () => ({
 // is stubbed — NoAiKeyError must remain the real class because
 // ai-error-response.ts does `error instanceof NoAiKeyError`.
 vi.mock("@/lib/ai-key-resolver", async (importOriginal) => {
-  const actual = await importOriginal<typeof import("@/lib/ai-key-resolver")>();
+  const actual = await importOriginal<typeof AiKeyResolverMod>();
   return {
     ...actual,
     resolveAiKey: vi.fn(async () => ({

--- a/apps/web/src/app/api/analytics/insights/deep/route.test.ts
+++ b/apps/web/src/app/api/analytics/insights/deep/route.test.ts
@@ -13,6 +13,7 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { NextRequest } from "next/server";
 import { NoAiKeyError } from "@/lib/ai-key-resolver";
+import type * as InsightJobServiceMod from "@/lib/server/insight-job-service";
 
 // ── Controllable stubs ───────────────────────────────────────────────────
 
@@ -94,9 +95,9 @@ vi.mock("@/app/api/ai/_shared/claude-client", () => ({
 }));
 
 vi.mock("@/lib/server/insight-job-service", async () => {
-  const actual = await vi.importActual<
-    typeof import("@/lib/server/insight-job-service")
-  >("@/lib/server/insight-job-service");
+  const actual = await vi.importActual<typeof InsightJobServiceMod>(
+    "@/lib/server/insight-job-service",
+  );
   return {
     ...actual,
     createInsightJob: async (input: unknown) => {

--- a/apps/web/src/app/api/sync/cleanup/route.ts
+++ b/apps/web/src/app/api/sync/cleanup/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from "next/server";
 import { eq } from "drizzle-orm";
+import { type PgColumn } from "drizzle-orm/pg-core";
 import { withAuth } from "@/lib/auth-middleware";
 import { db } from "@intake/db/client";
 import { schemaByTableName, type TableName } from "@intake/db/sync-payload";
@@ -33,7 +34,7 @@ export const POST = withAuth(async ({ auth }) => {
       const table = schemaByTableName[tableName];
       const result = await db
         .delete(table)
-        .where(eq((table as any).userId, auth.userId!));
+        .where(eq((table as { userId: PgColumn }).userId, auth.userId!));
 
       deleted[tableName] = result.rowCount ?? 0;
     }

--- a/apps/web/src/app/api/sync/pull/route.ts
+++ b/apps/web/src/app/api/sync/pull/route.ts
@@ -40,6 +40,7 @@
  */
 import { NextResponse } from "next/server";
 import { and, asc, eq, gt, or } from "drizzle-orm";
+import { type PgColumn, type PgTable } from "drizzle-orm/pg-core";
 import { withAuth } from "@/lib/auth-middleware";
 import { db as drizzleDb } from "@intake/db/client";
 import {
@@ -76,7 +77,11 @@ export const POST = withAuth(async ({ request, auth }) => {
           typeof rawCursor === "number" ? rawCursor : rawCursor?.updatedAt ?? 0;
         const cursorId =
           typeof rawCursor === "number" ? "" : rawCursor?.id ?? "";
-        const table = schemaByTableName[tableName] as any;
+        const table = schemaByTableName[tableName] as PgTable & {
+          id: PgColumn;
+          userId: PgColumn;
+          updatedAt: PgColumn;
+        };
 
         // `updatedAt > cursor` OR `(updatedAt = cursor AND id > cursorId)` —
         // the tuple comparison keeps pagination correct when many rows share

--- a/apps/web/src/app/api/sync/push/route.ts
+++ b/apps/web/src/app/api/sync/push/route.ts
@@ -39,6 +39,7 @@
  */
 import { NextResponse } from "next/server";
 import { eq, and, inArray } from "drizzle-orm";
+import { type PgColumn, type PgTable } from "drizzle-orm/pg-core";
 import { withAuth } from "@/lib/auth-middleware";
 import { db as drizzleDb } from "@intake/db/client";
 import { usersSync } from "@intake/db/schema";
@@ -53,7 +54,7 @@ export const maxDuration = 60;
 const MAX_FUTURE_MS = 60_000;
 const SELECT_CHUNK_SIZE = 100;
 
-function sanitizeRow(obj: Record<string, any>): Record<string, any> {
+function sanitizeRow(obj: Record<string, unknown>): Record<string, unknown> {
   for (const key of Object.keys(obj)) {
     if (obj[key] === undefined || obj[key] === "") {
       obj[key] = null;
@@ -64,10 +65,10 @@ function sanitizeRow(obj: Record<string, any>): Record<string, any> {
 
 function extractDbError(err: unknown): string {
   if (!(err instanceof Error)) return String(err);
-  const cause = (err as any).cause;
+  const cause = (err as { cause?: unknown }).cause;
   if (cause instanceof Error) {
-    const code = (cause as any).code ?? "";
-    const detail = (cause as any).detail ?? "";
+    const code = (cause as { code?: string }).code ?? "";
+    const detail = (cause as { detail?: string }).detail ?? "";
     return [cause.message, code && `code=${code}`, detail && `detail=${detail}`]
       .filter(Boolean)
       .join(" | ");
@@ -136,12 +137,13 @@ export const POST = withAuth(async ({ request, auth }) => {
             .from(table)
             .where(
               and(
-                inArray((table as any).id, chunk),
-                eq((table as any).userId, auth.userId!),
+                inArray((table as { id: PgColumn }).id, chunk),
+                eq((table as { userId: PgColumn }).userId, auth.userId!),
               ),
             );
           for (const r of rows) {
-            existingById.set((r as any).id as string, r as any);
+            const row = r as { id: string; updatedAt: number; deletedAt: number | null };
+            existingById.set(row.id, row);
           }
         }
       } catch (selectErr) {
@@ -192,11 +194,11 @@ export const POST = withAuth(async ({ request, auth }) => {
           clampedUpdatedAt === serverRow.updatedAt;
 
         if (!serverRow || clampedUpdatedAt > serverRow.updatedAt || tombstoneTieBreak) {
-          const rowWithoutUserId: Record<string, any> = { ...op.row };
+          const rowWithoutUserId: Record<string, unknown> = { ...op.row };
           delete rowWithoutUserId.userId;
           sanitizeRow(rowWithoutUserId);
 
-          const writeValues: Record<string, any> = {
+          const writeValues: Record<string, unknown> = {
             ...rowWithoutUserId,
             userId: auth.userId!,
             updatedAt: clampedUpdatedAt,
@@ -204,11 +206,11 @@ export const POST = withAuth(async ({ request, auth }) => {
 
           const { id: _id, ...setValues } = writeValues;
           try {
-            await (drizzleDb as any)
-              .insert(table)
+            await drizzleDb
+              .insert(table as PgTable)
               .values(writeValues)
               .onConflictDoUpdate({
-                target: (table as any).id,
+                target: (table as { id: PgColumn }).id,
                 set: setValues,
               });
             accepted.push({

--- a/apps/web/src/app/api/sync/status/route.ts
+++ b/apps/web/src/app/api/sync/status/route.ts
@@ -9,6 +9,7 @@
  */
 import { NextResponse } from "next/server";
 import { eq } from "drizzle-orm";
+import { type PgColumn } from "drizzle-orm/pg-core";
 import { withAuth } from "@/lib/auth-middleware";
 import { db as drizzleDb } from "@intake/db/client";
 import {
@@ -31,9 +32,9 @@ export const GET = withAuth(async ({ auth }) => {
   try {
     for (const table of PROBE_TABLES) {
       const rows = await drizzleDb
-        .select({ id: (table as any).id })
+        .select({ id: (table as { id: PgColumn }).id })
         .from(table)
-        .where(eq((table as any).userId, auth.userId!))
+        .where(eq((table as { userId: PgColumn }).userId, auth.userId!))
         .limit(1);
       if (rows.length > 0) {
         return NextResponse.json({ hasSyncedData: true });

--- a/apps/web/src/app/api/sync/verify-hash/route.ts
+++ b/apps/web/src/app/api/sync/verify-hash/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
 import { createHash } from "crypto";
 import { eq, gt, and } from "drizzle-orm";
+import { type PgColumn } from "drizzle-orm/pg-core";
 import { withAuth } from "@/lib/auth-middleware";
 import { db } from "@intake/db/client";
 import { schemaByTableName, type TableName } from "@intake/db/sync-payload";
@@ -37,16 +38,18 @@ export const POST = withAuth(async ({ auth }) => {
 
       hash.update("[");
       for (;;) {
-        const conditions = [eq((table as any).userId, auth.userId!)];
+        const conditions = [
+          eq((table as { userId: PgColumn }).userId, auth.userId!),
+        ];
         if (cursor) {
-          conditions.push(gt((table as any).id, cursor));
+          conditions.push(gt((table as { id: PgColumn }).id, cursor));
         }
 
         const rows = await db
           .select()
           .from(table)
           .where(and(...conditions))
-          .orderBy((table as any).id)
+          .orderBy((table as { id: PgColumn }).id)
           .limit(SELECT_CHUNK_SIZE);
 
         for (const row of rows) {
@@ -57,7 +60,7 @@ export const POST = withAuth(async ({ auth }) => {
         }
 
         if (rows.length < SELECT_CHUNK_SIZE) break;
-        cursor = (rows[rows.length - 1] as any).id as string;
+        cursor = (rows[rows.length - 1] as { id: string }).id;
       }
       hash.update("]");
 

--- a/apps/web/src/components/analytics/records-tab.tsx
+++ b/apps/web/src/components/analytics/records-tab.tsx
@@ -28,6 +28,7 @@ import {
 } from "@/lib/db";
 import {
   type FilterType,
+  type UnifiedRecord,
   getRecordId,
   groupRecordsByDate,
   filterRecords,
@@ -174,7 +175,7 @@ export function RecordsTab({ range }: RecordsTabProps) {
   const dateGroups = Array.from(groupedRecords.entries());
 
   // Delete handler
-  const handleDelete = useCallback(async (unified: import("@/lib/history-types").UnifiedRecord) => {
+  const handleDelete = useCallback(async (unified: UnifiedRecord) => {
     const id = getRecordId(unified);
     setDeletingId(id);
     try {
@@ -194,7 +195,7 @@ export function RecordsTab({ range }: RecordsTabProps) {
   }, [toast, deleteMutation, deleteWeight, deleteBP, deleteEatingMutation, deleteUrinationMutation, deleteDefecationMutation, deleteSubstance]);
 
   // Edit openers
-  const openEdit = useCallback((unified: import("@/lib/history-types").UnifiedRecord) => {
+  const openEdit = useCallback((unified: UnifiedRecord) => {
     setEditTimestamp(timestampToDateTimeLocal(unified.record.timestamp));
     setEditNote((unified.record as unknown as { note?: string }).note || "");
 

--- a/apps/web/src/components/analytics/titration-tab.tsx
+++ b/apps/web/src/components/analytics/titration-tab.tsx
@@ -338,7 +338,7 @@ function PrescriptionSection({ report }: { report: PrescriptionReport }) {
 // Main tab component
 // ---------------------------------------------------------------------------
 
-export function TitrationTab({ range }: { range: TimeRange }) {
+export function TitrationTab({ range: _range }: { range: TimeRange }) {
   const reports = useTitrationData();
 
   if (!reports) {

--- a/apps/web/src/components/defecation-card.tsx
+++ b/apps/web/src/components/defecation-card.tsx
@@ -82,7 +82,7 @@ export function DefecationCard() {
         description: `Defecation (${amountValue}) recorded`,
         variant: "success",
       });
-    } catch (error) {
+    } catch {
       toast({
         title: "Error",
         description: "Failed to record",
@@ -111,7 +111,7 @@ export function DefecationCard() {
       setAmount(settings.defecationDefaultAmount || "");
       setNote("");
       setDetailTime(getCurrentDateTimeLocal());
-    } catch (error) {
+    } catch {
       toast({
         title: "Error",
         description: "Failed to record",

--- a/apps/web/src/components/liquids-card.tsx
+++ b/apps/web/src/components/liquids-card.tsx
@@ -3,7 +3,6 @@
 import { useMemo, useRef, useState } from "react";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Card, CardContent } from "@/components/ui/card";
-import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { CARD_THEMES } from "@/lib/card-themes";

--- a/apps/web/src/components/medications/add-medication-wizard.flow.test.tsx
+++ b/apps/web/src/components/medications/add-medication-wizard.flow.test.tsx
@@ -31,11 +31,12 @@ import { screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { http, HttpResponse } from "msw";
 import { setupServer } from "msw/node";
+import type * as AuthGuardMod from "@/components/auth-guard";
 
 // Open the auth gate so the wizard renders its AI search input.
 // useAuthGate uses useAuth().authenticated, so mock the upstream hook.
 vi.mock("@/components/auth-guard", async (importActual) => {
-  const actual = await importActual<typeof import("@/components/auth-guard")>();
+  const actual = await importActual<typeof AuthGuardMod>();
   return {
     ...actual,
     useAuthGate: () => true,

--- a/apps/web/src/components/urination-card.tsx
+++ b/apps/web/src/components/urination-card.tsx
@@ -82,7 +82,7 @@ export function UrinationCard() {
         description: `Urination (${amountValue}) recorded`,
         variant: "success",
       });
-    } catch (error) {
+    } catch {
       toast({
         title: "Error",
         description: "Failed to record",
@@ -110,7 +110,7 @@ export function UrinationCard() {
       setAmount(settings.urinationDefaultAmount);
       setNote("");
       setDetailTime(getCurrentDateTimeLocal());
-    } catch (error) {
+    } catch {
       toast({
         title: "Error",
         description: "Failed to record",

--- a/apps/web/src/hooks/use-permissions.ts
+++ b/apps/web/src/hooks/use-permissions.ts
@@ -5,7 +5,6 @@ import {
   isNotificationSupported,
   getNotificationPermission,
   requestNotificationPermission,
-  type NotificationPermissionState,
 } from "@/lib/push-notification-service";
 import { unwrap } from "@/lib/service-result";
 

--- a/apps/web/src/hooks/use-timezone-detection.test.ts
+++ b/apps/web/src/hooks/use-timezone-detection.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, vi } from "vitest";
+import { describe, it, expect } from "vitest";
 import { db } from "@/lib/db";
 import {
   makePrescription,

--- a/apps/web/src/lib/analytics-service.test.ts
+++ b/apps/web/src/lib/analytics-service.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import type { IntakeRecord, WeightRecord, BloodPressureRecord, UrinationRecord, SubstanceRecord } from "@/lib/db";
+import type { IntakeRecord, WeightRecord, BloodPressureRecord, UrinationRecord } from "@/lib/db";
 import type { DoseSlot } from "@/lib/dose-schedule-service";
 import type { TimeRange } from "@/lib/analytics-types";
 
@@ -59,7 +59,6 @@ import {
   alcoholVsBP,
   getRecordsByDomain,
   groupByDay,
-  correlate,
 } from "@/lib/analytics-service";
 
 import { getRecordsByDateRange as mockGetIntake } from "@/lib/intake-service";

--- a/apps/web/src/lib/composable-entry-service.test.ts
+++ b/apps/web/src/lib/composable-entry-service.test.ts
@@ -217,18 +217,19 @@ describe("composable-entry-service", () => {
       // Monkey-patch crypto.randomUUID to return the existing id on the second call
       const originalRandomUUID = crypto.randomUUID.bind(crypto);
       let callCount = 0;
-      (crypto as any).randomUUID = (): string => {
+      const patchedRandomUUID = ((): string => {
         callCount++;
         // First call = groupId, second call = eating record, third call = intake record
         if (callCount === 3) return existingRecord.id;
         return originalRandomUUID();
-      };
+      }) as typeof crypto.randomUUID;
+      (crypto as { randomUUID: typeof crypto.randomUUID }).randomUUID = patchedRandomUUID;
 
       try {
         const result = await addComposableEntry(input);
         expect(result.success).toBe(false);
       } finally {
-        (crypto as any).randomUUID = originalRandomUUID;
+        (crypto as { randomUUID: typeof crypto.randomUUID }).randomUUID = originalRandomUUID;
       }
 
       // Verify no eating records were created (transaction rolled back)

--- a/apps/web/src/lib/composable-entry-service.ts
+++ b/apps/web/src/lib/composable-entry-service.ts
@@ -816,7 +816,7 @@ export async function syncLiquidEntrySubstances(
 // ─── recalculateFromCurrentValues (stub) ──────────────────────────────
 
 export async function recalculateFromCurrentValues(
-  groupId: string,
+  _groupId: string,
 ): Promise<ServiceResult<void>> {
   return err(
     "Not implemented — deferred to Phase 13/14. Requires preset data and recalculation logic not yet available.",

--- a/apps/web/src/lib/db.ts
+++ b/apps/web/src/lib/db.ts
@@ -162,7 +162,7 @@ realDb.version(10).stores(V10_STORES).upgrade(async (trans) => {
 
   // Helper: backfill sync fields on all records in a table
   const backfill = async (tableName: string, timestampField = "timestamp") => {
-    await trans.table(tableName).toCollection().modify((record: any) => {
+    await trans.table(tableName).toCollection().modify((record: Record<string, unknown>) => {
       if (record.createdAt == null) {
         record.createdAt = record[timestampField] ?? record.createdAt ?? now;
       }

--- a/apps/web/src/lib/dose-schedule-service.test.ts
+++ b/apps/web/src/lib/dose-schedule-service.test.ts
@@ -3,7 +3,6 @@ import { db } from "@/lib/db";
 import {
   getDailyDoseSchedule,
   getDoseScheduleForDateRange,
-  type DoseSlot,
 } from "@/lib/dose-schedule-service";
 import {
   makePrescription,

--- a/apps/web/src/lib/export-service.test.ts
+++ b/apps/web/src/lib/export-service.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
+import type * as JsPdfMod from "jspdf";
 import type { AnalyticsResult, DataPoint } from "@/lib/analytics-types";
 
 // Mock jsPDF so exportToPDF's `doc.save()` is captured instead of triggering a
@@ -6,7 +7,7 @@ import type { AnalyticsResult, DataPoint } from "@/lib/analytics-types";
 // and all PDF rendering still run for real.
 const pdfSaves: Array<{ filename: string; dataUri: string }> = [];
 vi.mock("jspdf", async () => {
-  const actual = await vi.importActual<typeof import("jspdf")>("jspdf");
+  const actual = await vi.importActual<typeof JsPdfMod>("jspdf");
   const Real = actual.jsPDF;
   const Wrapped = function WrappedJsPDF(...args: unknown[]) {
     const Ctor = Real as unknown as new (...a: unknown[]) => InstanceType<

--- a/apps/web/src/lib/export-service.ts
+++ b/apps/web/src/lib/export-service.ts
@@ -13,7 +13,7 @@ import {
   weightTrend,
   getRecordsByDomain,
 } from "@/lib/analytics-service";
-import type { TimeRange, Domain, AnalyticsResult, DataPoint } from "@/lib/analytics-types";
+import type { TimeRange, Domain, AnalyticsResult } from "@/lib/analytics-types";
 
 // ---------------------------------------------------------------------------
 // CSV helpers
@@ -25,14 +25,6 @@ function escapeCSVField(field: string): string {
     return `"${field.replace(/"/g, '""')}"`;
   }
   return field;
-}
-
-function dataPointsToCSVRows(points: DataPoint[]): string[][] {
-  return points.map((p) => [
-    new Date(p.timestamp).toISOString(),
-    String(p.value),
-    ...(p.label ? [p.label] : []),
-  ]);
 }
 
 function triggerDownload(blob: Blob, filename: string): void {

--- a/apps/web/src/lib/mcp/oauth-flow.test.ts
+++ b/apps/web/src/lib/mcp/oauth-flow.test.ts
@@ -8,6 +8,8 @@
  */
 import { describe, it, expect, beforeEach, vi } from "vitest";
 import { createHash } from "node:crypto";
+import type * as DrizzleOrm from "drizzle-orm";
+import type * as OAuthMod from "@/lib/mcp/oauth";
 
 // ────────────────────────────────────────────────────────────────────────
 // In-memory db stub
@@ -22,20 +24,12 @@ function tableFor(ref: unknown): Row[] {
   return tables.get(ref)!;
 }
 
-function matchesAll(row: Row, conds: Array<(r: Row) => boolean>): boolean {
-  return conds.every((c) => c(row));
-}
-
-interface Where {
-  __conds: Array<(r: Row) => boolean>;
-}
-
 // Sentinel objects representing each "and/eq/isNull" predicate. The
 // drizzle-orm mock just records the predicate as a function; the test
 // doesn't care about the SQL shape.
 vi.mock("drizzle-orm", async () => {
   const actual =
-    await vi.importActual<typeof import("drizzle-orm")>("drizzle-orm");
+    await vi.importActual<typeof DrizzleOrm>("drizzle-orm");
   return {
     ...actual,
     eq: (column: { name?: string; _key?: string }, value: unknown) => ({
@@ -188,7 +182,7 @@ vi.mock("@intake/db/client", () => {
 // Now import the SUT (after mocks).
 // ────────────────────────────────────────────────────────────────────────
 
-let oauth: typeof import("@/lib/mcp/oauth");
+let oauth: typeof OAuthMod;
 
 beforeEach(async () => {
   tables.clear();

--- a/apps/web/src/lib/medication-notification-service.ts
+++ b/apps/web/src/lib/medication-notification-service.ts
@@ -1,4 +1,4 @@
-import { db, type Prescription, type MedicationPhase, type InventoryItem } from "@/lib/db";
+import { db } from "@/lib/db";
 import { showNotification, getNotificationPermission } from "@/lib/push-notification-service";
 import { getSchedulesForPhase } from "@/lib/medication-schedule-service";
 import { isCombo, splitDose, formatCompoundShort } from "@/lib/compound-utils";

--- a/apps/web/src/lib/medication-service.test.ts
+++ b/apps/web/src/lib/medication-service.test.ts
@@ -15,7 +15,6 @@ import {
   deletePhase,
   getInventoryForPrescription,
   getActiveInventoryForPrescription,
-  addInventoryItem,
   adjustStock,
   addMedicationToPrescription,
   type CreatePrescriptionInput,

--- a/apps/web/src/lib/network-status.ts
+++ b/apps/web/src/lib/network-status.ts
@@ -10,7 +10,7 @@ export function isOnline(): boolean {
 function isCapacitor(): boolean {
   return (
     typeof window !== "undefined" &&
-    !!(window as any).Capacitor
+    !!(window as { Capacitor?: unknown }).Capacitor
   );
 }
 

--- a/apps/web/src/lib/sync-engine.ts
+++ b/apps/web/src/lib/sync-engine.ts
@@ -478,8 +478,8 @@ export async function runPullCycle(): Promise<void> {
           nextId = lastId;
         }
 
-        await db.transaction("rw", [db.table(tn), db._syncMeta] as any, async () => {
-          await (db.table(tn) as any).bulkPut(rows);
+        await db.transaction("rw", [db.table(tn), db._syncMeta], async () => {
+          await db.table(tn).bulkPut(rows);
           await db._syncMeta.put({
             tableName: tn,
             lastPulledUpdatedAt: nextUpdatedAt,
@@ -611,7 +611,15 @@ export function startEngine(): void {
 
   if (process.env.NODE_ENV !== "production") {
     if (typeof window !== "undefined") {
-      (window as any).__syncEngine = {
+      (
+        window as Window & {
+          __syncEngine?: {
+            pushNow: () => Promise<void>;
+            pullNow: () => Promise<void>;
+            getQueueDepth: typeof getQueueDepth;
+          };
+        }
+      ).__syncEngine = {
         pushNow: () => runPushCycle(),
         pullNow: () => runPullCycle(),
         getQueueDepth,

--- a/apps/web/src/lib/timezone-recalculation-service.test.ts
+++ b/apps/web/src/lib/timezone-recalculation-service.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach } from "vitest";
+import { describe, it, expect } from "vitest";
 import { db } from "@/lib/db";
 import {
   makePrescription,

--- a/apps/web/src/lib/timezone.test.ts
+++ b/apps/web/src/lib/timezone.test.ts
@@ -9,7 +9,7 @@ describe("clearTimezoneCache", () => {
     originalDateTimeFormat = Intl.DateTimeFormat;
     // Ensure `window` exists so getDeviceTimezone() reads from Intl API
     if (!hadWindow) {
-      (globalThis as any).window = {};
+      (globalThis as { window?: unknown }).window = {};
     }
     // Always start with a clean cache
     clearTimezoneCache();
@@ -22,7 +22,7 @@ describe("clearTimezoneCache", () => {
     clearTimezoneCache();
     // Remove the window shim if we added it
     if (!hadWindow) {
-      delete (globalThis as any).window;
+      delete (globalThis as { window?: unknown }).window;
     }
   });
 

--- a/apps/web/src/lib/titration-service.ts
+++ b/apps/web/src/lib/titration-service.ts
@@ -1,7 +1,6 @@
 import {
   db,
   type TitrationPlan,
-  type TitrationPlanStatus,
   type MedicationPhase,
   type PhaseSchedule,
 } from "@/lib/db";

--- a/apps/web/src/lib/user-data-deletion.ts
+++ b/apps/web/src/lib/user-data-deletion.ts
@@ -18,6 +18,7 @@
  */
 import "server-only";
 import { eq, or, type SQL } from "drizzle-orm";
+import { type PgColumn, type PgTable } from "drizzle-orm/pg-core";
 import { db } from "@intake/db/client";
 import { schemaByTableName, type TableName } from "@intake/db/sync-payload";
 import {
@@ -60,9 +61,9 @@ const SYNCED_DELETION_ORDER: TableName[] = [
   "insightReports",
 ];
 
-// Drizzle's table refs are heavily generic; the cleanup route uses the same
-// `as any` shape to delete by `userId` across many tables.
-async function del(table: any, where: SQL | undefined): Promise<number> {
+// Drizzle's table refs are heavily generic; we accept the base `PgTable` so a
+// single helper can delete by `userId` across many tables.
+async function del(table: PgTable, where: SQL | undefined): Promise<number> {
   const result = await db.delete(table).where(where);
   return result.rowCount ?? 0;
 }
@@ -71,7 +72,7 @@ async function del(table: any, where: SQL | undefined): Promise<number> {
 async function deleteSyncedData(userId: string): Promise<Record<string, number>> {
   const deleted: Record<string, number> = {};
   for (const name of SYNCED_DELETION_ORDER) {
-    const table = schemaByTableName[name] as any;
+    const table = schemaByTableName[name] as PgTable & { userId: PgColumn };
     deleted[name] = await del(table, eq(table.userId, userId));
   }
   return deleted;

--- a/packages/eslint-config/index.js
+++ b/packages/eslint-config/index.js
@@ -25,7 +25,7 @@ export default [
         "error",
         { argsIgnorePattern: "^_", varsIgnorePattern: "^_" },
       ],
-      "@typescript-eslint/consistent-type-imports": "warn",
+      "@typescript-eslint/consistent-type-imports": "error",
     },
   },
   {


### PR DESCRIPTION
## What

Real-work ESLint cleanup pass (DEFERRED.md tech-debt backlog, **B2**). Fixes every remaining violation of the three deferred quality rules, then flips them from `warn` to `error` so they can never regress.

| Rule | Count | How fixed |
|---|---|---|
| `@typescript-eslint/no-explicit-any` | 43 | Real types replace `any` |
| `@typescript-eslint/consistent-type-imports` | 13 | `import()` annotations hoisted to `import type` |
| `@typescript-eslint/no-unused-vars` | 30 | Dead code removed / params `_`-prefixed |

### `no-explicit-any` (the judgment-heavy part)
- `Record<string, any>` → `Record<string, unknown>` for generic row maps (sync push, db migration backfill).
- DB-error introspection narrowed to `{ cause?: unknown }` / `{ code?: string }` / `{ detail?: string }` shapes instead of `(err as any).cause`.
- drizzle dynamic-table dispatch typed with `PgColumn` / `PgTable` casts (`sync/push`, `sync/pull`, `sync/status`, `sync/verify-hash`, `sync/cleanup`, `user-data-deletion`) instead of `(table as any).id`.
- `sync-engine.ts` dropped two `as any` casts that turned out to be unnecessary.
- Test files use the real type-under-test (or `unknown` + use-site cast), never `any`.

### `consistent-type-imports`
- Inline `let x: typeof import("@/mod")` (paired with a runtime `await import`) → top-level `import type * as Mod` + `let x: typeof Mod`.
- `foo as import("@/mod").T` → hoisted `import { type T }`.

### `no-unused-vars`
- Genuinely dead imports / vars / helper functions deleted (e.g. `dataPointsToCSVRows`, `matchesAll`, `Where`).
- Unused `catch (error)` bindings collapsed to bare `catch {}` (ES2019).
- Signature/arity-required params `_`-prefixed.

## Where the flip lives
- `consistent-type-imports` → `error` in the **shared** `@intake/eslint-config` base (forward-looking for every package; only `@intake/core` + `@intake/web` currently run lint, both clean).
- `no-explicit-any` + `no-unused-vars` → `error` in `apps/web/eslint.config.mjs`.

## Verification
- `turbo run typecheck` — clean
- `eslint src` — **0 errors** (3 pre-existing intentional `jsx-a11y` warnings remain)
- `turbo run test` — **2032 unit tests** pass (210 files)
- `vitest --config vitest.integration.config.ts` — **33 integration tests** pass (Docker/Postgres)

## Method
Fixed via a 42-agent fan-out (one agent per file, each restricted to its own file, no config edits), then the config flip + full gate run in one pass. The security-critical `sync/push` insert cast was hand-simplified afterward to match the `PgTable` pattern used in `user-data-deletion.ts`.

---
> ⛔ **Do not merge until #226 (B1, mechanical ratchet) merges.** This PR is stacked on `chore/eslint-mechanical-ratchet`; GitHub will retarget it to `main` automatically once B1 lands.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced code quality by enforcing stricter TypeScript type safety rules across the application, including stricter unused variable detection and type annotations.
  * Improved type safety throughout the codebase by replacing generic type casting with explicit, strongly-typed declarations.
  * Cleaned up unused imports and simplified internal type definitions for better maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->