### PR TITLE
fix(ci): auto-build + attach the Android APK on every release-please release

### DIFF
--- a/.github/workflows/android-release.yml
+++ b/.github/workflows/android-release.yml
@@ -23,6 +23,19 @@ on:
         description: "Release tag to build and attach the APK + AAB to"
         required: true
         type: string
+    # Declared so the caller (release-please.yml) can pass exactly these
+    # secrets explicitly instead of `secrets: inherit` (least privilege).
+    secrets:
+      ANDROID_KEYSTORE_BASE64:
+        required: true
+      ANDROID_KEYSTORE_PASSWORD:
+        required: true
+      ANDROID_KEY_ALIAS:
+        required: true
+      ANDROID_KEY_PASSWORD:
+        required: true
+      PLAY_SERVICE_ACCOUNT_JSON:
+        required: false
 
 jobs:
   build-and-publish:
@@ -46,7 +59,11 @@ jobs:
       # Empty for a bare branch dispatch (build-only validation, no attach).
       - name: Resolve release tag
         id: tag
-        run: echo "name=${{ inputs.tag || github.event.release.tag_name }}" >> "$GITHUB_OUTPUT"
+        env:
+          # Pass the expression through an env var (not interpolated into the
+          # shell source) so a crafted tag can't inject shell syntax.
+          RESOLVED_TAG: ${{ inputs.tag || github.event.release.tag_name }}
+        run: printf 'name=%s\n' "$RESOLVED_TAG" >> "$GITHUB_OUTPUT"
 
       - uses: pnpm/action-setup@v6
       - uses: actions/setup-node@v6

--- a/.github/workflows/android-release.yml
+++ b/.github/workflows/android-release.yml
@@ -12,6 +12,17 @@ on:
         description: "Existing release tag to (re)build, e.g. v1.28.0 (blank = current branch)"
         required: false
         type: string
+  # Called by release-please.yml right after it publishes a release. A release
+  # created with the default GITHUB_TOKEN does NOT fire the `release` event (its
+  # loop-prevention), so `on: release` never runs for release-please releases.
+  # Invoking this as a reusable workflow in release-please's own run builds and
+  # attaches the APK without needing a PAT.
+  workflow_call:
+    inputs:
+      tag:
+        description: "Release tag to build and attach the APK + AAB to"
+        required: true
+        type: string
 
 jobs:
   build-and-publish:
@@ -26,7 +37,16 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with:
-          ref: ${{ github.event.inputs.tag || github.event.release.tag_name || github.ref_name }}
+          # `inputs.tag` covers both workflow_dispatch and workflow_call; falls
+          # back to the release tag, then to the dispatched branch.
+          ref: ${{ inputs.tag || github.event.release.tag_name || github.ref_name }}
+
+      # Resolve the release tag (if any) once. Non-empty for: release events,
+      # workflow_call from release-please, and workflow_dispatch given a tag.
+      # Empty for a bare branch dispatch (build-only validation, no attach).
+      - name: Resolve release tag
+        id: tag
+        run: echo "name=${{ inputs.tag || github.event.release.tag_name }}" >> "$GITHUB_OUTPUT"
 
       - uses: pnpm/action-setup@v6
       - uses: actions/setup-node@v6
@@ -116,10 +136,10 @@ jobs:
           if-no-files-found: error
 
       - name: Attach artifacts to GitHub release
-        if: github.event_name == 'release'
+        if: steps.tag.outputs.name != ''
         uses: softprops/action-gh-release@v3
         with:
-          tag_name: ${{ github.event.release.tag_name }}
+          tag_name: ${{ steps.tag.outputs.name }}
           files: |
             ${{ steps.artifacts.outputs.aab }}
             ${{ steps.artifacts.outputs.apk }}

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -31,4 +31,12 @@ jobs:
     uses: ./.github/workflows/android-release.yml
     with:
       tag: ${{ needs.release-please.outputs.tag_name }}
-    secrets: inherit
+    # Pass only the secrets android-release needs (least privilege) rather than
+    # `secrets: inherit`. These are declared in android-release.yml's
+    # workflow_call.secrets block.
+    secrets:
+      ANDROID_KEYSTORE_BASE64: ${{ secrets.ANDROID_KEYSTORE_BASE64 }}
+      ANDROID_KEYSTORE_PASSWORD: ${{ secrets.ANDROID_KEYSTORE_PASSWORD }}
+      ANDROID_KEY_ALIAS: ${{ secrets.ANDROID_KEY_ALIAS }}
+      ANDROID_KEY_PASSWORD: ${{ secrets.ANDROID_KEY_PASSWORD }}
+      PLAY_SERVICE_ACCOUNT_JSON: ${{ secrets.PLAY_SERVICE_ACCOUNT_JSON }}

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -11,7 +11,24 @@ permissions:
 jobs:
   release-please:
     runs-on: ubuntu-latest
+    outputs:
+      release_created: ${{ steps.rp.outputs.release_created }}
+      tag_name: ${{ steps.rp.outputs.tag_name }}
     steps:
       - uses: googleapis/release-please-action@v5
+        id: rp
         with:
           release-type: node
+
+  # Build + attach the signed Android APK + AAB to the release release-please
+  # just created. This runs in the SAME workflow run (triggered by push to main,
+  # a real event), so GITHUB_TOKEN can attach to the release — unlike
+  # `on: release` in android-release.yml, which never fires for a release that
+  # GITHUB_TOKEN itself created (GitHub's workflow loop-prevention). No PAT needed.
+  android:
+    needs: release-please
+    if: needs.release-please.outputs.release_created == 'true'
+    uses: ./.github/workflows/android-release.yml
+    with:
+      tag: ${{ needs.release-please.outputs.tag_name }}
+    secrets: inherit


### PR DESCRIPTION
## Problem
v1.32.2 was published with **no APK** — `android-release.yml` listens on `on: release: published`, but release-please creates the release with the default `GITHUB_TOKEN`, and GitHub **does not let `GITHUB_TOKEN`-created events trigger other workflows** (loop-prevention). So the Android build never ran.

## Fix (no PAT required)
Make `android-release.yml` a **reusable workflow** and call it from `release-please.yml` in the *same run*. That run is triggered by push-to-main (a real event), and same-run `GITHUB_TOKEN` is allowed to attach assets to the release it just created — the restriction is only on *triggering* separate workflows, not on API calls.

- **`android-release.yml`**: added `workflow_call` (required `tag` input); checkout now uses `inputs.tag` (covers both `workflow_dispatch` and `workflow_call`) → release tag → branch; new **Resolve release tag** step; the **attach** step now runs whenever a tag is resolved (release / call / dispatch-with-tag) instead of only `event_name == 'release'`. A bare branch dispatch still builds-only (no attach) for validation.
- **`release-please.yml`**: capture `release_created` + `tag_name` outputs; add an `android` job that `uses: ./.github/workflows/android-release.yml` with `secrets: inherit`, gated on `release_created == 'true'`.

`on: release` is kept too, so a manually-created (non-bot) release still works.

## v1.32.2 (the already-published one)
Fixed out-of-band via `workflow_dispatch -f tag=v1.32.2` against this branch — builds the tag and attaches the signed APK + AAB to the existing v1.32.2 release. (Run: 27682144499.)

## Validation
- both workflows parse as valid YAML
- the dispatch run exercises the full build + sign + attach path on the real v1.32.2 tag
- the release-please → reusable-call wiring is YAML-correct; it proves out fully on the next release-please release.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced release automation workflow to streamline Android build and publication processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->