### PR TITLE
chore(repo): zod v4 deprecation cleanup + syncable-table parity guard (tech-debt C)

### DIFF
--- a/apps/web/eslint.config.mjs
+++ b/apps/web/eslint.config.mjs
@@ -67,12 +67,12 @@ export default [
       // Next.js rules (from @next/eslint-plugin-next, ESLint-10 native).
       ...nextPlugin.configs.recommended.rules,
       ...nextPlugin.configs["core-web-vitals"].rules,
-      // Deferred strict rules — ride at warn pending a cleanup pass (DEFERRED.md).
+      // Promoted to error (B2 cleanup pass, June 2026 — DEFERRED.md).
       "@typescript-eslint/no-unused-vars": [
-        "warn",
+        "error",
         { argsIgnorePattern: "^_", varsIgnorePattern: "^_" },
       ],
-      "@typescript-eslint/no-explicit-any": "warn",
+      "@typescript-eslint/no-explicit-any": "error",
       "@typescript-eslint/no-require-imports": "error",
       "@typescript-eslint/no-empty-object-type": "error",
       "@typescript-eslint/no-unsafe-function-type": "error",

--- a/apps/web/src/__tests__/a11y/components-a11y.test.tsx
+++ b/apps/web/src/__tests__/a11y/components-a11y.test.tsx
@@ -46,6 +46,7 @@
  */
 import { describe, it, expect, vi, beforeAll } from "vitest";
 import axe from "axe-core";
+import type * as AuthGuardModule from "@/components/auth-guard";
 
 beforeAll(() => {
   if (!Element.prototype.hasPointerCapture) {
@@ -64,7 +65,7 @@ beforeAll(() => {
 
 // Auth gate open for the food card so the AI input renders too.
 vi.mock("@/components/auth-guard", async (importActual) => {
-  const actual = await importActual<typeof import("@/components/auth-guard")>();
+  const actual = await importActual<typeof AuthGuardModule>();
   return { ...actual, useAuthGate: () => true };
 });
 

--- a/apps/web/src/__tests__/auth-guard.test.ts
+++ b/apps/web/src/__tests__/auth-guard.test.ts
@@ -22,6 +22,7 @@
  * stack (zero Privy / PIN imports).
  */
 import { describe, it, expect, vi, beforeEach } from "vitest";
+import type * as ReactModule from "react";
 
 type SessionUser = { id: string; email?: string; name?: string };
 type SessionResult = {
@@ -46,7 +47,7 @@ vi.mock("@/lib/auth-client", () => ({
 }));
 
 vi.mock("react", async (importOriginal) => {
-  const actual = await importOriginal<typeof import("react")>();
+  const actual = await importOriginal<typeof ReactModule>();
   return {
     ...actual,
     useState: (init: unknown) => [init, vi.fn()],

--- a/apps/web/src/__tests__/integration/mcp-oauth-integration.test.ts
+++ b/apps/web/src/__tests__/integration/mcp-oauth-integration.test.ts
@@ -27,10 +27,12 @@ import {
   type TestDbContext,
 } from "@/__tests__/helpers/test-db";
 import * as schema from "@intake/db/schema";
+import type * as OauthMod from "@/lib/mcp/oauth";
+import type * as TokensMod from "@/lib/mcp/tokens";
 
 let ctx: TestDbContext;
-let oauth: typeof import("@/lib/mcp/oauth");
-let tokens: typeof import("@/lib/mcp/tokens");
+let oauth: typeof OauthMod;
+let tokens: typeof TokensMod;
 
 beforeAll(async () => {
   ctx = await setupTestDb();

--- a/apps/web/src/__tests__/integration/mcp-rotation-race.test.ts
+++ b/apps/web/src/__tests__/integration/mcp-rotation-race.test.ts
@@ -29,9 +29,10 @@ import {
   type TestDbContext,
 } from "@/__tests__/helpers/test-db";
 import * as schema from "@intake/db/schema";
+import type * as OAuthMod from "@/lib/mcp/oauth";
 
 let ctx: TestDbContext;
-let oauth: typeof import("@/lib/mcp/oauth");
+let oauth: typeof OAuthMod;
 
 beforeAll(async () => {
   ctx = await setupTestDb();

--- a/apps/web/src/__tests__/integrity/backup-round-trip.test.ts
+++ b/apps/web/src/__tests__/integrity/backup-round-trip.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, beforeEach } from "vitest";
+import { type Table } from "dexie";
 import { db } from "@/lib/db";
 import { exportBackup, importBackup, type BackupData } from "@/lib/backup-service";
 import {
@@ -48,7 +49,7 @@ describe("backup round-trip: deep field equality", () => {
     const invItem = makeInventoryItem(prescription.id);
 
     // Build records map -- intakeRecords has 2 records (water + salt) to verify multi-record survival
-    const fixtures: Record<string, { records: unknown[]; table: any }> = {
+    const fixtures: Record<string, { records: unknown[]; table: Table<unknown> }> = {
       intakeRecords: { records: [makeIntakeRecord(), makeIntakeRecord({ type: "salt", amount: 500 })], table: db.intakeRecords },
       weightRecords: { records: [makeWeightRecord()], table: db.weightRecords },
       bloodPressureRecords: { records: [makeBloodPressureRecord()], table: db.bloodPressureRecords },
@@ -96,7 +97,7 @@ describe("backup round-trip: deep field equality", () => {
       const restored = await table.toArray();
       for (const original of originals) {
         const originalWithId = original as { id: string };
-        const match = restored.find((r: any) => r.id === originalWithId.id);
+        const match = restored.find((r) => (r as { id: string }).id === originalWithId.id);
         expect(match, [
           `x [Backup Round-Trip]: Record ${originalWithId.id} missing from ${tableName} after round-trip`,
           `  Fix: Check exportBackup() and importBackup() in src/lib/backup-service.ts`,
@@ -131,7 +132,7 @@ describe("backup round-trip: deep field equality", () => {
 
     // Our fixture record should exist by ID
     const restored = await db.auditLogs.toArray();
-    const match = restored.find((r: any) => r.id === fixtureAuditLog.id);
+    const match = restored.find((r) => r.id === fixtureAuditLog.id);
     expect(match, [
       `x [Backup Round-Trip]: Fixture audit log ${fixtureAuditLog.id} missing after round-trip`,
       `  Fix: Audit log export/import may be filtering records incorrectly`,
@@ -173,7 +174,7 @@ describe("backup round-trip: deep field equality", () => {
 
     // Verify each by ID with deep equality
     for (const original of [water, salt]) {
-      const match = restored.find((r: any) => r.id === original.id);
+      const match = restored.find((r) => r.id === original.id);
       expect(match, [
         `x [Backup Round-Trip]: Record ${original.id} (type=${original.type}) missing from intakeRecords`,
         `  Fix: Check exportBackup() handles multiple records per table correctly`,

--- a/apps/web/src/__tests__/migration/v10-migration.test.ts
+++ b/apps/web/src/__tests__/migration/v10-migration.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach } from "vitest";
+import { describe, it, expect } from "vitest";
 import { db } from "@/lib/db";
 import {
   makeIntakeRecord,
@@ -77,7 +77,7 @@ describe("SCHM-03: event-sourced inventory", () => {
     const rx = makePrescription({ id: "rx-stock-1" });
     const item = makeInventoryItem(rx.id, { id: "item-stock-1" });
     // Ensure currentStock is not set
-    const { currentStock, ...itemWithoutStock } = item as any;
+    const { currentStock: _currentStock, ...itemWithoutStock } = item;
     await db.prescriptions.add(rx);
     await db.inventoryItems.add(itemWithoutStock);
     const retrieved = await db.inventoryItems.get("item-stock-1");

--- a/apps/web/src/__tests__/migration/v15-migration.test.ts
+++ b/apps/web/src/__tests__/migration/v15-migration.test.ts
@@ -1,10 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { db } from "@/lib/db";
-import {
-  makeIntakeRecord,
-  makeEatingRecord,
-  makeSubstanceRecord,
-} from "@/__tests__/fixtures/db-fixtures";
+import { makeIntakeRecord } from "@/__tests__/fixtures/db-fixtures";
 
 describe("v15 migration: groupId index on intakeRecords, eatingRecords, substanceRecords", () => {
   it("existing v14 intakeRecords survive v15 upgrade with all data intact", async () => {

--- a/apps/web/src/__tests__/smoke.test.ts
+++ b/apps/web/src/__tests__/smoke.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { db } from "@/lib/db";
+import { db, type IntakeRecord } from "@/lib/db";
 
 describe("test infrastructure", () => {
   it("can open and read an empty database", async () => {
@@ -13,7 +13,7 @@ describe("test infrastructure", () => {
       type: "water",
       amount: 250,
       timestamp: Date.now(),
-    } as any);
+    } as unknown as IntakeRecord);
     const record = await db.intakeRecords.get("smoke-test-id");
     expect(record).toBeDefined();
     expect(record?.amount).toBe(250);

--- a/apps/web/src/__tests__/sync-conflict.property.test.ts
+++ b/apps/web/src/__tests__/sync-conflict.property.test.ts
@@ -97,7 +97,7 @@ vi.mock("@intake/db/client", () => {
         where: () => Promise.resolve(Object.values(existingRows)),
       }),
     }),
-    insert: (table: unknown) => ({
+    insert: (_table: unknown) => ({
       values: (v: ServerRow) => ({
         onConflictDoUpdate: async ({ set }: { target: unknown; set: Partial<ServerRow> }) => {
           // Mirror Postgres' ON CONFLICT DO UPDATE: prefer `set` values

--- a/apps/web/src/__tests__/sync-push-route.test.ts
+++ b/apps/web/src/__tests__/sync-push-route.test.ts
@@ -28,15 +28,12 @@ import { NextRequest } from "next/server";
 // Controllable stubs driving the drizzle mock
 // ────────────────────────────────────────────────────────────────────────
 
-type ServerRow = {
-  id: string;
-  userId: string;
-  updatedAt: number;
-  deletedAt: number | null;
-} | undefined;
-
-let existingRows: Record<string, any> = {};
-const insertCalls: { table: unknown; values: any; set: any }[] = [];
+let existingRows: Record<string, Record<string, unknown>> = {};
+const insertCalls: {
+  table: unknown;
+  values: Record<string, unknown>;
+  set: Record<string, unknown>;
+}[] = [];
 
 function resetDbState() {
   existingRows = {};
@@ -73,10 +70,15 @@ vi.mock("@intake/db/client", () => {
       }),
     }),
     insert: (table: unknown) => ({
-      values: (v: any) => ({
-        onConflictDoUpdate: async ({ set }: { target: unknown; set: any }) => {
+      values: (v: Record<string, unknown>) => ({
+        onConflictDoUpdate: async ({
+          set,
+        }: {
+          target: unknown;
+          set: Record<string, unknown>;
+        }) => {
           insertCalls.push({ table, values: v, set });
-          existingRows[v.id] = { ...v };
+          existingRows[v.id as string] = { ...v };
           return undefined;
         },
         onConflictDoNothing: async () => undefined,

--- a/apps/web/src/__tests__/sync-service-tier2.test.ts
+++ b/apps/web/src/__tests__/sync-service-tier2.test.ts
@@ -9,7 +9,6 @@ import {
   addSubstanceRecord,
   deleteSubstanceRecord,
   updateSubstanceRecord,
-  getSubstanceRecords,
 } from "@/lib/substance-service";
 import {
   addComposableEntry,
@@ -17,7 +16,6 @@ import {
   undoDeleteEntryGroup,
   deleteSingleGroupRecord,
   undoDeleteSingleRecord,
-  getEntryGroup,
 } from "@/lib/composable-entry-service";
 import {
   addSchedule,

--- a/apps/web/src/app/api/_shared/validation.ts
+++ b/apps/web/src/app/api/_shared/validation.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from "next/server";
 import type { NextRequest } from "next/server";
-import type { ZodError } from "zod";
+import { z, type ZodError } from "zod";
 
 /**
  * Build a 400 response for a Zod validation failure.
@@ -13,7 +13,7 @@ export function zodErrorResponse(
   context: string,
   error: ZodError<unknown>,
 ): NextResponse {
-  console.error(`[VALIDATION] ${context}:`, JSON.stringify(error.flatten()));
+  console.error(`[VALIDATION] ${context}:`, JSON.stringify(z.flattenError(error)));
   return NextResponse.json({ error: "Invalid request" }, { status: 400 });
 }
 

--- a/apps/web/src/app/api/ai/interaction-check/route.ts
+++ b/apps/web/src/app/api/ai/interaction-check/route.ts
@@ -130,7 +130,7 @@ export const POST = withAuth(async ({ request, auth }) => {
 
     const validated = InteractionResultSchema.safeParse(toolBlock.input);
     if (!validated.success) {
-      console.error("[VALIDATION] Interaction check response validation failed:", JSON.stringify(validated.error.flatten()));
+      console.error("[VALIDATION] Interaction check response validation failed:", JSON.stringify(z.flattenError(validated.error)));
       return NextResponse.json(
         { error: "AI service unavailable" },
         { status: 502 }

--- a/apps/web/src/app/api/ai/medicine-search/route.ts
+++ b/apps/web/src/app/api/ai/medicine-search/route.ts
@@ -121,7 +121,7 @@ export const POST = withAuth(async ({ request, auth }) => {
 
     const validated = MedicineSearchResponseSchema.safeParse(toolBlock.input);
     if (!validated.success) {
-      console.error("[VALIDATION] Medicine search response validation failed:", JSON.stringify(validated.error.flatten()));
+      console.error("[VALIDATION] Medicine search response validation failed:", JSON.stringify(z.flattenError(validated.error)));
       return NextResponse.json(
         { error: "AI response format invalid", fallbackToManual: true },
         { status: 422 }

--- a/apps/web/src/app/api/ai/nutrient-analysis/route.ts
+++ b/apps/web/src/app/api/ai/nutrient-analysis/route.ts
@@ -220,7 +220,7 @@ export const POST = withAuth(async ({ request, auth }) => {
     if (!validated.success) {
       console.error(
         "[VALIDATION] Nutrient analysis response validation failed:",
-        JSON.stringify(validated.error.flatten()),
+        JSON.stringify(z.flattenError(validated.error)),
       );
       return NextResponse.json(
         { error: "The AI response didn't match the expected shape. Try again." },

--- a/apps/web/src/app/api/ai/parse/route.ts
+++ b/apps/web/src/app/api/ai/parse/route.ts
@@ -159,7 +159,7 @@ export const POST = withAuth(async ({ request, auth }) => {
       reasoning: toolInput.reasoning,
     });
     if (!validated.success) {
-      console.error("[VALIDATION] AI response validation failed:", JSON.stringify(validated.error.flatten()));
+      console.error("[VALIDATION] AI response validation failed:", JSON.stringify(z.flattenError(validated.error)));
       return NextResponse.json(
         { error: "AI response format invalid", fallbackToManual: true },
         { status: 422 }

--- a/apps/web/src/app/api/ai/substance-enrich/route.ts
+++ b/apps/web/src/app/api/ai/substance-enrich/route.ts
@@ -167,7 +167,7 @@ export const POST = withAuth(async ({ request, auth }) => {
       if (!validated.success) {
         console.error(
           "[VALIDATION] Caffeine enrichment validation failed:",
-          JSON.stringify(validated.error.flatten())
+          JSON.stringify(z.flattenError(validated.error))
         );
         return NextResponse.json(
           { error: "AI response format invalid", fallbackToManual: true },
@@ -181,7 +181,7 @@ export const POST = withAuth(async ({ request, auth }) => {
     if (!validated.success) {
       console.error(
         "[VALIDATION] Alcohol enrichment validation failed:",
-        JSON.stringify(validated.error.flatten())
+        JSON.stringify(z.flattenError(validated.error))
       );
       return NextResponse.json(
         { error: "AI response format invalid", fallbackToManual: true },

--- a/apps/web/src/app/api/ai/substance-lookup/route.ts
+++ b/apps/web/src/app/api/ai/substance-lookup/route.ts
@@ -140,7 +140,7 @@ export const POST = withAuth(async ({ request, auth }) => {
     if (!validated.success) {
       console.error(
         "[VALIDATION] Substance lookup response failed:",
-        JSON.stringify(validated.error.flatten())
+        JSON.stringify(z.flattenError(validated.error))
       );
       return NextResponse.json({ error: "AI response validation failed" }, { status: 422 });
     }

--- a/apps/web/src/app/api/ai/titration-warnings/route.ts
+++ b/apps/web/src/app/api/ai/titration-warnings/route.ts
@@ -117,7 +117,7 @@ export const POST = withAuth(async ({ request, auth }) => {
 
     const validated = ResponseSchema.safeParse(toolBlock.input);
     if (!validated.success) {
-      console.error("[VALIDATION] Titration warnings response validation failed:", JSON.stringify(validated.error.flatten()));
+      console.error("[VALIDATION] Titration warnings response validation failed:", JSON.stringify(z.flattenError(validated.error)));
       return NextResponse.json(
         { error: "AI service unavailable" },
         { status: 502 },

--- a/apps/web/src/app/api/ai/voice-transcribe/route.test.ts
+++ b/apps/web/src/app/api/ai/voice-transcribe/route.test.ts
@@ -15,6 +15,7 @@
  */
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { NextRequest } from "next/server";
+import type * as AiKeyResolverMod from "@/lib/ai-key-resolver";
 
 vi.mock("@/lib/auth-middleware", () => ({
   withAuth: (
@@ -35,7 +36,7 @@ vi.mock("@/lib/auth-middleware", () => ({
 // is stubbed — NoAiKeyError must remain the real class because
 // ai-error-response.ts does `error instanceof NoAiKeyError`.
 vi.mock("@/lib/ai-key-resolver", async (importOriginal) => {
-  const actual = await importOriginal<typeof import("@/lib/ai-key-resolver")>();
+  const actual = await importOriginal<typeof AiKeyResolverMod>();
   return {
     ...actual,
     resolveAiKey: vi.fn(async () => ({

--- a/apps/web/src/app/api/analytics/insights/deep/route.test.ts
+++ b/apps/web/src/app/api/analytics/insights/deep/route.test.ts
@@ -13,6 +13,7 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { NextRequest } from "next/server";
 import { NoAiKeyError } from "@/lib/ai-key-resolver";
+import type * as InsightJobServiceMod from "@/lib/server/insight-job-service";
 
 // ── Controllable stubs ───────────────────────────────────────────────────
 
@@ -94,9 +95,9 @@ vi.mock("@/app/api/ai/_shared/claude-client", () => ({
 }));
 
 vi.mock("@/lib/server/insight-job-service", async () => {
-  const actual = await vi.importActual<
-    typeof import("@/lib/server/insight-job-service")
-  >("@/lib/server/insight-job-service");
+  const actual = await vi.importActual<typeof InsightJobServiceMod>(
+    "@/lib/server/insight-job-service",
+  );
   return {
     ...actual,
     createInsightJob: async (input: unknown) => {

--- a/apps/web/src/app/api/analytics/insights/jobs/[id]/route.ts
+++ b/apps/web/src/app/api/analytics/insights/jobs/[id]/route.ts
@@ -1,4 +1,5 @@
 import { NextResponse } from "next/server";
+import { z } from "zod";
 import type Anthropic from "@anthropic-ai/sdk";
 import { withAuth } from "@/lib/auth-middleware";
 import {
@@ -258,7 +259,7 @@ export const GET = withAuth(async ({ request, auth }) => {
         )
       : -1;
     console.error(
-      `[analytics/insights/jobs] response validation failed: summaryLen=${summaryLen} obsCount=${obsCount} obsMaxLen=${obsMaxLen} fields=${JSON.stringify(validated.error.flatten().fieldErrors)}`,
+      `[analytics/insights/jobs] response validation failed: summaryLen=${summaryLen} obsCount=${obsCount} obsMaxLen=${obsMaxLen} fields=${JSON.stringify(z.flattenError(validated.error).fieldErrors)}`,
     );
     await failInsightJob(job.id, err);
     return NextResponse.json({

--- a/apps/web/src/app/api/analytics/insights/route.ts
+++ b/apps/web/src/app/api/analytics/insights/route.ts
@@ -1,4 +1,5 @@
 import { NextResponse } from "next/server";
+import { z } from "zod";
 import type Anthropic from "@anthropic-ai/sdk";
 import { withAuth } from "@/lib/auth-middleware";
 import {
@@ -144,7 +145,7 @@ export const POST = withAuth(async ({ request, auth }) => {
     if (!validated.success) {
       console.error(
         "[analytics/insights] AI response validation failed:",
-        JSON.stringify(validated.error.flatten()),
+        JSON.stringify(z.flattenError(validated.error)),
         { stopReason: response.stop_reason },
       );
       return NextResponse.json(

--- a/apps/web/src/app/api/mcp/oauth/authorize/route.ts
+++ b/apps/web/src/app/api/mcp/oauth/authorize/route.ts
@@ -40,7 +40,7 @@ export const dynamic = "force-dynamic";
 const querySchema = z.object({
   response_type: z.literal("code"),
   client_id: z.string().min(1),
-  redirect_uri: z.string().url(),
+  redirect_uri: z.url(),
   code_challenge: z.string().min(43).max(128),
   code_challenge_method: z.literal("S256").default("S256"),
   state: z.string().min(1).max(512),

--- a/apps/web/src/app/api/mcp/oauth/register/route.ts
+++ b/apps/web/src/app/api/mcp/oauth/register/route.ts
@@ -16,7 +16,7 @@ export const dynamic = "force-dynamic";
 
 const bodySchema = z.object({
   client_name: z.string().min(1).max(200).default("claude.ai"),
-  redirect_uris: z.array(z.string().url()).min(1).max(10),
+  redirect_uris: z.array(z.url()).min(1).max(10),
   token_endpoint_auth_method: z
     .enum(["none", "client_secret_basic", "client_secret_post"])
     .default("none"),

--- a/apps/web/src/app/api/mcp/oauth/token/route.ts
+++ b/apps/web/src/app/api/mcp/oauth/token/route.ts
@@ -25,7 +25,7 @@ export function OPTIONS() {
 const codeGrantSchema = z.object({
   grant_type: z.literal("authorization_code"),
   code: z.string().min(1),
-  redirect_uri: z.string().url(),
+  redirect_uri: z.url(),
   client_id: z.string().min(1),
   client_secret: z.string().optional(),
   code_verifier: z.string().min(43).max(128),

--- a/apps/web/src/app/api/push/settings/route.ts
+++ b/apps/web/src/app/api/push/settings/route.ts
@@ -15,7 +15,7 @@ export const POST = withAuth(async ({ request, auth }) => {
     const parsed = SettingsSchema.safeParse(body);
     if (!parsed.success) {
       return NextResponse.json(
-        { error: "Invalid request", details: parsed.error.flatten() },
+        { error: "Invalid request", details: z.flattenError(parsed.error) },
         { status: 400 }
       );
     }

--- a/apps/web/src/app/api/push/subscribe/route.ts
+++ b/apps/web/src/app/api/push/subscribe/route.ts
@@ -5,7 +5,7 @@ import { savePushSubscription } from "@/lib/push-db";
 import { parseJsonBody, zodErrorResponse } from "@/app/api/_shared/validation";
 
 const SubscribeSchema = z.object({
-  endpoint: z.string().url(),
+  endpoint: z.url(),
   keys: z.object({
     p256dh: z.string().min(1),
     auth: z.string().min(1),

--- a/apps/web/src/app/api/sync/cleanup/route.ts
+++ b/apps/web/src/app/api/sync/cleanup/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from "next/server";
 import { eq } from "drizzle-orm";
+import { type PgColumn } from "drizzle-orm/pg-core";
 import { withAuth } from "@/lib/auth-middleware";
 import { db } from "@intake/db/client";
 import { schemaByTableName, type TableName } from "@intake/db/sync-payload";
@@ -33,7 +34,7 @@ export const POST = withAuth(async ({ auth }) => {
       const table = schemaByTableName[tableName];
       const result = await db
         .delete(table)
-        .where(eq((table as any).userId, auth.userId!));
+        .where(eq((table as { userId: PgColumn }).userId, auth.userId!));
 
       deleted[tableName] = result.rowCount ?? 0;
     }

--- a/apps/web/src/app/api/sync/pull/route.ts
+++ b/apps/web/src/app/api/sync/pull/route.ts
@@ -40,6 +40,7 @@
  */
 import { NextResponse } from "next/server";
 import { and, asc, eq, gt, or } from "drizzle-orm";
+import { type PgColumn, type PgTable } from "drizzle-orm/pg-core";
 import { withAuth } from "@/lib/auth-middleware";
 import { db as drizzleDb } from "@intake/db/client";
 import {
@@ -76,7 +77,11 @@ export const POST = withAuth(async ({ request, auth }) => {
           typeof rawCursor === "number" ? rawCursor : rawCursor?.updatedAt ?? 0;
         const cursorId =
           typeof rawCursor === "number" ? "" : rawCursor?.id ?? "";
-        const table = schemaByTableName[tableName] as any;
+        const table = schemaByTableName[tableName] as PgTable & {
+          id: PgColumn;
+          userId: PgColumn;
+          updatedAt: PgColumn;
+        };
 
         // `updatedAt > cursor` OR `(updatedAt = cursor AND id > cursorId)` —
         // the tuple comparison keeps pagination correct when many rows share

--- a/apps/web/src/app/api/sync/pull/route.ts
+++ b/apps/web/src/app/api/sync/pull/route.ts
@@ -39,6 +39,7 @@
  * from sync routes — keeps PHI out of logs by default).
  */
 import { NextResponse } from "next/server";
+import { z } from "zod";
 import { and, asc, eq, gt, or } from "drizzle-orm";
 import { type PgColumn, type PgTable } from "drizzle-orm/pg-core";
 import { withAuth } from "@/lib/auth-middleware";
@@ -58,7 +59,7 @@ export const POST = withAuth(async ({ request, auth }) => {
     const parsed = pullBodySchema.safeParse(body);
     if (!parsed.success) {
       return NextResponse.json(
-        { error: "Invalid request", details: parsed.error.flatten() },
+        { error: "Invalid request", details: z.flattenError(parsed.error) },
         { status: 400 },
       );
     }

--- a/apps/web/src/app/api/sync/push/route.ts
+++ b/apps/web/src/app/api/sync/push/route.ts
@@ -38,6 +38,7 @@
  * (contains PHI — timestamps, food descriptions, medication names).
  */
 import { NextResponse } from "next/server";
+import { z } from "zod";
 import { eq, and, inArray } from "drizzle-orm";
 import { type PgColumn, type PgTable } from "drizzle-orm/pg-core";
 import { withAuth } from "@/lib/auth-middleware";
@@ -85,7 +86,7 @@ export const POST = withAuth(async ({ request, auth }) => {
     const body = await request.json();
     const parsed = pushBodySchema.safeParse(body);
     if (!parsed.success) {
-      console.error("[sync/push] Zod validation failed:", JSON.stringify(parsed.error.flatten(), null, 2));
+      console.error("[sync/push] Zod validation failed:", JSON.stringify(z.flattenError(parsed.error), null, 2));
       return NextResponse.json(
         { error: "Invalid request" },
         { status: 400 },

--- a/apps/web/src/app/api/sync/push/route.ts
+++ b/apps/web/src/app/api/sync/push/route.ts
@@ -39,6 +39,7 @@
  */
 import { NextResponse } from "next/server";
 import { eq, and, inArray } from "drizzle-orm";
+import { type PgColumn, type PgTable } from "drizzle-orm/pg-core";
 import { withAuth } from "@/lib/auth-middleware";
 import { db as drizzleDb } from "@intake/db/client";
 import { usersSync } from "@intake/db/schema";
@@ -53,7 +54,7 @@ export const maxDuration = 60;
 const MAX_FUTURE_MS = 60_000;
 const SELECT_CHUNK_SIZE = 100;
 
-function sanitizeRow(obj: Record<string, any>): Record<string, any> {
+function sanitizeRow(obj: Record<string, unknown>): Record<string, unknown> {
   for (const key of Object.keys(obj)) {
     if (obj[key] === undefined || obj[key] === "") {
       obj[key] = null;
@@ -64,10 +65,10 @@ function sanitizeRow(obj: Record<string, any>): Record<string, any> {
 
 function extractDbError(err: unknown): string {
   if (!(err instanceof Error)) return String(err);
-  const cause = (err as any).cause;
+  const cause = (err as { cause?: unknown }).cause;
   if (cause instanceof Error) {
-    const code = (cause as any).code ?? "";
-    const detail = (cause as any).detail ?? "";
+    const code = (cause as { code?: string }).code ?? "";
+    const detail = (cause as { detail?: string }).detail ?? "";
     return [cause.message, code && `code=${code}`, detail && `detail=${detail}`]
       .filter(Boolean)
       .join(" | ");
@@ -136,12 +137,13 @@ export const POST = withAuth(async ({ request, auth }) => {
             .from(table)
             .where(
               and(
-                inArray((table as any).id, chunk),
-                eq((table as any).userId, auth.userId!),
+                inArray((table as { id: PgColumn }).id, chunk),
+                eq((table as { userId: PgColumn }).userId, auth.userId!),
               ),
             );
           for (const r of rows) {
-            existingById.set((r as any).id as string, r as any);
+            const row = r as { id: string; updatedAt: number; deletedAt: number | null };
+            existingById.set(row.id, row);
           }
         }
       } catch (selectErr) {
@@ -192,11 +194,11 @@ export const POST = withAuth(async ({ request, auth }) => {
           clampedUpdatedAt === serverRow.updatedAt;
 
         if (!serverRow || clampedUpdatedAt > serverRow.updatedAt || tombstoneTieBreak) {
-          const rowWithoutUserId: Record<string, any> = { ...op.row };
+          const rowWithoutUserId: Record<string, unknown> = { ...op.row };
           delete rowWithoutUserId.userId;
           sanitizeRow(rowWithoutUserId);
 
-          const writeValues: Record<string, any> = {
+          const writeValues: Record<string, unknown> = {
             ...rowWithoutUserId,
             userId: auth.userId!,
             updatedAt: clampedUpdatedAt,
@@ -204,11 +206,11 @@ export const POST = withAuth(async ({ request, auth }) => {
 
           const { id: _id, ...setValues } = writeValues;
           try {
-            await (drizzleDb as any)
-              .insert(table)
+            await drizzleDb
+              .insert(table as PgTable)
               .values(writeValues)
               .onConflictDoUpdate({
-                target: (table as any).id,
+                target: (table as { id: PgColumn }).id,
                 set: setValues,
               });
             accepted.push({

--- a/apps/web/src/app/api/sync/status/route.ts
+++ b/apps/web/src/app/api/sync/status/route.ts
@@ -9,6 +9,7 @@
  */
 import { NextResponse } from "next/server";
 import { eq } from "drizzle-orm";
+import { type PgColumn } from "drizzle-orm/pg-core";
 import { withAuth } from "@/lib/auth-middleware";
 import { db as drizzleDb } from "@intake/db/client";
 import {
@@ -31,9 +32,9 @@ export const GET = withAuth(async ({ auth }) => {
   try {
     for (const table of PROBE_TABLES) {
       const rows = await drizzleDb
-        .select({ id: (table as any).id })
+        .select({ id: (table as { id: PgColumn }).id })
         .from(table)
-        .where(eq((table as any).userId, auth.userId!))
+        .where(eq((table as { userId: PgColumn }).userId, auth.userId!))
         .limit(1);
       if (rows.length > 0) {
         return NextResponse.json({ hasSyncedData: true });

--- a/apps/web/src/app/api/sync/verify-hash/route.ts
+++ b/apps/web/src/app/api/sync/verify-hash/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
 import { createHash } from "crypto";
 import { eq, gt, and } from "drizzle-orm";
+import { type PgColumn } from "drizzle-orm/pg-core";
 import { withAuth } from "@/lib/auth-middleware";
 import { db } from "@intake/db/client";
 import { schemaByTableName, type TableName } from "@intake/db/sync-payload";
@@ -37,16 +38,18 @@ export const POST = withAuth(async ({ auth }) => {
 
       hash.update("[");
       for (;;) {
-        const conditions = [eq((table as any).userId, auth.userId!)];
+        const conditions = [
+          eq((table as { userId: PgColumn }).userId, auth.userId!),
+        ];
         if (cursor) {
-          conditions.push(gt((table as any).id, cursor));
+          conditions.push(gt((table as { id: PgColumn }).id, cursor));
         }
 
         const rows = await db
           .select()
           .from(table)
           .where(and(...conditions))
-          .orderBy((table as any).id)
+          .orderBy((table as { id: PgColumn }).id)
           .limit(SELECT_CHUNK_SIZE);
 
         for (const row of rows) {
@@ -57,7 +60,7 @@ export const POST = withAuth(async ({ auth }) => {
         }
 
         if (rows.length < SELECT_CHUNK_SIZE) break;
-        cursor = (rows[rows.length - 1] as any).id as string;
+        cursor = (rows[rows.length - 1] as { id: string }).id;
       }
       hash.update("]");
 

--- a/apps/web/src/app/api/user/api-keys/shares/route.ts
+++ b/apps/web/src/app/api/user/api-keys/shares/route.ts
@@ -24,7 +24,7 @@ import { parseJsonBody, zodErrorResponse } from "@/app/api/_shared/validation";
  */
 
 const PostSchema = z.object({
-  granteeEmail: z.string().email().max(320),
+  granteeEmail: z.email().max(320),
   provider: z.enum(["anthropic", "groq"]),
 });
 

--- a/apps/web/src/components/analytics/ai-insights-card.tsx
+++ b/apps/web/src/components/analytics/ai-insights-card.tsx
@@ -69,7 +69,7 @@ function sourceLabel(url: string): string {
 }
 
 /**
- * Anchor-safety guard: `z.string().url()` accepts `javascript:` and `data:`
+ * Anchor-safety guard: `z.url()` accepts `javascript:` and `data:`
  * schemes, which we would NEVER want to render as a clickable link given
  * the URL is model-generated. Only http(s) survives as an anchor; anything
  * else falls back to plain text so the source still shows but cannot be

--- a/apps/web/src/components/analytics/records-tab.tsx
+++ b/apps/web/src/components/analytics/records-tab.tsx
@@ -28,6 +28,7 @@ import {
 } from "@/lib/db";
 import {
   type FilterType,
+  type UnifiedRecord,
   getRecordId,
   groupRecordsByDate,
   filterRecords,
@@ -174,7 +175,7 @@ export function RecordsTab({ range }: RecordsTabProps) {
   const dateGroups = Array.from(groupedRecords.entries());
 
   // Delete handler
-  const handleDelete = useCallback(async (unified: import("@/lib/history-types").UnifiedRecord) => {
+  const handleDelete = useCallback(async (unified: UnifiedRecord) => {
     const id = getRecordId(unified);
     setDeletingId(id);
     try {
@@ -194,7 +195,7 @@ export function RecordsTab({ range }: RecordsTabProps) {
   }, [toast, deleteMutation, deleteWeight, deleteBP, deleteEatingMutation, deleteUrinationMutation, deleteDefecationMutation, deleteSubstance]);
 
   // Edit openers
-  const openEdit = useCallback((unified: import("@/lib/history-types").UnifiedRecord) => {
+  const openEdit = useCallback((unified: UnifiedRecord) => {
     setEditTimestamp(timestampToDateTimeLocal(unified.record.timestamp));
     setEditNote((unified.record as unknown as { note?: string }).note || "");
 

--- a/apps/web/src/components/analytics/titration-tab.tsx
+++ b/apps/web/src/components/analytics/titration-tab.tsx
@@ -338,7 +338,7 @@ function PrescriptionSection({ report }: { report: PrescriptionReport }) {
 // Main tab component
 // ---------------------------------------------------------------------------
 
-export function TitrationTab({ range }: { range: TimeRange }) {
+export function TitrationTab({ range: _range }: { range: TimeRange }) {
   const reports = useTitrationData();
 
   if (!reports) {

--- a/apps/web/src/components/blood-pressure-card.tsx
+++ b/apps/web/src/components/blood-pressure-card.tsx
@@ -146,7 +146,7 @@ export function BloodPressureCard() {
         if (field && typeof field === "string") errors[field] = issue.message;
       }
       setFieldErrors(errors);
-      logAudit("validation_error", JSON.stringify({ form: "blood_pressure", errors: parsed.error.flatten() }).slice(0, 100));
+      logAudit("validation_error", JSON.stringify({ form: "blood_pressure", errors: z.flattenError(parsed.error) }).slice(0, 100));
       return;
     }
     setFieldErrors({});

--- a/apps/web/src/components/defecation-card.tsx
+++ b/apps/web/src/components/defecation-card.tsx
@@ -82,7 +82,7 @@ export function DefecationCard() {
         description: `Defecation (${amountValue}) recorded`,
         variant: "success",
       });
-    } catch (error) {
+    } catch {
       toast({
         title: "Error",
         description: "Failed to record",
@@ -111,7 +111,7 @@ export function DefecationCard() {
       setAmount(settings.defecationDefaultAmount || "");
       setNote("");
       setDetailTime(getCurrentDateTimeLocal());
-    } catch (error) {
+    } catch {
       toast({
         title: "Error",
         description: "Failed to record",

--- a/apps/web/src/components/liquids-card.tsx
+++ b/apps/web/src/components/liquids-card.tsx
@@ -3,7 +3,6 @@
 import { useMemo, useRef, useState } from "react";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Card, CardContent } from "@/components/ui/card";
-import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { CARD_THEMES } from "@/lib/card-themes";

--- a/apps/web/src/components/manual-input-dialog.tsx
+++ b/apps/web/src/components/manual-input-dialog.tsx
@@ -82,7 +82,7 @@ export function ManualInputDialog({
         if (field && typeof field === "string") errors[field] = issue.message;
       }
       setFieldErrors(errors);
-      logAudit("validation_error", JSON.stringify({ form: "intake", errors: parsed.error.flatten() }).slice(0, 100));
+      logAudit("validation_error", JSON.stringify({ form: "intake", errors: z.flattenError(parsed.error) }).slice(0, 100));
       return;
     }
     setFieldErrors({});

--- a/apps/web/src/components/medications/add-medication-wizard.flow.test.tsx
+++ b/apps/web/src/components/medications/add-medication-wizard.flow.test.tsx
@@ -31,11 +31,12 @@ import { screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { http, HttpResponse } from "msw";
 import { setupServer } from "msw/node";
+import type * as AuthGuardMod from "@/components/auth-guard";
 
 // Open the auth gate so the wizard renders its AI search input.
 // useAuthGate uses useAuth().authenticated, so mock the upstream hook.
 vi.mock("@/components/auth-guard", async (importActual) => {
-  const actual = await importActual<typeof import("@/components/auth-guard")>();
+  const actual = await importActual<typeof AuthGuardMod>();
   return {
     ...actual,
     useAuthGate: () => true,

--- a/apps/web/src/components/urination-card.tsx
+++ b/apps/web/src/components/urination-card.tsx
@@ -82,7 +82,7 @@ export function UrinationCard() {
         description: `Urination (${amountValue}) recorded`,
         variant: "success",
       });
-    } catch (error) {
+    } catch {
       toast({
         title: "Error",
         description: "Failed to record",
@@ -110,7 +110,7 @@ export function UrinationCard() {
       setAmount(settings.urinationDefaultAmount);
       setNote("");
       setDetailTime(getCurrentDateTimeLocal());
-    } catch (error) {
+    } catch {
       toast({
         title: "Error",
         description: "Failed to record",

--- a/apps/web/src/components/weight-card.tsx
+++ b/apps/web/src/components/weight-card.tsx
@@ -113,7 +113,7 @@ export function WeightCard() {
         if (field && typeof field === "string") errors[field] = issue.message;
       }
       setFieldErrors(errors);
-      logAudit("validation_error", JSON.stringify({ form: "weight", errors: parsed.error.flatten() }).slice(0, 100));
+      logAudit("validation_error", JSON.stringify({ form: "weight", errors: z.flattenError(parsed.error) }).slice(0, 100));
       return;
     }
     setFieldErrors({});

--- a/apps/web/src/hooks/use-add-medication-form.ts
+++ b/apps/web/src/hooks/use-add-medication-form.ts
@@ -186,7 +186,7 @@ export function useAddMedicationForm(): UseAddMedicationFormReturn {
             "validation_error",
             JSON.stringify({
               form: "medication_wizard_search",
-              errors: parsed.error.flatten(),
+              errors: z.flattenError(parsed.error),
             }).slice(0, 1000),
           );
           return false;
@@ -223,7 +223,7 @@ export function useAddMedicationForm(): UseAddMedicationFormReturn {
               "validation_error",
               JSON.stringify({
                 form: "medication_wizard_schedule",
-                errors: parsed.error.flatten(),
+                errors: z.flattenError(parsed.error),
               }).slice(0, 1000),
             );
             return false;
@@ -245,7 +245,7 @@ export function useAddMedicationForm(): UseAddMedicationFormReturn {
             "validation_error",
             JSON.stringify({
               form: "medication_wizard_inventory",
-              errors: parsed.error.flatten(),
+              errors: z.flattenError(parsed.error),
             }).slice(0, 1000),
           );
           return false;

--- a/apps/web/src/hooks/use-permissions.ts
+++ b/apps/web/src/hooks/use-permissions.ts
@@ -5,7 +5,6 @@ import {
   isNotificationSupported,
   getNotificationPermission,
   requestNotificationPermission,
-  type NotificationPermissionState,
 } from "@/lib/push-notification-service";
 import { unwrap } from "@/lib/service-result";
 

--- a/apps/web/src/hooks/use-timezone-detection.test.ts
+++ b/apps/web/src/hooks/use-timezone-detection.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, vi } from "vitest";
+import { describe, it, expect } from "vitest";
 import { db } from "@/lib/db";
 import {
   makePrescription,

--- a/apps/web/src/lib/analytics-service.test.ts
+++ b/apps/web/src/lib/analytics-service.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import type { IntakeRecord, WeightRecord, BloodPressureRecord, UrinationRecord, SubstanceRecord } from "@/lib/db";
+import type { IntakeRecord, WeightRecord, BloodPressureRecord, UrinationRecord } from "@/lib/db";
 import type { DoseSlot } from "@/lib/dose-schedule-service";
 import type { TimeRange } from "@/lib/analytics-types";
 
@@ -59,7 +59,6 @@ import {
   alcoholVsBP,
   getRecordsByDomain,
   groupByDay,
-  correlate,
 } from "@/lib/analytics-service";
 
 import { getRecordsByDateRange as mockGetIntake } from "@/lib/intake-service";

--- a/apps/web/src/lib/composable-entry-service.test.ts
+++ b/apps/web/src/lib/composable-entry-service.test.ts
@@ -217,18 +217,19 @@ describe("composable-entry-service", () => {
       // Monkey-patch crypto.randomUUID to return the existing id on the second call
       const originalRandomUUID = crypto.randomUUID.bind(crypto);
       let callCount = 0;
-      (crypto as any).randomUUID = (): string => {
+      const patchedRandomUUID = ((): string => {
         callCount++;
         // First call = groupId, second call = eating record, third call = intake record
         if (callCount === 3) return existingRecord.id;
         return originalRandomUUID();
-      };
+      }) as typeof crypto.randomUUID;
+      (crypto as { randomUUID: typeof crypto.randomUUID }).randomUUID = patchedRandomUUID;
 
       try {
         const result = await addComposableEntry(input);
         expect(result.success).toBe(false);
       } finally {
-        (crypto as any).randomUUID = originalRandomUUID;
+        (crypto as { randomUUID: typeof crypto.randomUUID }).randomUUID = originalRandomUUID;
       }
 
       // Verify no eating records were created (transaction rolled back)

--- a/apps/web/src/lib/composable-entry-service.ts
+++ b/apps/web/src/lib/composable-entry-service.ts
@@ -816,7 +816,7 @@ export async function syncLiquidEntrySubstances(
 // ─── recalculateFromCurrentValues (stub) ──────────────────────────────
 
 export async function recalculateFromCurrentValues(
-  groupId: string,
+  _groupId: string,
 ): Promise<ServiceResult<void>> {
   return err(
     "Not implemented — deferred to Phase 13/14. Requires preset data and recalculation logic not yet available.",

--- a/apps/web/src/lib/db.ts
+++ b/apps/web/src/lib/db.ts
@@ -162,7 +162,7 @@ realDb.version(10).stores(V10_STORES).upgrade(async (trans) => {
 
   // Helper: backfill sync fields on all records in a table
   const backfill = async (tableName: string, timestampField = "timestamp") => {
-    await trans.table(tableName).toCollection().modify((record: any) => {
+    await trans.table(tableName).toCollection().modify((record: Record<string, unknown>) => {
       if (record.createdAt == null) {
         record.createdAt = record[timestampField] ?? record.createdAt ?? now;
       }

--- a/apps/web/src/lib/dose-schedule-service.test.ts
+++ b/apps/web/src/lib/dose-schedule-service.test.ts
@@ -3,7 +3,6 @@ import { db } from "@/lib/db";
 import {
   getDailyDoseSchedule,
   getDoseScheduleForDateRange,
-  type DoseSlot,
 } from "@/lib/dose-schedule-service";
 import {
   makePrescription,

--- a/apps/web/src/lib/export-service.test.ts
+++ b/apps/web/src/lib/export-service.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
+import type * as JsPdfMod from "jspdf";
 import type { AnalyticsResult, DataPoint } from "@/lib/analytics-types";
 
 // Mock jsPDF so exportToPDF's `doc.save()` is captured instead of triggering a
@@ -6,7 +7,7 @@ import type { AnalyticsResult, DataPoint } from "@/lib/analytics-types";
 // and all PDF rendering still run for real.
 const pdfSaves: Array<{ filename: string; dataUri: string }> = [];
 vi.mock("jspdf", async () => {
-  const actual = await vi.importActual<typeof import("jspdf")>("jspdf");
+  const actual = await vi.importActual<typeof JsPdfMod>("jspdf");
   const Real = actual.jsPDF;
   const Wrapped = function WrappedJsPDF(...args: unknown[]) {
     const Ctor = Real as unknown as new (...a: unknown[]) => InstanceType<

--- a/apps/web/src/lib/export-service.ts
+++ b/apps/web/src/lib/export-service.ts
@@ -13,7 +13,7 @@ import {
   weightTrend,
   getRecordsByDomain,
 } from "@/lib/analytics-service";
-import type { TimeRange, Domain, AnalyticsResult, DataPoint } from "@/lib/analytics-types";
+import type { TimeRange, Domain, AnalyticsResult } from "@/lib/analytics-types";
 
 // ---------------------------------------------------------------------------
 // CSV helpers
@@ -25,14 +25,6 @@ function escapeCSVField(field: string): string {
     return `"${field.replace(/"/g, '""')}"`;
   }
   return field;
-}
-
-function dataPointsToCSVRows(points: DataPoint[]): string[][] {
-  return points.map((p) => [
-    new Date(p.timestamp).toISOString(),
-    String(p.value),
-    ...(p.label ? [p.label] : []),
-  ]);
 }
 
 function triggerDownload(blob: Blob, filename: string): void {

--- a/apps/web/src/lib/mcp/oauth-flow.test.ts
+++ b/apps/web/src/lib/mcp/oauth-flow.test.ts
@@ -8,6 +8,8 @@
  */
 import { describe, it, expect, beforeEach, vi } from "vitest";
 import { createHash } from "node:crypto";
+import type * as DrizzleOrm from "drizzle-orm";
+import type * as OAuthMod from "@/lib/mcp/oauth";
 
 // ────────────────────────────────────────────────────────────────────────
 // In-memory db stub
@@ -22,20 +24,12 @@ function tableFor(ref: unknown): Row[] {
   return tables.get(ref)!;
 }
 
-function matchesAll(row: Row, conds: Array<(r: Row) => boolean>): boolean {
-  return conds.every((c) => c(row));
-}
-
-interface Where {
-  __conds: Array<(r: Row) => boolean>;
-}
-
 // Sentinel objects representing each "and/eq/isNull" predicate. The
 // drizzle-orm mock just records the predicate as a function; the test
 // doesn't care about the SQL shape.
 vi.mock("drizzle-orm", async () => {
   const actual =
-    await vi.importActual<typeof import("drizzle-orm")>("drizzle-orm");
+    await vi.importActual<typeof DrizzleOrm>("drizzle-orm");
   return {
     ...actual,
     eq: (column: { name?: string; _key?: string }, value: unknown) => ({
@@ -188,7 +182,7 @@ vi.mock("@intake/db/client", () => {
 // Now import the SUT (after mocks).
 // ────────────────────────────────────────────────────────────────────────
 
-let oauth: typeof import("@/lib/mcp/oauth");
+let oauth: typeof OAuthMod;
 
 beforeEach(async () => {
   tables.clear();

--- a/apps/web/src/lib/medication-notification-service.ts
+++ b/apps/web/src/lib/medication-notification-service.ts
@@ -1,4 +1,4 @@
-import { db, type Prescription, type MedicationPhase, type InventoryItem } from "@/lib/db";
+import { db } from "@/lib/db";
 import { showNotification, getNotificationPermission } from "@/lib/push-notification-service";
 import { getSchedulesForPhase } from "@/lib/medication-schedule-service";
 import { isCombo, splitDose, formatCompoundShort } from "@/lib/compound-utils";

--- a/apps/web/src/lib/medication-service.test.ts
+++ b/apps/web/src/lib/medication-service.test.ts
@@ -15,7 +15,6 @@ import {
   deletePhase,
   getInventoryForPrescription,
   getActiveInventoryForPrescription,
-  addInventoryItem,
   adjustStock,
   addMedicationToPrescription,
   type CreatePrescriptionInput,

--- a/apps/web/src/lib/network-status.ts
+++ b/apps/web/src/lib/network-status.ts
@@ -10,7 +10,7 @@ export function isOnline(): boolean {
 function isCapacitor(): boolean {
   return (
     typeof window !== "undefined" &&
-    !!(window as any).Capacitor
+    !!(window as { Capacitor?: unknown }).Capacitor
   );
 }
 

--- a/apps/web/src/lib/sync-engine.ts
+++ b/apps/web/src/lib/sync-engine.ts
@@ -478,8 +478,8 @@ export async function runPullCycle(): Promise<void> {
           nextId = lastId;
         }
 
-        await db.transaction("rw", [db.table(tn), db._syncMeta] as any, async () => {
-          await (db.table(tn) as any).bulkPut(rows);
+        await db.transaction("rw", [db.table(tn), db._syncMeta], async () => {
+          await db.table(tn).bulkPut(rows);
           await db._syncMeta.put({
             tableName: tn,
             lastPulledUpdatedAt: nextUpdatedAt,
@@ -611,7 +611,15 @@ export function startEngine(): void {
 
   if (process.env.NODE_ENV !== "production") {
     if (typeof window !== "undefined") {
-      (window as any).__syncEngine = {
+      (
+        window as Window & {
+          __syncEngine?: {
+            pushNow: () => Promise<void>;
+            pullNow: () => Promise<void>;
+            getQueueDepth: typeof getQueueDepth;
+          };
+        }
+      ).__syncEngine = {
         pushNow: () => runPushCycle(),
         pullNow: () => runPullCycle(),
         getQueueDepth,

--- a/apps/web/src/lib/sync-payload.property.test.ts
+++ b/apps/web/src/lib/sync-payload.property.test.ts
@@ -36,7 +36,13 @@
  */
 import { describe, it, expect } from "vitest";
 import fc from "fast-check";
-import { pushBodySchema, pullBodySchema } from "@intake/db/sync-payload";
+import {
+  pushBodySchema,
+  pullBodySchema,
+  schemaByTableName,
+  tableNameSchema,
+} from "@intake/db/sync-payload";
+import { TABLE_PUSH_ORDER } from "@/lib/sync-topology";
 
 // ─────────────────────────────────────────────────────────────────────────
 // Arbitraries
@@ -60,6 +66,7 @@ const KNOWN_TABLES = [
   "substanceRecords",
   "titrationPlans",
   "userProfile",
+  "insightReports",
 ] as const;
 
 // Minimal valid row shape for the intakeRecords table — used as the
@@ -413,4 +420,56 @@ describe("pullBodySchema — property invariants", () => {
     const result = pullBodySchema.safeParse({ cursors: {} });
     expect(result.success).toBe(true);
   });
+});
+
+// ─────────────────────────────────────────────────────────────────────────
+// Syncable-table list parity (drift guard)
+//
+// The set of syncable tables is hand-maintained in FOUR independent places.
+// They MUST stay identical — a table present in one but missing from another
+// is a silent sync hole. This regression class already bit once: `KNOWN_TABLES`
+// in this very file was missing `insightReports`, so PUSH-3 could (rarely)
+// generate "insightReports" as a supposedly-"unknown" table and assert it
+// rejects, even though the schema accepts it.
+//
+//   1. schemaByTableName       — the map the push/pull routes look tables up in
+//                                (SOURCE OF TRUTH; a table absent here can't sync)
+//   2. tableNameSchema (enum)  — the pull-side cursor-key allowlist
+//   3. TABLE_PUSH_ORDER        — the FK parent-before-child push ordering
+//   4. KNOWN_TABLES            — this test's own arbitrary generator alphabet
+//
+// (The push-side discriminated union shares this file with #1 and #2 and is
+// documented as the source `tableNameSchema` is derived from; its `tableName`
+// literals are exercised directly by PUSH-1/PUSH-3 above.)
+// ─────────────────────────────────────────────────────────────────────────
+
+describe("syncable-table list parity (drift guard)", () => {
+  const canonical = [...Object.keys(schemaByTableName)].sort();
+
+  const LISTS: Record<string, readonly string[]> = {
+    "tableNameSchema enum (pull-side allowlist)": tableNameSchema.options,
+    "TABLE_PUSH_ORDER (sync-topology.ts)": TABLE_PUSH_ORDER,
+    "KNOWN_TABLES (this test file)": KNOWN_TABLES,
+  };
+
+  it("schemaByTableName has the expected 18 syncable tables", () => {
+    // Pins the canonical count so adding/removing a synced table is a
+    // deliberate, reviewed change rather than a silent drift.
+    expect(canonical).toHaveLength(18);
+  });
+
+  it.each(Object.entries(LISTS))(
+    "%s is set-equal to schemaByTableName",
+    (name, list) => {
+      const missing = canonical.filter((t) => !list.includes(t));
+      const extra = [...list].filter((t) => !canonical.includes(t)).sort();
+      expect(
+        { missing, extra },
+        `${name} drifted from schemaByTableName (the source of truth).\n` +
+          `  Missing here (present in canonical): ${missing.join(", ") || "none"}\n` +
+          `  Extra here (absent from canonical):  ${extra.join(", ") || "none"}\n` +
+          `  Fix: reconcile the list so it matches Object.keys(schemaByTableName).`,
+      ).toEqual({ missing: [], extra: [] });
+    },
+  );
 });

--- a/apps/web/src/lib/timezone-recalculation-service.test.ts
+++ b/apps/web/src/lib/timezone-recalculation-service.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach } from "vitest";
+import { describe, it, expect } from "vitest";
 import { db } from "@/lib/db";
 import {
   makePrescription,

--- a/apps/web/src/lib/timezone.test.ts
+++ b/apps/web/src/lib/timezone.test.ts
@@ -9,7 +9,7 @@ describe("clearTimezoneCache", () => {
     originalDateTimeFormat = Intl.DateTimeFormat;
     // Ensure `window` exists so getDeviceTimezone() reads from Intl API
     if (!hadWindow) {
-      (globalThis as any).window = {};
+      (globalThis as { window?: unknown }).window = {};
     }
     // Always start with a clean cache
     clearTimezoneCache();
@@ -22,7 +22,7 @@ describe("clearTimezoneCache", () => {
     clearTimezoneCache();
     // Remove the window shim if we added it
     if (!hadWindow) {
-      delete (globalThis as any).window;
+      delete (globalThis as { window?: unknown }).window;
     }
   });
 

--- a/apps/web/src/lib/titration-service.ts
+++ b/apps/web/src/lib/titration-service.ts
@@ -1,7 +1,6 @@
 import {
   db,
   type TitrationPlan,
-  type TitrationPlanStatus,
   type MedicationPhase,
   type PhaseSchedule,
 } from "@/lib/db";

--- a/apps/web/src/lib/user-data-deletion.ts
+++ b/apps/web/src/lib/user-data-deletion.ts
@@ -18,6 +18,7 @@
  */
 import "server-only";
 import { eq, or, type SQL } from "drizzle-orm";
+import { type PgColumn, type PgTable } from "drizzle-orm/pg-core";
 import { db } from "@intake/db/client";
 import { schemaByTableName, type TableName } from "@intake/db/sync-payload";
 import {
@@ -60,9 +61,9 @@ const SYNCED_DELETION_ORDER: TableName[] = [
   "insightReports",
 ];
 
-// Drizzle's table refs are heavily generic; the cleanup route uses the same
-// `as any` shape to delete by `userId` across many tables.
-async function del(table: any, where: SQL | undefined): Promise<number> {
+// Drizzle's table refs are heavily generic; we accept the base `PgTable` so a
+// single helper can delete by `userId` across many tables.
+async function del(table: PgTable, where: SQL | undefined): Promise<number> {
   const result = await db.delete(table).where(where);
   return result.rowCount ?? 0;
 }
@@ -71,7 +72,7 @@ async function del(table: any, where: SQL | undefined): Promise<number> {
 async function deleteSyncedData(userId: string): Promise<Record<string, number>> {
   const deleted: Record<string, number> = {};
   for (const name of SYNCED_DELETION_ORDER) {
-    const table = schemaByTableName[name] as any;
+    const table = schemaByTableName[name] as PgTable & { userId: PgColumn };
     deleted[name] = await del(table, eq(table.userId, userId));
   }
   return deleted;

--- a/packages/ai-prompts/src/analytics-insights.ts
+++ b/packages/ai-prompts/src/analytics-insights.ts
@@ -127,7 +127,7 @@ const PriorAssessmentSchema = z.object({
   observations: z.array(z.string().min(1).max(2000)).max(16),
   // URLs from the prior deep report's web_search citations. Sent back so
   // the model can avoid re-fetching sources it already grounded against.
-  sources: z.array(z.string().url()).max(30).optional(),
+  sources: z.array(z.url()).max(30).optional(),
 });
 
 export type PriorAssessment = z.infer<typeof PriorAssessmentSchema>;
@@ -182,7 +182,7 @@ export type AnalyticsInsightsRequest = z.infer<
 export const InsightResponseSchema = z.object({
   summary: z.string().min(1).max(4000),
   observations: z.array(z.string().min(1).max(2000)).max(16),
-  sources: z.array(z.string().url()).max(30).optional(),
+  sources: z.array(z.url()).max(30).optional(),
 });
 
 export const INSIGHT_TOOL = {

--- a/packages/db/src/sync-payload.ts
+++ b/packages/db/src/sync-payload.ts
@@ -269,8 +269,12 @@ export const PULL_SOFT_CAP = 500;
  * Enum of every syncable table name — derived from the push discriminated
  * union above so the pull-side schema and the push-side schema always agree
  * on what "a valid table" means.
+ *
+ * Exported so the sync-table parity guard (sync-payload.property.test.ts) can
+ * assert this list, the push union, `schemaByTableName`, and the topology /
+ * test-side lists never drift apart.
  */
-const tableNameSchema = z.enum([
+export const tableNameSchema = z.enum([
   "intakeRecords",
   "weightRecords",
   "bloodPressureRecords",

--- a/packages/eslint-config/index.js
+++ b/packages/eslint-config/index.js
@@ -25,7 +25,7 @@ export default [
         "error",
         { argsIgnorePattern: "^_", varsIgnorePattern: "^_" },
       ],
-      "@typescript-eslint/consistent-type-imports": "warn",
+      "@typescript-eslint/consistent-type-imports": "error",
     },
   },
   {


### PR DESCRIPTION
## What

Tech-debt batch **C** (DEFERRED.md backlog). Three behavior-preserving cleanups.

### 1. zod v4 deprecations
All three are flagged `@deprecated` in zod 4.4.3; each replacement is the **exact-shape successor** named by the deprecation tag, so runtime behavior is unchanged.

| Before | After | Sites |
|---|---|---|
| `error.flatten()` | `z.flattenError(error)` | 20 |
| `z.string().url()` | `z.url()` | 6 |
| `z.string().email()` | `z.email()` | 1 |

- `z.flattenError` returns the identical `{ formErrors, fieldErrors }` shape `.flatten()` did — confirmed by the validation-failure test logs (`{"formErrors":[],"fieldErrors":{...}}`), so the call sites that read `.fieldErrors` are unaffected. (zod nudges `z.treeifyError`, but that has a *different* nested shape and would break those readers — `z.flattenError` is the correct drop-in.)
- Added `import { z }` to the 5 files that previously imported only schemas / the `ZodError` type.
- The `isSafeHref` runtime anchor guard (the real `javascript:`/`data:` XSS defence) is **untouched**; only its doc comment was refreshed.

### 2. Syncable-table list parity guard
- **Bug fixed:** `KNOWN_TABLES` in `sync-payload.property.test.ts` was missing `insightReports` (17 of 18 tables). That let property `PUSH-3` ("unknown tableName rejects") occasionally generate `"insightReports"` as a supposedly-*unknown* table and assert it rejects — even though the schema **accepts** it. A latent false-failure / coverage hole.
- **Guard added:** exported `tableNameSchema` from `@intake/db/sync-payload` and added a drift test asserting the four hand-maintained table lists stay **set-equal** to the source of truth:
  1. `schemaByTableName` (what the routes look tables up in — source of truth)
  2. `tableNameSchema` (pull-side cursor-key allowlist)
  3. `TABLE_PUSH_ORDER` (`sync-topology.ts`, FK push ordering)
  4. `KNOWN_TABLES` (this test's generator alphabet)
- **Mutation-verified to bite:** removing any table from any list fails the guard with a table-named message (`Missing here (present in canonical): insightReports`).

## Verification
- `turbo run typecheck` — clean (8 tasks)
- `turbo run lint` — **0 errors** (3 pre-existing intentional `jsx-a11y` warnings)
- `turbo run test` — **2036 unit tests** pass (2032 + 4 new parity tests)
- `vitest --config vitest.integration.config.ts` — **33 integration tests** pass

---
> ⛔ **Do not merge until #227 (B2) merges.** Stacked on `chore/eslint-realwork-ratchet` → `chore/eslint-mechanical-ratchet` (#226) → `main`. GitHub retargets each to `main` as the one below it lands.