### PR TITLE
fix(mobile): load the live site in the Capacitor shell so in-app auth works

### DIFF
--- a/apps/web/capacitor.config.ts
+++ b/apps/web/capacitor.config.ts
@@ -14,6 +14,21 @@ const config: CapacitorConfig = {
   },
   server: {
     androidScheme: 'https',
+    // Load the LIVE web app instead of the bundled static export, so the
+    // WebView runs at the real origin (https://intake-tracker.ryanjnoble.dev).
+    // This makes auth (cookies + OAuth redirects), sync, and AI behave exactly
+    // like the website — the only way to get in-app Google sign-in, because the
+    // bundled https://localhost origin + managed Neon Auth cannot complete the
+    // OAuth round-trip (no idToken support, no custom-scheme callback). The
+    // live site's service worker caches the shell for offline launch.
+    // (webDir 'out' is still built + required by Capacitor, but unused for load.)
+    url: 'https://intake-tracker.ryanjnoble.dev',
+    // Keep the OAuth round-trip (Neon Auth hosted host + Google) INSIDE the
+    // WebView so the session cookie is shared back to the app. Without this,
+    // Capacitor opens off-origin hosts in the external browser and the cookie
+    // never returns. NOTE: Google may still refuse OAuth in an embedded WebView
+    // (disallowed_useragent) — verify on-device; email/password is unaffected.
+    allowNavigation: ['*.neon.tech', 'accounts.google.com', '*.google.com'],
   },
 };
 

--- a/apps/web/capacitor.config.ts
+++ b/apps/web/capacitor.config.ts
@@ -28,7 +28,10 @@ const config: CapacitorConfig = {
     // Capacitor opens off-origin hosts in the external browser and the cookie
     // never returns. NOTE: Google may still refuse OAuth in an embedded WebView
     // (disallowed_useragent) — verify on-device; email/password is unaffected.
-    allowNavigation: ['*.neon.tech', 'accounts.google.com', '*.google.com'],
+    // Scoped to the specific OAuth nav hosts (least privilege). `*.neon.tech`
+    // stays a wildcard because the Neon Auth endpoint subdomain is a generated,
+    // rotatable id (ep-<id>.neonauth.<region>.aws.neon.tech).
+    allowNavigation: ['*.neon.tech', 'accounts.google.com', 'oauth2.googleapis.com'],
   },
 };
 


### PR DESCRIPTION
## Problem
In the installed APK, **"Continue with Google" fails with "Failed to fetch."** Root-caused with live tests (not guesses):

- The auth client URL is correct (remote, baked in) ✅; our backend's CORS for `https://localhost` is complete (`204` preflight + `200` POST, all `Allow-*` headers) ✅; the Neon Auth host also CORS-allows `https://localhost` ✅; no CSP block ✅.
- The real cause: the bundled WebView runs at `https://localhost`, and OAuth needs a top-level redirect to Google + a return path *into the app*. Managed Neon Auth can't deliver that — **idToken sign-in is ignored** (probed: sending `idToken` still returns the redirect flow) and the Console only allows **https trusted origins, not custom-scheme** callbacks. So neither native-OAuth route (idToken, nor Custom-Tabs + deep link) is possible app-side.

Conclusion: with managed Neon Auth, you can have the **bundled** app *or* **in-app Google sign-in**, not both. Google needs the app to be the real web origin.

## Change
Point the Capacitor WebView at the live site (`server.url = https://intake-tracker.ryanjnoble.dev`) instead of the bundled static export. The WebView is now the real origin, so cookies, OAuth redirects, sync, and AI behave exactly like the website. `allowNavigation` keeps the Neon Auth + Google hosts inside the WebView so the session cookie returns to the app. (`webDir: 'out'` is still built — Capacitor requires it — but unused for load. The live site's service worker caches the shell for offline launch.)

```ts
server: {
  androidScheme: 'https',
  url: 'https://intake-tracker.ryanjnoble.dev',
  allowNavigation: ['*.neon.tech', 'accounts.google.com', '*.google.com'],
}
```

## Why native notifications still work
Native local notifications (`@capacitor/local-notifications`) are gated on the **runtime** `Capacitor.isNativePlatform()` (`local-notifications.ts:7,19`), wired via `providers.tsx:63` (init) + `use-medication-queries.ts:164` (`syncMedicationNotifications`). Capacitor injects its native bridge even when loading a remote `server.url` (same mechanism as live-reload), so `isNativePlatform()` stays `true` and the medication reminders schedule natively — unchanged from the bundled app (this path never depended on `CAPACITOR_BUILD`). Web Push never worked in an Android WebView either way (WebView lacks the browser Push API; true server push would need FCM — separate, not set up).

## Caveats (verify on-device)
- **Google may still refuse OAuth in an embedded WebView** (`disallowed_useragent`). That's a Google-side policy affecting *every* WebView approach; if it triggers, email/password is the working path. This PR is the prerequisite that makes Google *possible*; whether Google permits the WebView is out of our control.
- App is now online-first (loads remote); offline launch relies on the live site's service-worker cache.

## Status / testing
- `cap config` confirms the new `server.url` + `allowNavigation` parse correctly; a signed test APK built green via `workflow_dispatch` (run 27685203379).
- On-device checks to confirm after merge/install: (1) email/password sign-in, (2) Google, (3) the notification-permission prompt appears.

Independent of #241 (auto-attach APK on release); disjoint files, no merge-order constraint.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved in-app sign-in flows to work reliably within the mobile application
  * Enhanced OAuth authentication support during app use

<!-- end of auto-generated comment: release notes by coderabbit.ai -->