### PR TITLE
fix: scope Delete Account to Settings and harden sync against malformed records

### DIFF
--- a/apps/web/src/__tests__/sync-engine.test.ts
+++ b/apps/web/src/__tests__/sync-engine.test.ts
@@ -594,6 +594,47 @@ describe("sync-engine", () => {
     expect(err).toContain("schema mismatch");
   });
 
+  it("push: validation-rejected ops (code 'invalid') are dropped from the queue, not retried", async () => {
+    installDom();
+    __startEngineForTests();
+
+    // One permanently-invalid op. Before the fix it would 400 the batch and
+    // loop forever; now the server returns it in `rejected` with code
+    // "invalid" and the client drops it so the queue can drain.
+    const bad = makeIntake({ id: "bad-1" });
+    await db.intakeRecords.bulkAdd([bad]);
+    await enqueue("intakeRecords", "bad-1", "upsert");
+
+    const queueBefore = await db._syncQueue.toArray();
+    const badQueueId = queueBefore.find((q) => q.recordId === "bad-1")!.id!;
+
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(
+        async () =>
+          jsonResponse({
+            accepted: [],
+            rejected: [
+              {
+                queueId: badQueueId,
+                tableName: "intakeRecords",
+                error: "Record failed validation and cannot be synced",
+                code: "invalid",
+              },
+            ],
+          }),
+      ) as unknown as Mock,
+    );
+
+    await runPushCycle();
+
+    // The invalid op was removed from the queue (dropped, not retried).
+    const after = await db._syncQueue.toArray();
+    expect(after).toHaveLength(0);
+    // The local Dexie row is untouched — only the sync queue entry is dropped.
+    expect(await db.intakeRecords.get("bad-1")).toBeTruthy();
+  });
+
   it("pull: network error sets lastError without throwing or stalling", async () => {
     installDom();
     __startEngineForTests();

--- a/apps/web/src/__tests__/sync-push-route.test.ts
+++ b/apps/web/src/__tests__/sync-push-route.test.ts
@@ -338,6 +338,46 @@ describe("sync-push-route", () => {
     expect(insertCalls[0]!.set.userId).not.toBe("attacker");
   });
 
+  it("isolates a malformed op: rejects it but applies the valid ones (no batch-wide 400)", async () => {
+    const { POST } = await import("@/app/api/sync/push/route");
+    const req = makePushRequest({
+      ops: [
+        // Malformed: `amount` must be a number — a NaN serialises to null and
+        // a notNull column would 400 the WHOLE batch under atomic validation.
+        {
+          queueId: 1,
+          tableName: "intakeRecords",
+          op: "upsert",
+          row: validIntakeRow({ id: "bad", amount: null }),
+        },
+        // Valid op behind the bad one must still apply.
+        {
+          queueId: 2,
+          tableName: "intakeRecords",
+          op: "upsert",
+          row: validIntakeRow({ id: "good", updatedAt: 3000 }),
+        },
+      ],
+    });
+
+    const res = await POST(req);
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      accepted: { queueId: number; serverUpdatedAt: number }[];
+      rejected: { queueId: number; tableName: string; error: string; code?: string }[];
+    };
+    expect(body.accepted).toEqual([{ queueId: 2, serverUpdatedAt: 3000 }]);
+    expect(body.rejected).toHaveLength(1);
+    expect(body.rejected[0]).toMatchObject({
+      queueId: 1,
+      tableName: "intakeRecords",
+      code: "invalid",
+    });
+    // The valid op was written; the bad one was not.
+    expect(insertCalls).toHaveLength(1);
+    expect(insertCalls[0]!.values.id).toBe("good");
+  });
+
   it("rejects oversized batch", async () => {
     const validOp = {
       queueId: 1,

--- a/apps/web/src/app/api/sync/push/route.ts
+++ b/apps/web/src/app/api/sync/push/route.ts
@@ -7,9 +7,15 @@
  *     never trusts a client-supplied userId; every DB write stamps
  *     `auth.userId!` on the row and every SELECT includes
  *     `eq(table.userId, auth.userId!)` so cross-user access is impossible.
- *   - Body is validated by `pushBodySchema` (drizzle-zod discriminated union
- *     keyed by tableName, with `.omit({userId: true})` on every row schema).
- *     Malformed payloads → 400 with generic error (no schema detail exposed).
+ *   - The OUTER envelope (`{ ops: [...] }`, ≤500) is validated by
+ *     `pushEnvelopeSchema`; a non-array body or oversized batch → 400.
+ *   - Each op is then validated INDIVIDUALLY against `opSchema_` (drizzle-zod
+ *     discriminated union keyed by tableName, with `.omit({userId: true})` on
+ *     every row schema). A single malformed row is quarantined into the
+ *     `rejected` array (code "invalid") rather than 400-ing the whole batch —
+ *     otherwise one poisoned record wedges the client's queue forever, since
+ *     it just re-sends the same failing batch every cycle. No schema detail is
+ *     exposed to the client (only logged server-side).
  *   - Batch size capped at 500 ops via Zod `.max(500)` — blocks DoS payloads
  *     before any DB round trip.
  *
@@ -45,8 +51,10 @@ import { withAuth } from "@/lib/auth-middleware";
 import { db as drizzleDb } from "@intake/db/client";
 import { usersSync } from "@intake/db/schema";
 import {
-  pushBodySchema,
+  pushEnvelopeSchema,
+  opSchema_,
   schemaByTableName,
+  type PushOp,
   type TableName,
 } from "@intake/db/sync-payload";
 
@@ -84,14 +92,52 @@ function extractDbError(err: unknown): string {
 export const POST = withAuth(async ({ request, auth }) => {
   try {
     const body = await request.json();
-    const parsed = pushBodySchema.safeParse(body);
-    if (!parsed.success) {
-      console.error("[sync/push] Zod validation failed:", JSON.stringify(z.flattenError(parsed.error), null, 2));
+    // Validate the OUTER envelope only (ops is an array within the DoS cap).
+    // A non-array body or an oversized batch is a malformed request → 400.
+    const envelope = pushEnvelopeSchema.safeParse(body);
+    if (!envelope.success) {
+      console.error("[sync/push] Envelope validation failed:", JSON.stringify(z.flattenError(envelope.error), null, 2));
       return NextResponse.json(
         { error: "Invalid request" },
         { status: 400 },
       );
     }
+
+    // Validate each op INDIVIDUALLY. One malformed row (e.g. a NaN that
+    // serialised to null in a notNull column) must not 400 the whole batch —
+    // doing so wedges the entire sync queue forever, because the client just
+    // re-sends the same poisoned batch on every cycle. Instead, quarantine the
+    // bad op into `rejected` (code "invalid", so the client can drop it) and
+    // let every valid op apply.
+    const validOps: PushOp[] = [];
+    const rejected: Array<{
+      queueId: number;
+      tableName: string;
+      error: string;
+      code?: string;
+    }> = [];
+    for (const rawOp of envelope.data.ops) {
+      const parsedOp = opSchema_.safeParse(rawOp);
+      if (parsedOp.success) {
+        validOps.push(parsedOp.data);
+      } else {
+        const raw = (rawOp ?? {}) as Record<string, unknown>;
+        const queueId = typeof raw.queueId === "number" ? raw.queueId : -1;
+        const tableName =
+          typeof raw.tableName === "string" ? raw.tableName : "unknown";
+        console.error(
+          `[sync/push] Op rejected (invalid shape): table=${tableName} queueId=${queueId} — ${JSON.stringify(z.flattenError(parsedOp.error))}`,
+        );
+        rejected.push({
+          queueId,
+          tableName,
+          error: "Record failed validation and cannot be synced",
+          code: "invalid",
+        });
+      }
+    }
+
+    const parsed = { data: { ops: validOps } };
 
     // Ensure the user exists in neon_auth.users_sync before any FK-dependent
     // inserts. Neon Auth replicates users asynchronously — on preview branches
@@ -103,11 +149,6 @@ export const POST = withAuth(async ({ request, auth }) => {
 
     const serverNow = Date.now();
     const accepted: Array<{ queueId: number; serverUpdatedAt: number }> = [];
-    const rejected: Array<{
-      queueId: number;
-      tableName: string;
-      error: string;
-    }> = [];
 
     const opsByTable = new Map<
       TableName,

--- a/apps/web/src/app/settings/page.tsx
+++ b/apps/web/src/app/settings/page.tsx
@@ -78,7 +78,7 @@ function SettingsContent() {
   return (
     <>
       <div className="pb-6">
-        <AccountSection />
+        <AccountSection showDeleteAccount />
       </div>
 
       <Accordion type="single" collapsible className="pb-8">

--- a/apps/web/src/components/settings/account-section.tsx
+++ b/apps/web/src/components/settings/account-section.tsx
@@ -8,7 +8,12 @@ import { useAuth } from "@/components/auth-guard";
 import { handleSignOut } from "@/lib/sign-out";
 import { DeleteAccountDialog } from "@/components/settings/delete-account-dialog";
 
-export function AccountSection() {
+/**
+ * @param showDeleteAccount - When true, renders the destructive "Delete Account"
+ *   action. Off by default so it only appears where we explicitly want it
+ *   (Settings), not on the profile page.
+ */
+export function AccountSection({ showDeleteAccount = false }: { showDeleteAccount?: boolean } = {}) {
   const { ready, authenticated, user } = useAuth();
   const router = useRouter();
   const [deleteOpen, setDeleteOpen] = useState(false);
@@ -74,22 +79,26 @@ export function AccountSection() {
         Sign Out
       </Button>
 
-      <div className="pt-2 mt-1 border-t">
-        <Button
-          variant="ghost"
-          className="w-full justify-start gap-2 text-muted-foreground hover:text-red-700 hover:bg-red-50 dark:hover:bg-red-950/30"
-          onClick={() => setDeleteOpen(true)}
-        >
-          <Trash2 className="w-4 h-4" />
-          Delete Account
-        </Button>
-        <p className="px-3 pt-1 text-xs text-muted-foreground">
-          Erases all your data from our servers and removes your login. The copy
-          on this device is kept.
-        </p>
-      </div>
+      {showDeleteAccount && (
+        <>
+          <div className="pt-2 mt-1 border-t">
+            <Button
+              variant="ghost"
+              className="w-full justify-start gap-2 text-muted-foreground hover:text-red-700 hover:bg-red-50 dark:hover:bg-red-950/30"
+              onClick={() => setDeleteOpen(true)}
+            >
+              <Trash2 className="w-4 h-4" />
+              Delete Account
+            </Button>
+            <p className="px-3 pt-1 text-xs text-muted-foreground">
+              Erases all your data from our servers and removes your login. The copy
+              on this device is kept.
+            </p>
+          </div>
 
-      <DeleteAccountDialog open={deleteOpen} onOpenChange={setDeleteOpen} />
+          <DeleteAccountDialog open={deleteOpen} onOpenChange={setDeleteOpen} />
+        </>
+      )}
     </div>
   );
 }

--- a/apps/web/src/hooks/use-ai-keys.ts
+++ b/apps/web/src/hooks/use-ai-keys.ts
@@ -2,6 +2,7 @@
 
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { apiFetch } from "@/lib/api-fetch";
+import { useAuth } from "@/components/auth-guard";
 
 export type AiProvider = "anthropic" | "groq";
 
@@ -28,9 +29,15 @@ async function asJson<T>(res: Response): Promise<T> {
 }
 
 export function useApiKeyStatus() {
+  // These endpoints require a session; firing them while signed out (e.g. on
+  // /auth, or before the session resolves on first paint) 401s with
+  // "No active session", which apiFetch records into the in-app error log.
+  // Gate on auth so the query only runs once we know there's a session.
+  const { authenticated } = useAuth();
   return useQuery<KeyStatus>({
     queryKey: KEYS_QUERY_KEY,
     queryFn: async () => asJson<KeyStatus>(await apiFetch("/api/user/api-keys")),
+    enabled: authenticated,
   });
 }
 
@@ -82,10 +89,12 @@ export interface KeyShares {
 }
 
 export function useKeyShares() {
+  const { authenticated } = useAuth();
   return useQuery<KeyShares>({
     queryKey: SHARES_QUERY_KEY,
     queryFn: async () =>
       asJson<KeyShares>(await apiFetch("/api/user/api-keys/shares")),
+    enabled: authenticated,
   });
 }
 
@@ -168,9 +177,11 @@ export interface AiUsage {
 }
 
 export function useAiUsage(days: number = 30) {
+  const { authenticated } = useAuth();
   return useQuery<AiUsage>({
     queryKey: [...USAGE_QUERY_KEY, days],
     queryFn: async () =>
       asJson<AiUsage>(await apiFetch(`/api/user/ai-usage?days=${days}`)),
+    enabled: authenticated,
   });
 }

--- a/apps/web/src/lib/sync-engine.ts
+++ b/apps/web/src/lib/sync-engine.ts
@@ -275,6 +275,7 @@ export async function runPushCycle(): Promise<void> {
         queueId: number;
         tableName: string;
         error: string;
+        code?: string;
       }>;
     };
     const accepted = body.accepted ?? [];
@@ -287,6 +288,7 @@ export async function runPushCycle(): Promise<void> {
     await applyServerAck(accepted, queueRowsById);
     await ack(accepted.map((a) => a.queueId));
 
+    let droppedInvalid = 0;
     if (rejected.length > 0) {
       const firstErr = rejected[0]!;
       const detail = `${firstErr.tableName}: ${firstErr.error}`;
@@ -294,14 +296,25 @@ export async function runPushCycle(): Promise<void> {
         `[sync] ${rejected.length} op(s) rejected:`,
         rejected.map((r) => `${r.tableName}: ${r.error}`),
       );
+      // `code: "invalid"` means the row failed server-side schema validation.
+      // It can never succeed (the schema won't change), so retrying it forever
+      // just keeps the error banner up and re-sends it in every batch. Drop it
+      // from the queue (the local Dexie row is untouched). Other rejections —
+      // transient DB write failures — get an attempts bump so backoff applies.
+      const dropIds: number[] = [];
       for (const r of rejected) {
         const q = queueRowsById.get(r.queueId);
-        if (q?.id != null) {
+        if (q?.id == null) continue;
+        if (r.code === "invalid") {
+          dropIds.push(q.id);
+        } else {
           await db._syncQueue.update(q.id, {
             attempts: (q.attempts ?? 0) + 1,
           });
         }
       }
+      if (dropIds.length > 0) await ack(dropIds);
+      droppedInvalid = dropIds.length;
       useSyncStatusStore.setState({
         lastError: `${rejected.length} record(s) failed: ${detail}`,
         lastPushedAt: Date.now(),
@@ -320,9 +333,11 @@ export async function runPushCycle(): Promise<void> {
     schedulePull();
 
     // Re-drain: if new records arrived while the push was in flight, flush
-    // them immediately. Only re-drain when this cycle actually acked items —
-    // otherwise the same un-acked ops would loop forever.
-    if (accepted.length > 0) {
+    // them immediately. Re-drain whenever this cycle made forward progress —
+    // either it acked items, or it dropped permanently-invalid ops (a batch
+    // of only-invalid ops that wedged the queue must keep draining). Without
+    // progress we must NOT re-drain, or the same un-acked ops loop forever.
+    if (accepted.length > 0 || droppedInvalid > 0) {
       const remaining = await getQueueDepth();
       if (remaining > 0) {
         schedulePush(0);

--- a/packages/db/src/sync-payload.ts
+++ b/packages/db/src/sync-payload.ts
@@ -202,6 +202,24 @@ export const pushBodySchema = z.object({
   ops: z.array(opSchema).max(500),
 });
 
+/**
+ * Per-op schema, exported so the push route can validate each op
+ * INDIVIDUALLY instead of rejecting the entire batch when one row is
+ * malformed. A single bad record (e.g. a NaN that JSON-serialised to null in
+ * a notNull column) must never wedge the whole sync queue — it gets
+ * quarantined into the `rejected` array while every other op still applies.
+ */
+export const opSchema_ = opSchema;
+
+/**
+ * Outer envelope only — validates that `ops` is an array within the DoS cap,
+ * WITHOUT validating each op's row shape. The route pairs this with per-op
+ * `opSchema_` validation so malformed rows are isolated, not fatal.
+ */
+export const pushEnvelopeSchema = z.object({
+  ops: z.array(z.unknown()).max(500),
+});
+
 // ─────────────────────────────────────────────────────────────────────────
 // Type exports
 // ─────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
The shared AccountSection rendered the destructive Delete Account action
on both the profile and settings pages. Gate it behind an opt-in
showDeleteAccount prop so it only appears in Settings.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01DijMMsNfJJNffvvkFfkKDC

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Delete account option in Settings is now configurable and can be shown or hidden.

* **Bug Fixes**
  * Improved API handling to prevent errors when accessing features while unauthenticated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->