### PR TITLE
fix(security): resolve open CodeQL alerts (XSS/open-redirect, clear-text logging, dead conditionals)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,9 @@
 *.jks.base64.txt
 upload-keystore.*
 android/keystore.properties
+
+# Generated VAPID keypair (scripts/generate-vapid-keys.js) — contains a private key
+vapid-keys.env
 play-service-account*.json
 
 # Debug
@@ -86,6 +89,7 @@ Thumbs.db
 !.env.example
 node_modules/
 .next/
+out/
 dist/
 build/
 __pycache__/

--- a/apps/web/public/recover.html
+++ b/apps/web/public/recover.html
@@ -55,8 +55,25 @@
   <script>
     (function () {
       var params = new URLSearchParams(location.search);
-      var target = params.get('return') || '/';
-      if (!target.startsWith('/') || target.startsWith('//')) target = '/';
+      // Validate the `return` target as a SAME-ORIGIN path. Resolving against
+      // the current origin and accepting only same-origin results rebuilds a
+      // clean relative path and rejects every redirect/XSS vector: absolute
+      // URLs, protocol-relative `//evil`, backslash tricks `/\evil` (browsers
+      // normalize `\`→`/`), and `javascript:`/`data:` schemes all fail the
+      // origin check. The naive `startsWith('/')` guard this replaces let
+      // `/\evil.com` through (CodeQL js/xss + open-redirect).
+      var target = '/';
+      var requested = params.get('return');
+      if (requested) {
+        try {
+          var url = new URL(requested, location.origin);
+          if (url.origin === location.origin) {
+            target = url.pathname + url.search + url.hash;
+          }
+        } catch (e) {
+          target = '/';
+        }
+      }
 
       var status = document.getElementById('status');
       var report = document.getElementById('report');

--- a/apps/web/scripts/generate-vapid-keys.js
+++ b/apps/web/scripts/generate-vapid-keys.js
@@ -1,11 +1,28 @@
 #!/usr/bin/env node
 // Run: node scripts/generate-vapid-keys.js
-// Generates VAPID key pair for Web Push notifications.
-// Add the output to your .env.local file.
+// Generates a VAPID key pair for Web Push notifications and writes it to a
+// git-ignored `vapid-keys.env` file (mode 600). Copy the two lines into
+// apps/web/.env.local, then delete the file.
+//
+// The keypair is written to a restricted-permission file rather than printed,
+// so the private key never lands in terminal scrollback / CI logs
+// (CodeQL js/clear-text-logging).
 
+const fs = require("fs");
+const path = require("path");
 const webpush = require("web-push");
 
 const vapidKeys = webpush.generateVAPIDKeys();
 
-console.log(`NEXT_PUBLIC_VAPID_PUBLIC_KEY=${vapidKeys.publicKey}`);
-console.log(`VAPID_PRIVATE_KEY=${vapidKeys.privateKey}`);
+const outPath = path.join(process.cwd(), "vapid-keys.env");
+fs.writeFileSync(
+  outPath,
+  `NEXT_PUBLIC_VAPID_PUBLIC_KEY=${vapidKeys.publicKey}\n` +
+    `VAPID_PRIVATE_KEY=${vapidKeys.privateKey}\n`,
+  { mode: 0o600 },
+);
+
+console.log(`VAPID keypair written to ${outPath} (mode 600).`);
+console.log("Next steps:");
+console.log("  1. Copy both lines into apps/web/.env.local");
+console.log("  2. Delete the file:  rm vapid-keys.env");

--- a/apps/web/src/app/api/analytics/insights/deep/route.test.ts
+++ b/apps/web/src/app/api/analytics/insights/deep/route.test.ts
@@ -272,6 +272,28 @@ describe("POST /api/analytics/insights/deep", () => {
     ]);
   });
 
+  it("still releases the reservation and returns 502 when cancelling the orphaned batch also fails", async () => {
+    // attach fails → the route tries to cancel the now-orphaned batch, but
+    // that cancel call ALSO blows up. The route wraps the cancel in .catch,
+    // so the failure must be swallowed: it still deletes the pending job and
+    // returns the generic 502 rather than crashing or leaking the raw error.
+    attachReturns = false;
+    batchCancelThrows = new Error("anthropic cancel 500: secret-internal-detail");
+
+    const { POST } = await import("@/app/api/analytics/insights/deep/route");
+    const res = await POST(makeRequest(validBody()));
+
+    expect(res.status).toBe(502);
+    // The cancel was attempted (and threw) ...
+    expect(batchesCancelCalls).toEqual(["msgbatch_test_123"]);
+    // ... but the route recovered: reservation released, no orphaned lock left.
+    expect(deleteCalls).toEqual([{ jobId: "job-test-1", userId: "user-test" }]);
+
+    // The generic error body must not leak the raw underlying error text.
+    const body = (await res.json()) as { error: string };
+    expect(body.error).not.toContain("secret-internal-detail");
+  });
+
   it("returns 409 / PENDING_JOB_EXISTS when the user already has a pending deep job", async () => {
     const { PendingJobConflictError } = await import(
       "@/lib/server/insight-job-service"

--- a/apps/web/src/app/api/bug-report/route.test.ts
+++ b/apps/web/src/app/api/bug-report/route.test.ts
@@ -193,6 +193,37 @@ describe("POST /api/bug-report", () => {
     );
   });
 
+  it("falls back to the plain template when the Claude client cannot be obtained", async () => {
+    // structureWithAi swallows a getClaudeClientForUser failure and degrades
+    // to the plain template, so the report is still filed without ever
+    // reaching messages.create.
+    claudeClientThrows = new Error("no anthropic key configured");
+
+    const { POST } = await import("@/app/api/bug-report/route");
+    // Use a distinct client IP so this case gets its own rate-limit bucket
+    // and doesn't push the shared default IP over the per-window limit.
+    const req = new NextRequest("https://example.test/api/bug-report", {
+      method: "POST",
+      body: JSON.stringify({ ...validBody(), useAi: true }),
+      headers: {
+        "content-type": "application/json",
+        "x-forwarded-for": "203.0.113.7",
+      },
+    });
+    const res = await POST(req);
+
+    // Client-factory failure is non-fatal — the issue is still filed.
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { number: number };
+    expect(body.number).toBe(42);
+    // The model call is never reached because the client was never built.
+    expect(messagesCreateCalls).toHaveLength(0);
+    // Template title is derived from the first line of the description.
+    expect(String(lastOctokitCreateArgs!.title)).toContain(
+      "The water counter resets",
+    );
+  });
+
   it("uses the feature label set for a feature request", async () => {
     const { POST } = await import("@/app/api/bug-report/route");
     const res = await POST(

--- a/apps/web/src/app/api/e2e-test/count-intake/route.test.ts
+++ b/apps/web/src/app/api/e2e-test/count-intake/route.test.ts
@@ -122,4 +122,20 @@ describe("e2e-test/count-intake-route", () => {
     const body = (await res.json()) as { count: number };
     expect(body.count).toBe(0);
   });
+
+  it("propagates the failure when the count query rejects", async () => {
+    vi.stubEnv("NODE_ENV", "test");
+    // Arm the error-injection seam in the db mock: the select().where()
+    // chain now rejects instead of resolving.
+    selectShouldThrow = new Error("boom");
+
+    const { POST } = await import("@/app/api/e2e-test/count-intake/route");
+
+    // The route awaits the query without a try/catch, so the rejection
+    // surfaces out of the handler (Next.js then renders its own 500). The
+    // raw "boom" message is never wrapped into a JSON body by this route.
+    await expect(POST(makeRequest())).rejects.toThrow("boom");
+    // The query was reached (guard passed, filter applied) before it threw.
+    expect(lastWhereCond).not.toBeNull();
+  });
 });

--- a/apps/web/src/app/api/user/api-keys/shares/route.test.ts
+++ b/apps/web/src/app/api/user/api-keys/shares/route.test.ts
@@ -225,6 +225,25 @@ describe("/api/user/api-keys/shares", () => {
     expect(serialized).not.toContain("DB_FAILURE");
   });
 
+  it("GET error path: a raw-SQL failure during grantor-email lookup yields a generic 500, no raw leak", async () => {
+    // Drizzle selects succeed so the route advances to grantor-email
+    // resolution, which goes through the raw neon() tagged template…
+    drizzleResults = [
+      [],
+      [{ grantorId: "user-alice", provider: "anthropic", createdAt: new Date() }],
+    ];
+    // …and that raw call blows up.
+    rawSqlShouldThrow = true;
+
+    const { GET } = await import("@/app/api/user/api-keys/shares/route");
+    const res = await GET(getRequest());
+
+    expect(res.status).toBe(500);
+    const serialized = JSON.stringify(await res.json());
+    expect(serialized).not.toContain("postgres://");
+    expect(serialized).not.toContain("raw pg connection failed");
+  });
+
   // ── POST ────────────────────────────────────────────────────────────────
 
   it("POST happy path: creates a share, persisting the grantee email lowercased", async () => {


### PR DESCRIPTION
Clears all **8 open CodeQL alerts** (all pre-existing on `main`) — code fixes, not dismissals.

| # | Severity | Rule | Location | Fix |
|---|---|---|---|---|
| 26 | medium | `js/client-side-unvalidated-url-redirection` | `recover.html:73` | same-origin URL validation |
| 27 | high | `js/xss` | `recover.html:73` | same-origin URL validation |
| 28 | high | `js/clear-text-logging` | `generate-vapid-keys.js:10` | write to 0600 file, don't log |
| 29 | high | `js/clear-text-logging` | `generate-vapid-keys.js:11` | write to 0600 file, don't log |
| 30 | warning | `js/trivial-conditional` | `insights/deep/route.test.ts` | added error-path test |
| 31 | warning | `js/trivial-conditional` | `bug-report/route.test.ts` | added error-path test |
| 32 | warning | `js/trivial-conditional` | `count-intake/route.test.ts` | added error-path test |
| 33 | warning | `js/trivial-conditional` | `shares/route.test.ts` | added error-path test |

### recover.html (the real one)
The `return` param used `startsWith('/') && !startsWith('//')`, which **`/\evil.com` bypasses** (browsers normalize `\`→`/` ⇒ `//evil.com` protocol-relative redirect). Replaced with: resolve against `location.origin`, accept only same-origin results, rebuild a clean relative path. Verified against every vector — `//`, `https://`, `/\`, `javascript:`, malformed — only same-origin paths reach `cont.href`.

### vapid keygen
A local one-off CLI that printed the private key to stdout. Now writes the keypair to a git-ignored `vapid-keys.env` (mode 600) and prints only copy-then-delete instructions — the private key never hits stdout/CI logs.

### trivial-conditional ×4
Each `if (toggle) throw …` was a **dead error-injection seam** — the toggle was declared + reset but never set truthy (CodeQL correctly flagged it). Instead of deleting the scaffolding, I added the missing error-path test for each (flip the toggle, assert the route's failure handling) — clears the alert **and** adds real coverage (+4 tests).

### also
`.gitignore`: ignore `out/` (the Next static export was only ignored when anchored at repo root, so `apps/web/out` slipped through) + the generated `vapid-keys.env`.

## Verification
- `turbo run typecheck` + `lint` — 0 errors (3 pre-existing a11y warnings)
- full suite — **2040 passed** (+4 new tests)
- the PR's CodeQL **Analyze** run will confirm no new alerts; the 8 existing alerts auto-close when `main` is re-scanned after merge.

> Note: if CodeQL's model doesn't recognize the `URL`-origin guard as a sanitizer, #26/#27 could linger as now-*genuine* false positives post-merge — I'll confirm on the next main scan and dismiss with the bypass analysis if so.