### PR TITLE
feat(mobile): in-app native Google sign-in (Custom Tab + App Link bridge)

### DIFF
--- a/apps/native/android/app/capacitor.build.gradle
+++ b/apps/native/android/app/capacitor.build.gradle
@@ -9,6 +9,8 @@ android {
 
 apply from: "../capacitor-cordova-android-plugins/cordova.variables.gradle"
 dependencies {
+    implementation project(':capacitor-app')
+    implementation project(':capacitor-browser')
     implementation project(':capacitor-local-notifications')
     implementation project(':capacitor-network')
 

--- a/apps/native/android/app/src/main/AndroidManifest.xml
+++ b/apps/native/android/app/src/main/AndroidManifest.xml
@@ -22,6 +22,21 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
 
+            <!-- Verified HTTPS App Link for the native Google sign-in return
+                 trip. /auth/native-done (carrying a one-time code) opens the app
+                 directly instead of a browser tab. autoVerify checks
+                 https://intake-tracker.ryanjnoble.dev/.well-known/assetlinks.json
+                 against this app's signing certificate. -->
+            <intent-filter android:autoVerify="true">
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <data
+                    android:scheme="https"
+                    android:host="intake-tracker.ryanjnoble.dev"
+                    android:pathPrefix="/auth/native-done" />
+            </intent-filter>
+
         </activity>
 
         <provider

--- a/apps/native/android/capacitor.settings.gradle
+++ b/apps/native/android/capacitor.settings.gradle
@@ -2,6 +2,12 @@
 include ':capacitor-android'
 project(':capacitor-android').projectDir = new File('../../../node_modules/.pnpm/@capacitor+android@8.4.0_@capacitor+core@8.4.0/node_modules/@capacitor/android/capacitor')
 
+include ':capacitor-app'
+project(':capacitor-app').projectDir = new File('../../../node_modules/.pnpm/@capacitor+app@8.1.0_@capacitor+core@8.4.0/node_modules/@capacitor/app/android')
+
+include ':capacitor-browser'
+project(':capacitor-browser').projectDir = new File('../../../node_modules/.pnpm/@capacitor+browser@8.0.3_@capacitor+core@8.4.0/node_modules/@capacitor/browser/android')
+
 include ':capacitor-local-notifications'
 project(':capacitor-local-notifications').projectDir = new File('../../../node_modules/.pnpm/@capacitor+local-notifications@8.2.0_@capacitor+core@8.4.0/node_modules/@capacitor/local-notifications/android')
 

--- a/apps/native/capacitor.config.ts
+++ b/apps/native/capacitor.config.ts
@@ -30,6 +30,8 @@ const config: CapacitorConfig = {
   // the native plugins to include. @capacitor/android (platform) and
   // @capacitor/core (runtime) are always included and are not listed here.
   includePlugins: [
+    '@capacitor/app',
+    '@capacitor/browser',
     '@capacitor/local-notifications',
     '@capacitor/network',
   ],

--- a/apps/native/package.json
+++ b/apps/native/package.json
@@ -9,6 +9,8 @@
   },
   "dependencies": {
     "@capacitor/android": "^8.4.0",
+    "@capacitor/app": "^8.1.0",
+    "@capacitor/browser": "^8.0.3",
     "@capacitor/core": "^8.4.0",
     "@capacitor/local-notifications": "^8.1.0",
     "@capacitor/network": "^8.0.1"

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -28,6 +28,8 @@
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.104.1",
+    "@capacitor/app": "^8.1.0",
+    "@capacitor/browser": "^8.0.3",
     "@capacitor/core": "^8.4.0",
     "@capacitor/local-notifications": "^8.1.0",
     "@capacitor/network": "^8.0.1",

--- a/apps/web/public/.well-known/assetlinks.json
+++ b/apps/web/public/.well-known/assetlinks.json
@@ -1,0 +1,12 @@
+[
+  {
+    "relation": ["delegate_permission/common.handle_all_urls"],
+    "target": {
+      "namespace": "android_app",
+      "package_name": "dev.ryanjnoble.intaketracker",
+      "sha256_cert_fingerprints": [
+        "07:8E:0B:5A:DB:9C:9F:7B:8A:71:D4:C7:35:F2:49:06:31:04:76:F2:18:A2:EB:24:62:58:F3:09:06:65:96:FA"
+      ]
+    }
+  }
+]

--- a/apps/web/scripts/verify-schema.ts
+++ b/apps/web/scripts/verify-schema.ts
@@ -22,12 +22,13 @@ import { neon } from "@neondatabase/serverless";
 // custom-connector tables added in migration 0012 (mcp_oauth_clients,
 // mcp_auth_codes, mcp_access_tokens, mcp_audit_log) + 1 insight_reports
 // table added in migration 0013 + 1 insight_jobs table (server-only
-// deep-research batch tracking) added in migration 0014 = 30.
+// deep-research batch tracking) added in migration 0014 + 1 native_auth_codes
+// table (server-only native Google sign-in bridge) added in migration 0018 = 31.
 // (18 Dexie-mirrored app tables incl. user_profile + insight_reports + 4
-// push tables + 3 AI + 4 MCP + 1 insight_jobs.)
+// push tables + 3 AI + 4 MCP + 1 insight_jobs + 1 native_auth_codes.)
 // drizzle-kit 0.31.x stores its __drizzle_migrations journal in the
 // "drizzle" schema, not "public".
-const EXPECTED_TABLE_COUNT = 30;
+const EXPECTED_TABLE_COUNT = 31;
 
 // Representative tables spot-checked by name. Five is enough to catch
 // a schema that happened to have the right COUNT but the wrong shape
@@ -40,6 +41,7 @@ const SPOT_CHECK_TABLES = [
   "prescriptions",
   "mcp_oauth_clients",
   "insight_reports",
+  "native_auth_codes",
 ] as const;
 
 async function main(): Promise<void> {

--- a/apps/web/src/__tests__/integration/native-auth-bridge-integration.test.ts
+++ b/apps/web/src/__tests__/integration/native-auth-bridge-integration.test.ts
@@ -1,0 +1,81 @@
+/**
+ * Integration tests for the native Google sign-in bridge against real Postgres.
+ *
+ * Verifies the Postgres-dependent semantics a mocked stub can't: the atomic
+ * single-use claim (DELETE ... RETURNING), expiry filtering, and the users_sync
+ * FK. Mirrors src/__tests__/integration/mcp-oauth-integration.test.ts.
+ */
+import { describe, it, expect, beforeAll, afterAll, beforeEach, vi } from "vitest";
+import { eq } from "drizzle-orm";
+import { setupTestDb, type TestDbContext } from "@/__tests__/helpers/test-db";
+import * as schema from "@intake/db/schema";
+import type * as BridgeMod from "@/lib/native-auth-bridge";
+
+let ctx: TestDbContext;
+let bridge: typeof BridgeMod;
+
+beforeAll(async () => {
+  ctx = await setupTestDb();
+  vi.mock("@intake/db/client", () => ({ db: ctx.db }));
+  bridge = await import("@/lib/native-auth-bridge");
+}, 60_000);
+
+afterAll(async () => {
+  vi.restoreAllMocks();
+  await ctx?.teardown();
+}, 30_000);
+
+beforeEach(async () => {
+  await ctx.db.delete(schema.nativeAuthCodes);
+});
+
+describe("native-auth-bridge (integration)", () => {
+  it("mints a code that claims back the exact session token", async () => {
+    const code = await bridge.mintNativeAuthCode({
+      sessionToken: "sess-abc",
+      userId: ctx.testUserId,
+    });
+    expect(code).toMatch(/^[A-Za-z0-9_-]+$/);
+    expect(await bridge.claimNativeAuthCode(code)).toBe("sess-abc");
+  });
+
+  it("is single-use — a second claim returns null", async () => {
+    const code = await bridge.mintNativeAuthCode({
+      sessionToken: "sess-1",
+      userId: ctx.testUserId,
+    });
+    expect(await bridge.claimNativeAuthCode(code)).toBe("sess-1");
+    expect(await bridge.claimNativeAuthCode(code)).toBeNull();
+  });
+
+  it("returns null for an unknown code", async () => {
+    expect(await bridge.claimNativeAuthCode("does-not-exist")).toBeNull();
+  });
+
+  it("will not claim an expired code", async () => {
+    const code = await bridge.mintNativeAuthCode({
+      sessionToken: "sess-exp",
+      userId: ctx.testUserId,
+    });
+    await ctx.db
+      .update(schema.nativeAuthCodes)
+      .set({ expiresAt: Date.now() - 1_000 })
+      .where(eq(schema.nativeAuthCodes.code, code));
+    expect(await bridge.claimNativeAuthCode(code)).toBeNull();
+  });
+
+  it("mint prunes already-expired rows", async () => {
+    const stale = await bridge.mintNativeAuthCode({
+      sessionToken: "stale",
+      userId: ctx.testUserId,
+    });
+    await ctx.db
+      .update(schema.nativeAuthCodes)
+      .set({ expiresAt: Date.now() - 1_000 })
+      .where(eq(schema.nativeAuthCodes.code, stale));
+    // Minting a fresh code triggers opportunistic cleanup of expired rows.
+    await bridge.mintNativeAuthCode({ sessionToken: "fresh", userId: ctx.testUserId });
+    const remaining = await ctx.db.select().from(schema.nativeAuthCodes);
+    expect(remaining.map((r) => r.sessionToken)).toEqual(["fresh"]);
+  });
+});

--- a/apps/web/src/app/api/native-auth/claim/route.test.ts
+++ b/apps/web/src/app/api/native-auth/claim/route.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+vi.mock("@/lib/native-auth-bridge", () => ({
+  claimNativeAuthCode: vi.fn(),
+}));
+
+import { POST } from "@/app/api/native-auth/claim/route";
+import { claimNativeAuthCode } from "@/lib/native-auth-bridge";
+
+const mockClaim = vi.mocked(claimNativeAuthCode);
+
+function req(body: string) {
+  return new NextRequest("https://intake-tracker.ryanjnoble.dev/api/native-auth/claim", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body,
+  });
+}
+
+describe("POST /api/native-auth/claim", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("400 on non-JSON body", async () => {
+    const res = await POST(req("{not json"));
+    expect(res.status).toBe(400);
+    expect((await res.json()).error).toBe("invalid_request");
+    expect(mockClaim).not.toHaveBeenCalled();
+  });
+
+  it("400 when code is missing", async () => {
+    const res = await POST(req(JSON.stringify({})));
+    expect(res.status).toBe(400);
+    expect((await res.json()).error).toBe("invalid_request");
+  });
+
+  it("400 invalid_grant for an unknown/expired/used code", async () => {
+    mockClaim.mockResolvedValue(null);
+    const res = await POST(req(JSON.stringify({ code: "nope" })));
+    expect(res.status).toBe(400);
+    expect((await res.json()).error).toBe("invalid_grant");
+    expect(mockClaim).toHaveBeenCalledWith("nope");
+  });
+
+  it("200 returns the session token for a valid code, no-store", async () => {
+    mockClaim.mockResolvedValue("sess-token-xyz");
+    const res = await POST(req(JSON.stringify({ code: "good-code" })));
+    expect(res.status).toBe(200);
+    expect((await res.json()).token).toBe("sess-token-xyz");
+    expect(res.headers.get("Cache-Control")).toBe("no-store");
+  });
+});

--- a/apps/web/src/app/api/native-auth/claim/route.ts
+++ b/apps/web/src/app/api/native-auth/claim/route.ts
@@ -1,0 +1,55 @@
+/**
+ * POST /api/native-auth/claim — native Google sign-in code exchange.
+ *
+ * The Capacitor app calls this after catching the App Link return
+ * (`/auth/native-done?code=…`). The one-time `code` is the credential; it is
+ * traded once for the Neon session token, which the app then uses on its
+ * Authorization: Bearer path. No session/auth required — the code IS the proof.
+ *
+ * CORS for the app's `https://localhost` WebView origin is applied by the
+ * root middleware (`/api/:path*`). Deliberately NOT under `/api/auth/*` so it
+ * doesn't collide with the Neon Auth catch-all handler.
+ */
+import { NextResponse, type NextRequest } from "next/server";
+import { z } from "zod";
+import { claimNativeAuthCode } from "@/lib/native-auth-bridge";
+
+export const dynamic = "force-dynamic";
+
+const NO_STORE = { "Cache-Control": "no-store", Pragma: "no-cache" } as const;
+
+const schema = z.object({ code: z.string().min(1).max(512) });
+
+export async function POST(request: NextRequest) {
+  let raw: unknown;
+  try {
+    raw = await request.json();
+  } catch {
+    return NextResponse.json(
+      { error: "invalid_request" },
+      { status: 400, headers: NO_STORE },
+    );
+  }
+
+  const parsed = schema.safeParse(raw);
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: "invalid_request" },
+      { status: 400, headers: NO_STORE },
+    );
+  }
+
+  const sessionToken = await claimNativeAuthCode(parsed.data.code);
+  if (!sessionToken) {
+    // Unknown, already-claimed, or expired code.
+    return NextResponse.json(
+      { error: "invalid_grant" },
+      { status: 400, headers: NO_STORE },
+    );
+  }
+
+  return NextResponse.json(
+    { token: sessionToken },
+    { status: 200, headers: NO_STORE },
+  );
+}

--- a/apps/web/src/app/api/native-auth/mint/route.ts
+++ b/apps/web/src/app/api/native-auth/mint/route.ts
@@ -1,0 +1,41 @@
+/**
+ * POST /api/native-auth/mint — mint a one-time native sign-in code.
+ *
+ * Called by the /auth/native-bridge page from inside the system-browser Custom
+ * Tab, AFTER Neon Auth's middleware has exchanged the OAuth verifier and set the
+ * session cookie. Reads that session cookie server-side (it is HttpOnly, so only
+ * the server can), confirms it, and mints a one-time code bound to it. The page
+ * then hands the code to the app via an HTTPS App Link.
+ *
+ * Cookie-authenticated, same-origin. The session cookie is `__Secure` +
+ * SameSite, so a cross-site POST cannot present it (CSRF-safe); and even if a
+ * code were minted, the response is not readable cross-origin.
+ */
+import { cookies } from "next/headers";
+import { NextResponse } from "next/server";
+import { validateBearerToken } from "@/lib/auth-middleware";
+import { mintNativeAuthCode } from "@/lib/native-auth-bridge";
+
+export const dynamic = "force-dynamic";
+
+const NO_STORE = { "Cache-Control": "no-store", Pragma: "no-cache" } as const;
+
+const SESSION_COOKIE = "__Secure-neon-auth.session_token";
+
+export async function POST() {
+  const token = (await cookies()).get(SESSION_COOKIE)?.value;
+  const session = token ? await validateBearerToken(token) : null;
+  if (!token || !session) {
+    return NextResponse.json(
+      { error: "no_session" },
+      { status: 401, headers: NO_STORE },
+    );
+  }
+
+  const code = await mintNativeAuthCode({
+    sessionToken: token,
+    userId: session.userId,
+  });
+
+  return NextResponse.json({ code }, { status: 200, headers: NO_STORE });
+}

--- a/apps/web/src/app/auth/native-bridge/page.tsx
+++ b/apps/web/src/app/auth/native-bridge/page.tsx
@@ -1,0 +1,79 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+/**
+ * Native Google sign-in — STEP 2 (runs in the Custom Tab after the OAuth
+ * return). By the time this renders, Neon Auth's middleware has already
+ * exchanged the verifier and set the session cookie (the matcher covers
+ * /auth/*). This page mints a one-time code from that session (server reads the
+ * HttpOnly cookie) and hands ONLY the code back to the app via a verified HTTPS
+ * App Link — never the session token in a URL.
+ *
+ * Client component (not a server component) so it survives the Capacitor
+ * `output: export` build; the cookie-reading lives in /api/native-auth/mint,
+ * which the export stashes out.
+ */
+
+// Production origin: the App Link host that assetlinks.json delegates to the app.
+const APP_ORIGIN = "https://intake-tracker.ryanjnoble.dev";
+
+export default function NativeSignInBridge() {
+  const [appLink, setAppLink] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const res = await fetch("/api/native-auth/mint", {
+          method: "POST",
+          credentials: "include",
+        });
+        if (!res.ok) {
+          if (!cancelled) setError("Sign-in didn't complete. Please try again from the app.");
+          return;
+        }
+        const data = (await res.json()) as { code?: string };
+        if (!data.code) {
+          if (!cancelled) setError("Sign-in didn't complete. Please try again from the app.");
+          return;
+        }
+        const link = `${APP_ORIGIN}/auth/native-done?code=${encodeURIComponent(data.code)}`;
+        if (cancelled) return;
+        setAppLink(link);
+        // Auto-return; the visible button is the reliable fallback if the
+        // Custom Tab doesn't fire the App Link on a programmatic navigation.
+        window.location.replace(link);
+      } catch {
+        if (!cancelled) setError("Something went wrong finishing sign-in.");
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  return (
+    <main className="flex min-h-dvh flex-col items-center justify-center gap-4 p-6 text-center">
+      {error ? (
+        <>
+          <h1 className="text-lg font-semibold text-destructive">Sign-in error</h1>
+          <p className="text-sm text-muted-foreground">{error}</p>
+        </>
+      ) : (
+        <>
+          <h1 className="text-lg font-semibold">Returning to the app…</h1>
+          {appLink && (
+            <a
+              href={appLink}
+              className="inline-flex h-10 items-center justify-center rounded-md bg-primary px-4 text-sm font-medium text-primary-foreground"
+            >
+              Return to Intake Tracker
+            </a>
+          )}
+        </>
+      )}
+    </main>
+  );
+}

--- a/apps/web/src/app/auth/native-done/page.tsx
+++ b/apps/web/src/app/auth/native-done/page.tsx
@@ -1,0 +1,23 @@
+"use client";
+
+/**
+ * Native Google sign-in — App Link target.
+ *
+ * When the app is installed and the App Link is verified, Android intercepts
+ * this URL and opens the app directly (this web page never renders). It only
+ * renders as a FALLBACK — opened in a browser when App Link verification didn't
+ * take (e.g. a sideloaded install where autoVerify failed). In that case we tell
+ * the user to return to the app; the app surfaces a manual code-entry recovery
+ * (the `?code=` is intentionally not auto-actioned here — a web page must never
+ * complete the sign-in).
+ */
+export default function NativeSignInDone() {
+  return (
+    <main className="flex min-h-dvh flex-col items-center justify-center gap-3 p-6 text-center">
+      <h1 className="text-lg font-semibold">Finishing sign-in…</h1>
+      <p className="text-sm text-muted-foreground">
+        Open the Intake Tracker app to complete signing in.
+      </p>
+    </main>
+  );
+}

--- a/apps/web/src/app/auth/native-start/page.tsx
+++ b/apps/web/src/app/auth/native-start/page.tsx
@@ -1,0 +1,48 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { signIn } from "@/lib/auth-client";
+
+/**
+ * Native Google sign-in — STEP 1 (runs in the app's system-browser Custom Tab,
+ * loaded from the deployed site, NOT the bundled app).
+ *
+ * Kicks off Neon Auth's hosted Google flow with `callbackURL` pointed at
+ * /auth/native-bridge. Because this runs in a real browser tab (not the app
+ * WebView), Google permits the OAuth, and the PKCE challenge cookie is set in
+ * this same browser context — so the verifier exchange on the return trip
+ * succeeds. The app opens this URL via @capacitor/browser.
+ */
+export default function NativeSignInStart() {
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    signIn
+      .social({ provider: "google", callbackURL: "/auth/native-bridge" })
+      .then((result) => {
+        if (result && "error" in result && result.error) {
+          setError(result.error.message ?? "Could not start Google sign-in.");
+        }
+      })
+      .catch((err) => {
+        setError(err instanceof Error ? err.message : "Could not start Google sign-in.");
+      });
+  }, []);
+
+  return (
+    <main className="flex min-h-dvh flex-col items-center justify-center gap-3 p-6 text-center">
+      {error ? (
+        <>
+          <h1 className="text-lg font-semibold text-destructive">Sign-in error</h1>
+          <p className="text-sm text-muted-foreground">{error}</p>
+          <p className="text-sm text-muted-foreground">Close this window and try again from the app.</p>
+        </>
+      ) : (
+        <>
+          <h1 className="text-lg font-semibold">Redirecting to Google…</h1>
+          <p className="text-sm text-muted-foreground">Continue signing in with Google.</p>
+        </>
+      )}
+    </main>
+  );
+}

--- a/apps/web/src/app/auth/sign-in-form.tsx
+++ b/apps/web/src/app/auth/sign-in-form.tsx
@@ -6,6 +6,7 @@ import { useEffect, useState, type FormEvent } from "react";
 import { Button } from "@intake/ui/button";
 import { Input } from "@intake/ui/input";
 import { Label } from "@intake/ui/label";
+import { Capacitor } from "@capacitor/core";
 import { signIn, useSession } from "@/lib/auth-client";
 import { isCapacitorMode } from "@/lib/api-fetch";
 
@@ -82,6 +83,16 @@ export function SignInForm() {
     setError(null);
     setLoading(true);
     try {
+      if (Capacitor.isNativePlatform()) {
+        // Native app: open the hosted Google flow in the system browser (Google
+        // blocks OAuth in the WebView). The App Link return — handled by
+        // initNativeAuthReturn — claims the session and reloads, so we just stop
+        // the spinner once the Custom Tab is open.
+        const { startNativeGoogleSignIn } = await import("@/lib/native-auth-return");
+        await startNativeGoogleSignIn();
+        setLoading(false);
+        return;
+      }
       await signIn.social({ provider: "google", callbackURL });
     } catch (err) {
       setError(err instanceof Error ? err.message : "Google sign in failed");

--- a/apps/web/src/app/providers.tsx
+++ b/apps/web/src/app/providers.tsx
@@ -64,6 +64,10 @@ export function Providers({ children }: { children: React.ReactNode }) {
   }, []);
 
   useEffect(() => {
+    import("@/lib/native-auth-return").then((m) => m.initNativeAuthReturn());
+  }, []);
+
+  useEffect(() => {
     import("@/lib/error-log-service").then((m) => m.installErrorCapture());
   }, []);
 

--- a/apps/web/src/lib/auth-middleware.ts
+++ b/apps/web/src/lib/auth-middleware.ts
@@ -36,7 +36,7 @@ function extractBearerToken(request: NextRequest): string | null {
   return token.length > 0 ? token : null;
 }
 
-async function validateBearerToken(
+export async function validateBearerToken(
   token: string
 ): Promise<{ userId: string; email: string } | null> {
   const baseUrl = process.env.NEON_AUTH_URL;

--- a/apps/web/src/lib/native-auth-bridge.ts
+++ b/apps/web/src/lib/native-auth-bridge.ts
@@ -1,0 +1,69 @@
+/**
+ * Native (Capacitor) Google sign-in bridge — one-time code store.
+ *
+ * The OAuth round-trip runs in the system-browser Custom Tab on our own origin
+ * (so Google permits it and the PKCE challenge cookie is local). Once Neon Auth
+ * has minted a session there, the /auth/native-bridge page calls
+ * {@link mintNativeAuthCode} and hands ONLY the resulting code back to the app
+ * via a verified HTTPS App Link — never the session token in a URL. The app then
+ * POSTs the code to /api/auth/native-claim, which calls
+ * {@link claimNativeAuthCode} to atomically trade it for the session token (for
+ * the app's existing Authorization: Bearer path).
+ *
+ * Security posture: the session token is stored only for the ~60s claim window
+ * and the row is DELETED the instant it is claimed (single-use). Backed by the
+ * server-only `native_auth_codes` table (see @intake/db/schema) — modelled on
+ * the MCP OAuth `mcp_auth_codes` flow.
+ */
+import { randomBytes } from "node:crypto";
+import { and, eq, gte, lt } from "drizzle-orm";
+import { db } from "@intake/db/client";
+import { nativeAuthCodes } from "@intake/db/schema";
+
+// The app claims the code immediately on the App Link return, so the window is
+// deliberately short to minimise the at-rest exposure of the session token.
+export const NATIVE_CODE_TTL_MS = 60_000;
+
+/**
+ * Mint a single-use code bound to a Neon session token. The code is a 256-bit
+ * URL-safe random string. Opportunistically prunes expired rows so the table
+ * stays tiny without a separate cron.
+ */
+export async function mintNativeAuthCode(input: {
+  sessionToken: string;
+  userId: string;
+}): Promise<string> {
+  const now = Date.now();
+  const code = randomBytes(32).toString("base64url");
+
+  await db.insert(nativeAuthCodes).values({
+    code,
+    sessionToken: input.sessionToken,
+    userId: input.userId,
+    expiresAt: now + NATIVE_CODE_TTL_MS,
+    createdAt: now,
+  });
+
+  // Best-effort cleanup of already-expired rows; never fail the mint over it.
+  try {
+    await db.delete(nativeAuthCodes).where(lt(nativeAuthCodes.expiresAt, now));
+  } catch {
+    // ignore — expiry filtering in claim is the real guard
+  }
+
+  return code;
+}
+
+/**
+ * Atomically claim a code: deletes the row and returns its session token, but
+ * only if the code exists and has not expired. Single-use — a replay finds the
+ * row already gone and returns null. Returns null for unknown/expired codes.
+ */
+export async function claimNativeAuthCode(code: string): Promise<string | null> {
+  const now = Date.now();
+  const deleted = await db
+    .delete(nativeAuthCodes)
+    .where(and(eq(nativeAuthCodes.code, code), gte(nativeAuthCodes.expiresAt, now)))
+    .returning({ sessionToken: nativeAuthCodes.sessionToken });
+  return deleted[0]?.sessionToken ?? null;
+}

--- a/apps/web/src/lib/native-auth-return.test.ts
+++ b/apps/web/src/lib/native-auth-return.test.ts
@@ -1,0 +1,80 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("@/lib/api-fetch", () => ({
+  apiFetch: vi.fn(),
+  saveAuthToken: vi.fn(),
+}));
+vi.mock("@capacitor/core", () => ({
+  Capacitor: { isNativePlatform: () => true },
+}));
+vi.mock("@capacitor/browser", () => ({
+  Browser: { close: vi.fn().mockResolvedValue(undefined) },
+}));
+
+import { handleNativeAuthReturn } from "@/lib/native-auth-return";
+import { apiFetch, saveAuthToken } from "@/lib/api-fetch";
+
+const mockApiFetch = vi.mocked(apiFetch);
+const mockSave = vi.mocked(saveAuthToken);
+
+const DONE = "https://intake-tracker.ryanjnoble.dev/auth/native-done";
+
+function jsonRes(status: number, body: unknown): Response {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => body,
+  } as Response;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  Object.defineProperty(window, "location", {
+    configurable: true,
+    value: { replace: vi.fn() },
+  });
+});
+
+describe("handleNativeAuthReturn", () => {
+  it("ignores URLs that are not the native-done path", async () => {
+    expect(await handleNativeAuthReturn(`${DONE.replace("native-done", "history")}`)).toBe(false);
+    expect(mockApiFetch).not.toHaveBeenCalled();
+  });
+
+  it("ignores a malformed URL", async () => {
+    expect(await handleNativeAuthReturn("not a url")).toBe(false);
+    expect(mockApiFetch).not.toHaveBeenCalled();
+  });
+
+  it("ignores native-done without a code", async () => {
+    expect(await handleNativeAuthReturn(DONE)).toBe(false);
+    expect(mockApiFetch).not.toHaveBeenCalled();
+  });
+
+  it("claims the code, stores the token, and reloads", async () => {
+    mockApiFetch.mockResolvedValue(jsonRes(200, { token: "sess-xyz" }));
+    const ok = await handleNativeAuthReturn(`${DONE}?code=abc123`);
+    expect(ok).toBe(true);
+    expect(mockApiFetch).toHaveBeenCalledWith(
+      "/api/native-auth/claim",
+      expect.objectContaining({ method: "POST" }),
+    );
+    expect(mockSave).toHaveBeenCalledWith("sess-xyz");
+    expect(window.location.replace).toHaveBeenCalledWith("/");
+  });
+
+  it("does not store a token or reload when the claim fails", async () => {
+    mockApiFetch.mockResolvedValue(jsonRes(400, { error: "invalid_grant" }));
+    const ok = await handleNativeAuthReturn(`${DONE}?code=bad`);
+    expect(ok).toBe(false);
+    expect(mockSave).not.toHaveBeenCalled();
+    expect(window.location.replace).not.toHaveBeenCalled();
+  });
+
+  it("does not store a token when the response has no token", async () => {
+    mockApiFetch.mockResolvedValue(jsonRes(200, {}));
+    expect(await handleNativeAuthReturn(`${DONE}?code=x`)).toBe(false);
+    expect(mockSave).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/lib/native-auth-return.ts
+++ b/apps/web/src/lib/native-auth-return.ts
@@ -1,0 +1,78 @@
+/**
+ * Native (Capacitor) Google sign-in — client return handler.
+ *
+ * Companion to the server bridge (lib/native-auth-bridge.ts + the /auth/native-*
+ * pages). In the native app, "Continue with Google" calls
+ * {@link startNativeGoogleSignIn}, which opens the OS browser (Custom Tab) on the
+ * deployed site's /auth/native-start. After sign-in the site returns to the app
+ * via a verified HTTPS App Link (/auth/native-done?code=…).
+ * {@link initNativeAuthReturn} catches that link — warm via `appUrlOpen`, cold
+ * via `getLaunchUrl` — trades the one-time code for the Neon session token
+ * (POST /api/native-auth/claim), stores it for the Bearer path, and reloads
+ * authenticated.
+ */
+import { Capacitor } from "@capacitor/core";
+import { apiFetch, saveAuthToken } from "@/lib/api-fetch";
+
+const API_ORIGIN = process.env.NEXT_PUBLIC_API_BASE_URL ?? "";
+const RETURN_PATH = "/auth/native-done";
+
+/** Open the hosted Google flow in the system browser (Custom Tab). */
+export async function startNativeGoogleSignIn(): Promise<void> {
+  const { Browser } = await import("@capacitor/browser");
+  await Browser.open({ url: `${API_ORIGIN}/auth/native-start` });
+}
+
+/**
+ * Handle an inbound App Link. Returns true if it was a native-auth return we
+ * successfully claimed (and triggered a reload), false otherwise. Exported for
+ * unit testing; production code reaches it via {@link initNativeAuthReturn}.
+ */
+export async function handleNativeAuthReturn(url: string): Promise<boolean> {
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    return false;
+  }
+  if (parsed.pathname !== RETURN_PATH) return false;
+  const code = parsed.searchParams.get("code");
+  if (!code) return false;
+
+  try {
+    const res = await apiFetch("/api/native-auth/claim", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ code }),
+    });
+    if (!res.ok) return false;
+    const data = (await res.json()) as { token?: string };
+    if (!data.token) return false;
+    saveAuthToken(data.token);
+  } catch {
+    return false;
+  }
+
+  // Best-effort close the Custom Tab (a no-op on Android), then reload as an
+  // authenticated session so useSession picks up the new Bearer token.
+  try {
+    const { Browser } = await import("@capacitor/browser");
+    await Browser.close();
+  } catch {
+    /* no-op */
+  }
+  window.location.replace("/");
+  return true;
+}
+
+/** Register the App Link return listener. Safe to call on web (no-ops). */
+export async function initNativeAuthReturn(): Promise<void> {
+  if (!Capacitor.isNativePlatform()) return;
+  const { App } = await import("@capacitor/app");
+  await App.addListener("appUrlOpen", (event) => {
+    void handleNativeAuthReturn(event.url);
+  });
+  // Cold start: the app was launched directly by the App Link.
+  const launch = await App.getLaunchUrl();
+  if (launch?.url) void handleNativeAuthReturn(launch.url);
+}

--- a/packages/db/migrations/0018_lazy_jackal.sql
+++ b/packages/db/migrations/0018_lazy_jackal.sql
@@ -1,0 +1,10 @@
+CREATE TABLE "native_auth_codes" (
+	"code" text PRIMARY KEY NOT NULL,
+	"session_token" text NOT NULL,
+	"user_id" text NOT NULL,
+	"expires_at" bigint NOT NULL,
+	"created_at" bigint NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "native_auth_codes" ADD CONSTRAINT "native_auth_codes_user_id_users_sync_id_fk" FOREIGN KEY ("user_id") REFERENCES "neon_auth"."users_sync"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "idx_native_auth_codes_expires" ON "native_auth_codes" USING btree ("expires_at");

--- a/packages/db/migrations/meta/0018_snapshot.json
+++ b/packages/db/migrations/meta/0018_snapshot.json
@@ -1,0 +1,4418 @@
+{
+  "id": "6c1504cd-bbe8-4320-ab30-78e24c007ef0",
+  "prevId": "c8239706-e418-4d62-955d-17d2d8b7f4d8",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.ai_usage": {
+      "name": "ai_usage",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_owner_id": {
+          "name": "key_owner_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "key_source": {
+          "name": "key_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "route": {
+          "name": "route",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "cache_read_tokens": {
+          "name": "cache_read_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "cache_create_tokens": {
+          "name": "cache_create_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "audio_seconds": {
+          "name": "audio_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_ai_usage_user_ts": {
+          "name": "idx_ai_usage_user_ts",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_ai_usage_owner_ts": {
+          "name": "idx_ai_usage_owner_ts",
+          "columns": [
+            {
+              "expression": "key_owner_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ai_usage_user_id_users_sync_id_fk": {
+          "name": "ai_usage_user_id_users_sync_id_fk",
+          "tableFrom": "ai_usage",
+          "tableTo": "users_sync",
+          "schemaTo": "neon_auth",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "ai_usage_key_owner_id_users_sync_id_fk": {
+          "name": "ai_usage_key_owner_id_users_sync_id_fk",
+          "tableFrom": "ai_usage",
+          "tableTo": "users_sync",
+          "schemaTo": "neon_auth",
+          "columnsFrom": [
+            "key_owner_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "ai_usage_key_source_check": {
+          "name": "ai_usage_key_source_check",
+          "value": "\"ai_usage\".\"key_source\" IN ('own_stored','shared_from','env_var')"
+        },
+        "ai_usage_provider_check": {
+          "name": "ai_usage_provider_check",
+          "value": "\"ai_usage\".\"provider\" IN ('anthropic','groq')"
+        },
+        "ai_usage_status_check": {
+          "name": "ai_usage_status_check",
+          "value": "\"ai_usage\".\"status\" IN ('success','error')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.audit_logs": {
+      "name": "audit_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "details": {
+          "name": "details",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "device_id": {
+          "name": "device_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_audit_user_updated": {
+          "name": "idx_audit_user_updated",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_audit_action_ts": {
+          "name": "idx_audit_action_ts",
+          "columns": [
+            {
+              "expression": "action",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "audit_logs_user_id_users_sync_id_fk": {
+          "name": "audit_logs_user_id_users_sync_id_fk",
+          "tableFrom": "audit_logs",
+          "tableTo": "users_sync",
+          "schemaTo": "neon_auth",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "audit_logs_action_check": {
+          "name": "audit_logs_action_check",
+          "value": "\"audit_logs\".\"action\" IN (\n        'ai_parse_request','ai_parse_success','ai_parse_error','data_export',\n        'data_import','data_clear','settings_change','api_key_set','api_key_clear',\n        'pin_set','pin_verify_success','pin_verify_failure','dose_taken',\n        'dose_skipped','dose_rescheduled','dose_time_edited','prescription_added',\n        'prescription_updated','inventory_adjusted','phase_activated','validation_error',\n        'dose_untaken','prescription_deleted','phase_completed','phase_started',\n        'stock_recalculated','inventory_added','inventory_deleted','titration_plan_updated',\n        'timezone_adjusted'\n      )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.blood_pressure_records": {
+      "name": "blood_pressure_records",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "systolic": {
+          "name": "systolic",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "diastolic": {
+          "name": "diastolic",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "heart_rate": {
+          "name": "heart_rate",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "irregular_heartbeat": {
+          "name": "irregular_heartbeat",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position": {
+          "name": "position",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "arm": {
+          "name": "arm",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "device_id": {
+          "name": "device_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_bp_user_updated": {
+          "name": "idx_bp_user_updated",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_bp_ts": {
+          "name": "idx_bp_ts",
+          "columns": [
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "blood_pressure_records_user_id_users_sync_id_fk": {
+          "name": "blood_pressure_records_user_id_users_sync_id_fk",
+          "tableFrom": "blood_pressure_records",
+          "tableTo": "users_sync",
+          "schemaTo": "neon_auth",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "blood_pressure_records_position_check": {
+          "name": "blood_pressure_records_position_check",
+          "value": "\"blood_pressure_records\".\"position\" IN ('standing','sitting')"
+        },
+        "blood_pressure_records_arm_check": {
+          "name": "blood_pressure_records_arm_check",
+          "value": "\"blood_pressure_records\".\"arm\" IN ('left','right')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.daily_notes": {
+      "name": "daily_notes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prescription_id": {
+          "name": "prescription_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dose_log_id": {
+          "name": "dose_log_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "device_id": {
+          "name": "device_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_daily_notes_user_updated": {
+          "name": "idx_daily_notes_user_updated",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_daily_notes_date": {
+          "name": "idx_daily_notes_date",
+          "columns": [
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_daily_notes_prescription": {
+          "name": "idx_daily_notes_prescription",
+          "columns": [
+            {
+              "expression": "prescription_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "daily_notes_user_id_users_sync_id_fk": {
+          "name": "daily_notes_user_id_users_sync_id_fk",
+          "tableFrom": "daily_notes",
+          "tableTo": "users_sync",
+          "schemaTo": "neon_auth",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "daily_notes_prescription_id_prescriptions_id_fk": {
+          "name": "daily_notes_prescription_id_prescriptions_id_fk",
+          "tableFrom": "daily_notes",
+          "tableTo": "prescriptions",
+          "columnsFrom": [
+            "prescription_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "daily_notes_dose_log_id_dose_logs_id_fk": {
+          "name": "daily_notes_dose_log_id_dose_logs_id_fk",
+          "tableFrom": "daily_notes",
+          "tableTo": "dose_logs",
+          "columnsFrom": [
+            "dose_log_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.defecation_records": {
+      "name": "defecation_records",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount_estimate": {
+          "name": "amount_estimate",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "device_id": {
+          "name": "device_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_defecation_user_updated": {
+          "name": "idx_defecation_user_updated",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "defecation_records_user_id_users_sync_id_fk": {
+          "name": "defecation_records_user_id_users_sync_id_fk",
+          "tableFrom": "defecation_records",
+          "tableTo": "users_sync",
+          "schemaTo": "neon_auth",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.dose_logs": {
+      "name": "dose_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prescription_id": {
+          "name": "prescription_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "phase_id": {
+          "name": "phase_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "schedule_id": {
+          "name": "schedule_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "inventory_item_id": {
+          "name": "inventory_item_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scheduled_date": {
+          "name": "scheduled_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scheduled_time": {
+          "name": "scheduled_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action_timestamp": {
+          "name": "action_timestamp",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rescheduled_to": {
+          "name": "rescheduled_to",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "skip_reason": {
+          "name": "skip_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "device_id": {
+          "name": "device_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_dose_logs_user_updated": {
+          "name": "idx_dose_logs_user_updated",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_dose_logs_prescription_date": {
+          "name": "idx_dose_logs_prescription_date",
+          "columns": [
+            {
+              "expression": "prescription_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "scheduled_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_dose_logs_status": {
+          "name": "idx_dose_logs_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "dose_logs_user_id_users_sync_id_fk": {
+          "name": "dose_logs_user_id_users_sync_id_fk",
+          "tableFrom": "dose_logs",
+          "tableTo": "users_sync",
+          "schemaTo": "neon_auth",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "dose_logs_prescription_id_prescriptions_id_fk": {
+          "name": "dose_logs_prescription_id_prescriptions_id_fk",
+          "tableFrom": "dose_logs",
+          "tableTo": "prescriptions",
+          "columnsFrom": [
+            "prescription_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "dose_logs_phase_id_medication_phases_id_fk": {
+          "name": "dose_logs_phase_id_medication_phases_id_fk",
+          "tableFrom": "dose_logs",
+          "tableTo": "medication_phases",
+          "columnsFrom": [
+            "phase_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "dose_logs_schedule_id_phase_schedules_id_fk": {
+          "name": "dose_logs_schedule_id_phase_schedules_id_fk",
+          "tableFrom": "dose_logs",
+          "tableTo": "phase_schedules",
+          "columnsFrom": [
+            "schedule_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "dose_logs_inventory_item_id_inventory_items_id_fk": {
+          "name": "dose_logs_inventory_item_id_inventory_items_id_fk",
+          "tableFrom": "dose_logs",
+          "tableTo": "inventory_items",
+          "columnsFrom": [
+            "inventory_item_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "dose_logs_status_check": {
+          "name": "dose_logs_status_check",
+          "value": "\"dose_logs\".\"status\" IN ('taken','skipped','rescheduled','pending')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.eating_records": {
+      "name": "eating_records",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "grams": {
+          "name": "grams",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "original_input_text": {
+          "name": "original_input_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "group_source": {
+          "name": "group_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "device_id": {
+          "name": "device_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_eating_user_updated": {
+          "name": "idx_eating_user_updated",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_eating_group": {
+          "name": "idx_eating_group",
+          "columns": [
+            {
+              "expression": "group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "eating_records_user_id_users_sync_id_fk": {
+          "name": "eating_records_user_id_users_sync_id_fk",
+          "tableFrom": "eating_records",
+          "tableTo": "users_sync",
+          "schemaTo": "neon_auth",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.insight_jobs": {
+      "name": "insight_jobs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "batch_id": {
+          "name": "batch_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "request_payload": {
+          "name": "request_payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "result_report_id": {
+          "name": "result_report_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "insight_jobs_one_pending_per_user_uq": {
+          "name": "insight_jobs_one_pending_per_user_uq",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "status = 'pending'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_insight_jobs_user_created": {
+          "name": "idx_insight_jobs_user_created",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_insight_jobs_batch": {
+          "name": "idx_insight_jobs_batch",
+          "columns": [
+            {
+              "expression": "batch_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "insight_jobs_user_id_users_sync_id_fk": {
+          "name": "insight_jobs_user_id_users_sync_id_fk",
+          "tableFrom": "insight_jobs",
+          "tableTo": "users_sync",
+          "schemaTo": "neon_auth",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "insight_jobs_result_report_id_insight_reports_id_fk": {
+          "name": "insight_jobs_result_report_id_insight_reports_id_fk",
+          "tableFrom": "insight_jobs",
+          "tableTo": "insight_reports",
+          "columnsFrom": [
+            "result_report_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "insight_jobs_status_check": {
+          "name": "insight_jobs_status_check",
+          "value": "\"insight_jobs\".\"status\" IN ('pending','completed','failed','expired')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.insight_reports": {
+      "name": "insight_reports",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "generated_at": {
+          "name": "generated_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "range_start": {
+          "name": "range_start",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "range_end": {
+          "name": "range_end",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "narrative": {
+          "name": "narrative",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "observations": {
+          "name": "observations",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sources": {
+          "name": "sources",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "personalised": {
+          "name": "personalised",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mode": {
+          "name": "mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "device_id": {
+          "name": "device_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_insight_reports_user_updated": {
+          "name": "idx_insight_reports_user_updated",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_insight_reports_generated": {
+          "name": "idx_insight_reports_generated",
+          "columns": [
+            {
+              "expression": "generated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "insight_reports_user_id_users_sync_id_fk": {
+          "name": "insight_reports_user_id_users_sync_id_fk",
+          "tableFrom": "insight_reports",
+          "tableTo": "users_sync",
+          "schemaTo": "neon_auth",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "insight_reports_mode_check": {
+          "name": "insight_reports_mode_check",
+          "value": "\"insight_reports\".\"mode\" IS NULL OR \"insight_reports\".\"mode\" IN ('fast','deep')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.intake_records": {
+      "name": "intake_records",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "original_input_text": {
+          "name": "original_input_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "group_source": {
+          "name": "group_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "device_id": {
+          "name": "device_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_intake_user_updated": {
+          "name": "idx_intake_user_updated",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_intake_type_ts": {
+          "name": "idx_intake_type_ts",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_intake_group": {
+          "name": "idx_intake_group",
+          "columns": [
+            {
+              "expression": "group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "intake_records_user_id_users_sync_id_fk": {
+          "name": "intake_records_user_id_users_sync_id_fk",
+          "tableFrom": "intake_records",
+          "tableTo": "users_sync",
+          "schemaTo": "neon_auth",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "intake_records_type_check": {
+          "name": "intake_records_type_check",
+          "value": "\"intake_records\".\"type\" IN ('water','salt','sugar','potassium')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.inventory_items": {
+      "name": "inventory_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prescription_id": {
+          "name": "prescription_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "brand_name": {
+          "name": "brand_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "current_stock": {
+          "name": "current_stock",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "strength": {
+          "name": "strength",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "compounds": {
+          "name": "compounds",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "unit": {
+          "name": "unit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pill_shape": {
+          "name": "pill_shape",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pill_color": {
+          "name": "pill_color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "visual_identification": {
+          "name": "visual_identification",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refill_alert_days": {
+          "name": "refill_alert_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refill_alert_pills": {
+          "name": "refill_alert_pills",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_archived": {
+          "name": "is_archived",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "device_id": {
+          "name": "device_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_inventory_user_updated": {
+          "name": "idx_inventory_user_updated",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_inventory_prescription": {
+          "name": "idx_inventory_prescription",
+          "columns": [
+            {
+              "expression": "prescription_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_inventory_active": {
+          "name": "idx_inventory_active",
+          "columns": [
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "inventory_items_user_id_users_sync_id_fk": {
+          "name": "inventory_items_user_id_users_sync_id_fk",
+          "tableFrom": "inventory_items",
+          "tableTo": "users_sync",
+          "schemaTo": "neon_auth",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "inventory_items_prescription_id_prescriptions_id_fk": {
+          "name": "inventory_items_prescription_id_prescriptions_id_fk",
+          "tableFrom": "inventory_items",
+          "tableTo": "prescriptions",
+          "columnsFrom": [
+            "prescription_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "inventory_items_pill_shape_check": {
+          "name": "inventory_items_pill_shape_check",
+          "value": "\"inventory_items\".\"pill_shape\" IN ('round','oval','capsule','diamond','tablet')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.inventory_transactions": {
+      "name": "inventory_transactions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "inventory_item_id": {
+          "name": "inventory_item_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dose_log_id": {
+          "name": "dose_log_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "device_id": {
+          "name": "device_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_inventory_tx_user_updated": {
+          "name": "idx_inventory_tx_user_updated",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_inventory_tx_item_ts": {
+          "name": "idx_inventory_tx_item_ts",
+          "columns": [
+            {
+              "expression": "inventory_item_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_inventory_tx_type": {
+          "name": "idx_inventory_tx_type",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "inventory_transactions_user_id_users_sync_id_fk": {
+          "name": "inventory_transactions_user_id_users_sync_id_fk",
+          "tableFrom": "inventory_transactions",
+          "tableTo": "users_sync",
+          "schemaTo": "neon_auth",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "inventory_transactions_inventory_item_id_inventory_items_id_fk": {
+          "name": "inventory_transactions_inventory_item_id_inventory_items_id_fk",
+          "tableFrom": "inventory_transactions",
+          "tableTo": "inventory_items",
+          "columnsFrom": [
+            "inventory_item_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "inventory_transactions_dose_log_id_dose_logs_id_fk": {
+          "name": "inventory_transactions_dose_log_id_dose_logs_id_fk",
+          "tableFrom": "inventory_transactions",
+          "tableTo": "dose_logs",
+          "columnsFrom": [
+            "dose_log_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "inventory_transactions_type_check": {
+          "name": "inventory_transactions_type_check",
+          "value": "\"inventory_transactions\".\"type\" IN ('refill','consumed','adjusted','initial')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.mcp_access_tokens": {
+      "name": "mcp_access_tokens",
+      "schema": "",
+      "columns": {
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "refresh_token_hash": {
+          "name": "refresh_token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_expires_at": {
+          "name": "refresh_expires_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_mcp_access_tokens_user": {
+          "name": "idx_mcp_access_tokens_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_mcp_access_tokens_expires": {
+          "name": "idx_mcp_access_tokens_expires",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "mcp_access_tokens_client_id_mcp_oauth_clients_client_id_fk": {
+          "name": "mcp_access_tokens_client_id_mcp_oauth_clients_client_id_fk",
+          "tableFrom": "mcp_access_tokens",
+          "tableTo": "mcp_oauth_clients",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "client_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "mcp_access_tokens_user_id_users_sync_id_fk": {
+          "name": "mcp_access_tokens_user_id_users_sync_id_fk",
+          "tableFrom": "mcp_access_tokens",
+          "tableTo": "users_sync",
+          "schemaTo": "neon_auth",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "mcp_access_tokens_refresh_token_hash_unique": {
+          "name": "mcp_access_tokens_refresh_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "refresh_token_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mcp_audit_log": {
+      "name": "mcp_audit_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tool": {
+          "name": "tool",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "args_json": {
+          "name": "args_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_mcp_audit_user_ts": {
+          "name": "idx_mcp_audit_user_ts",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "mcp_audit_log_user_id_users_sync_id_fk": {
+          "name": "mcp_audit_log_user_id_users_sync_id_fk",
+          "tableFrom": "mcp_audit_log",
+          "tableTo": "users_sync",
+          "schemaTo": "neon_auth",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "mcp_audit_log_status_check": {
+          "name": "mcp_audit_log_status_check",
+          "value": "\"mcp_audit_log\".\"status\" IN ('success','error')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.mcp_auth_codes": {
+      "name": "mcp_auth_codes",
+      "schema": "",
+      "columns": {
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "redirect_uri": {
+          "name": "redirect_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code_challenge": {
+          "name": "code_challenge",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code_challenge_method": {
+          "name": "code_challenge_method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consumed_at": {
+          "name": "consumed_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_mcp_auth_codes_client": {
+          "name": "idx_mcp_auth_codes_client",
+          "columns": [
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_mcp_auth_codes_expires": {
+          "name": "idx_mcp_auth_codes_expires",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "mcp_auth_codes_client_id_mcp_oauth_clients_client_id_fk": {
+          "name": "mcp_auth_codes_client_id_mcp_oauth_clients_client_id_fk",
+          "tableFrom": "mcp_auth_codes",
+          "tableTo": "mcp_oauth_clients",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "client_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "mcp_auth_codes_user_id_users_sync_id_fk": {
+          "name": "mcp_auth_codes_user_id_users_sync_id_fk",
+          "tableFrom": "mcp_auth_codes",
+          "tableTo": "users_sync",
+          "schemaTo": "neon_auth",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "mcp_auth_codes_challenge_method_check": {
+          "name": "mcp_auth_codes_challenge_method_check",
+          "value": "\"mcp_auth_codes\".\"code_challenge_method\" IN ('S256','plain')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.mcp_oauth_clients": {
+      "name": "mcp_oauth_clients",
+      "schema": "",
+      "columns": {
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "client_secret_hash": {
+          "name": "client_secret_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "client_name": {
+          "name": "client_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "redirect_uris": {
+          "name": "redirect_uris",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_endpoint_auth_method": {
+          "name": "token_endpoint_auth_method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "mcp_oauth_clients_auth_method_check": {
+          "name": "mcp_oauth_clients_auth_method_check",
+          "value": "\"mcp_oauth_clients\".\"token_endpoint_auth_method\" IN ('none','client_secret_basic','client_secret_post')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.medication_phases": {
+      "name": "medication_phases",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prescription_id": {
+          "name": "prescription_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "unit": {
+          "name": "unit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "food_instruction": {
+          "name": "food_instruction",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "food_note": {
+          "name": "food_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "titration_plan_id": {
+          "name": "titration_plan_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "device_id": {
+          "name": "device_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_phases_user_updated": {
+          "name": "idx_phases_user_updated",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_phases_prescription": {
+          "name": "idx_phases_prescription",
+          "columns": [
+            {
+              "expression": "prescription_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_phases_status_type": {
+          "name": "idx_phases_status_type",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "medication_phases_user_id_users_sync_id_fk": {
+          "name": "medication_phases_user_id_users_sync_id_fk",
+          "tableFrom": "medication_phases",
+          "tableTo": "users_sync",
+          "schemaTo": "neon_auth",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "medication_phases_prescription_id_prescriptions_id_fk": {
+          "name": "medication_phases_prescription_id_prescriptions_id_fk",
+          "tableFrom": "medication_phases",
+          "tableTo": "prescriptions",
+          "columnsFrom": [
+            "prescription_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "medication_phases_titration_plan_id_titration_plans_id_fk": {
+          "name": "medication_phases_titration_plan_id_titration_plans_id_fk",
+          "tableFrom": "medication_phases",
+          "tableTo": "titration_plans",
+          "columnsFrom": [
+            "titration_plan_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "medication_phases_type_check": {
+          "name": "medication_phases_type_check",
+          "value": "\"medication_phases\".\"type\" IN ('maintenance','titration')"
+        },
+        "medication_phases_food_instruction_check": {
+          "name": "medication_phases_food_instruction_check",
+          "value": "\"medication_phases\".\"food_instruction\" IN ('before','after','none')"
+        },
+        "medication_phases_status_check": {
+          "name": "medication_phases_status_check",
+          "value": "\"medication_phases\".\"status\" IN ('active','completed','cancelled','pending')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.native_auth_codes": {
+      "name": "native_auth_codes",
+      "schema": "",
+      "columns": {
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "session_token": {
+          "name": "session_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_native_auth_codes_expires": {
+          "name": "idx_native_auth_codes_expires",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "native_auth_codes_user_id_users_sync_id_fk": {
+          "name": "native_auth_codes_user_id_users_sync_id_fk",
+          "tableFrom": "native_auth_codes",
+          "tableTo": "users_sync",
+          "schemaTo": "neon_auth",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.phase_schedules": {
+      "name": "phase_schedules",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "phase_id": {
+          "name": "phase_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "time": {
+          "name": "time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "schedule_time_utc": {
+          "name": "schedule_time_utc",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "anchor_timezone": {
+          "name": "anchor_timezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dosage": {
+          "name": "dosage",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "days_of_week": {
+          "name": "days_of_week",
+          "type": "integer[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "unit": {
+          "name": "unit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "device_id": {
+          "name": "device_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_phase_schedules_user_updated": {
+          "name": "idx_phase_schedules_user_updated",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_phase_schedules_phase": {
+          "name": "idx_phase_schedules_phase",
+          "columns": [
+            {
+              "expression": "phase_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_phase_schedules_enabled": {
+          "name": "idx_phase_schedules_enabled",
+          "columns": [
+            {
+              "expression": "enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "phase_schedules_user_id_users_sync_id_fk": {
+          "name": "phase_schedules_user_id_users_sync_id_fk",
+          "tableFrom": "phase_schedules",
+          "tableTo": "users_sync",
+          "schemaTo": "neon_auth",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "phase_schedules_phase_id_medication_phases_id_fk": {
+          "name": "phase_schedules_phase_id_medication_phases_id_fk",
+          "tableFrom": "phase_schedules",
+          "tableTo": "medication_phases",
+          "columnsFrom": [
+            "phase_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.prescriptions": {
+      "name": "prescriptions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "generic_name": {
+          "name": "generic_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "indication": {
+          "name": "indication",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contraindications": {
+          "name": "contraindications",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "warnings": {
+          "name": "warnings",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "compounds": {
+          "name": "compounds",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "device_id": {
+          "name": "device_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_prescriptions_user_updated": {
+          "name": "idx_prescriptions_user_updated",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_prescriptions_active": {
+          "name": "idx_prescriptions_active",
+          "columns": [
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "prescriptions_user_id_users_sync_id_fk": {
+          "name": "prescriptions_user_id_users_sync_id_fk",
+          "tableFrom": "prescriptions",
+          "tableTo": "users_sync",
+          "schemaTo": "neon_auth",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.push_schedules": {
+      "name": "push_schedules",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "time_slot": {
+          "name": "time_slot",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "day_of_week": {
+          "name": "day_of_week",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "medications_json": {
+          "name": "medications_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "push_schedules_user_slot_dow_uq": {
+          "name": "push_schedules_user_slot_dow_uq",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "time_slot",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "day_of_week",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "push_schedules_user_id_users_sync_id_fk": {
+          "name": "push_schedules_user_id_users_sync_id_fk",
+          "tableFrom": "push_schedules",
+          "tableTo": "users_sync",
+          "schemaTo": "neon_auth",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.push_sent_log": {
+      "name": "push_sent_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "time_slot": {
+          "name": "time_slot",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sent_date": {
+          "name": "sent_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "follow_up_index": {
+          "name": "follow_up_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "sent_at": {
+          "name": "sent_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "push_sent_log_uq": {
+          "name": "push_sent_log_uq",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "time_slot",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sent_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "follow_up_index",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "push_sent_log_user_id_users_sync_id_fk": {
+          "name": "push_sent_log_user_id_users_sync_id_fk",
+          "tableFrom": "push_sent_log",
+          "tableTo": "users_sync",
+          "schemaTo": "neon_auth",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.push_settings": {
+      "name": "push_settings",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "follow_up_count": {
+          "name": "follow_up_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 2
+        },
+        "follow_up_interval_minutes": {
+          "name": "follow_up_interval_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 10
+        },
+        "day_start_hour": {
+          "name": "day_start_hour",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 2
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "push_settings_user_id_users_sync_id_fk": {
+          "name": "push_settings_user_id_users_sync_id_fk",
+          "tableFrom": "push_settings",
+          "tableTo": "users_sync",
+          "schemaTo": "neon_auth",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.push_subscriptions": {
+      "name": "push_subscriptions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "endpoint": {
+          "name": "endpoint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "p256dh": {
+          "name": "p256dh",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auth_key": {
+          "name": "auth_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'UTC'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "push_subscriptions_user_id_users_sync_id_fk": {
+          "name": "push_subscriptions_user_id_users_sync_id_fk",
+          "tableFrom": "push_subscriptions",
+          "tableTo": "users_sync",
+          "schemaTo": "neon_auth",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "push_subscriptions_user_id_unique": {
+          "name": "push_subscriptions_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.substance_records": {
+      "name": "substance_records",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount_mg": {
+          "name": "amount_mg",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "amount_standard_drinks": {
+          "name": "amount_standard_drinks",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "abv_percent": {
+          "name": "abv_percent",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "volume_ml": {
+          "name": "volume_ml",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_record_id": {
+          "name": "source_record_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ai_enriched": {
+          "name": "ai_enriched",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "original_input_text": {
+          "name": "original_input_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "group_source": {
+          "name": "group_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "device_id": {
+          "name": "device_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_substance_user_updated": {
+          "name": "idx_substance_user_updated",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_substance_type_ts": {
+          "name": "idx_substance_type_ts",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_substance_group": {
+          "name": "idx_substance_group",
+          "columns": [
+            {
+              "expression": "group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "substance_records_user_id_users_sync_id_fk": {
+          "name": "substance_records_user_id_users_sync_id_fk",
+          "tableFrom": "substance_records",
+          "tableTo": "users_sync",
+          "schemaTo": "neon_auth",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "substance_records_source_record_id_intake_records_id_fk": {
+          "name": "substance_records_source_record_id_intake_records_id_fk",
+          "tableFrom": "substance_records",
+          "tableTo": "intake_records",
+          "columnsFrom": [
+            "source_record_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "substance_records_type_check": {
+          "name": "substance_records_type_check",
+          "value": "\"substance_records\".\"type\" IN ('caffeine','alcohol')"
+        },
+        "substance_records_source_check": {
+          "name": "substance_records_source_check",
+          "value": "\"substance_records\".\"source\" IN ('water_intake','eating','standalone')"
+        },
+        "substance_records_abv_percent_range": {
+          "name": "substance_records_abv_percent_range",
+          "value": "\"substance_records\".\"abv_percent\" IS NULL OR (\"substance_records\".\"abv_percent\" >= 0 AND \"substance_records\".\"abv_percent\" <= 100)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.titration_plans": {
+      "name": "titration_plans",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "condition_label": {
+          "name": "condition_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recommended_start_date": {
+          "name": "recommended_start_date",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "warnings": {
+          "name": "warnings",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "device_id": {
+          "name": "device_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_titration_user_updated": {
+          "name": "idx_titration_user_updated",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_titration_condition": {
+          "name": "idx_titration_condition",
+          "columns": [
+            {
+              "expression": "condition_label",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_titration_status": {
+          "name": "idx_titration_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "titration_plans_user_id_users_sync_id_fk": {
+          "name": "titration_plans_user_id_users_sync_id_fk",
+          "tableFrom": "titration_plans",
+          "tableTo": "users_sync",
+          "schemaTo": "neon_auth",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "titration_plans_status_check": {
+          "name": "titration_plans_status_check",
+          "value": "\"titration_plans\".\"status\" IN ('draft','active','completed','cancelled')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.urination_records": {
+      "name": "urination_records",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount_estimate": {
+          "name": "amount_estimate",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "device_id": {
+          "name": "device_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_urination_user_updated": {
+          "name": "idx_urination_user_updated",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "urination_records_user_id_users_sync_id_fk": {
+          "name": "urination_records_user_id_users_sync_id_fk",
+          "tableFrom": "urination_records",
+          "tableTo": "users_sync",
+          "schemaTo": "neon_auth",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_api_keys": {
+      "name": "user_api_keys",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "anthropic_key_encrypted": {
+          "name": "anthropic_key_encrypted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "anthropic_last4": {
+          "name": "anthropic_last4",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "groq_key_encrypted": {
+          "name": "groq_key_encrypted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "groq_last4": {
+          "name": "groq_last4",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_api_keys_user_id_users_sync_id_fk": {
+          "name": "user_api_keys_user_id_users_sync_id_fk",
+          "tableFrom": "user_api_keys",
+          "tableTo": "users_sync",
+          "schemaTo": "neon_auth",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_key_shares": {
+      "name": "user_key_shares",
+      "schema": "",
+      "columns": {
+        "grantor_id": {
+          "name": "grantor_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "grantee_id": {
+          "name": "grantee_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "grantee_email": {
+          "name": "grantee_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_user_key_shares_grantee": {
+          "name": "idx_user_key_shares_grantee",
+          "columns": [
+            {
+              "expression": "grantee_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_key_shares_grantor_id_users_sync_id_fk": {
+          "name": "user_key_shares_grantor_id_users_sync_id_fk",
+          "tableFrom": "user_key_shares",
+          "tableTo": "users_sync",
+          "schemaTo": "neon_auth",
+          "columnsFrom": [
+            "grantor_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_key_shares_grantee_id_users_sync_id_fk": {
+          "name": "user_key_shares_grantee_id_users_sync_id_fk",
+          "tableFrom": "user_key_shares",
+          "tableTo": "users_sync",
+          "schemaTo": "neon_auth",
+          "columnsFrom": [
+            "grantee_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "user_key_shares_grantor_id_grantee_id_provider_pk": {
+          "name": "user_key_shares_grantor_id_grantee_id_provider_pk",
+          "columns": [
+            "grantor_id",
+            "grantee_id",
+            "provider"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "user_key_shares_provider_check": {
+          "name": "user_key_shares_provider_check",
+          "value": "\"user_key_shares\".\"provider\" IN ('anthropic','groq')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.user_profile": {
+      "name": "user_profile",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conditions": {
+          "name": "conditions",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "share_conditions_with_ai": {
+          "name": "share_conditions_with_ai",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "share_medications_with_ai": {
+          "name": "share_medications_with_ai",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "ai_insights_consent_at": {
+          "name": "ai_insights_consent_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "device_id": {
+          "name": "device_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_user_profile_user_updated": {
+          "name": "idx_user_profile_user_updated",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_profile_user_id_users_sync_id_fk": {
+          "name": "user_profile_user_id_users_sync_id_fk",
+          "tableFrom": "user_profile",
+          "tableTo": "users_sync",
+          "schemaTo": "neon_auth",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "neon_auth.users_sync": {
+      "name": "users_sync",
+      "schema": "neon_auth",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.weight_records": {
+      "name": "weight_records",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "weight": {
+          "name": "weight",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "device_id": {
+          "name": "device_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_weight_user_updated": {
+          "name": "idx_weight_user_updated",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "weight_records_user_id_users_sync_id_fk": {
+          "name": "weight_records_user_id_users_sync_id_fk",
+          "tableFrom": "weight_records",
+          "tableTo": "users_sync",
+          "schemaTo": "neon_auth",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/db/migrations/meta/_journal.json
+++ b/packages/db/migrations/meta/_journal.json
@@ -127,6 +127,13 @@
       "when": 1780800000000,
       "tag": "0017_potassium_intake_type",
       "breakpoints": true
+    },
+    {
+      "idx": 18,
+      "version": "7",
+      "when": 1781797699476,
+      "tag": "0018_lazy_jackal",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -1069,3 +1069,29 @@ export const mcpAuditLog = pgTable(
     userTsIdx: index("idx_mcp_audit_user_ts").on(t.userId, t.timestamp),
   }),
 );
+
+// Native (Capacitor) Google sign-in bridge — server-only (no Dexie mirror).
+//
+// After the Neon Auth OAuth exchange completes INSIDE the system-browser Custom
+// Tab (where the PKCE challenge cookie lives), the /auth/native-bridge page mints
+// a one-time `code` bound to the resulting Neon session token and hands ONLY the
+// code back to the app via a verified HTTPS App Link (never the token in a URL).
+// The app exchanges it (POST /api/auth/native-claim) for the session token and
+// uses it on the existing Bearer path. Single-use + short-lived: the row is
+// deleted on claim and ignored past `expiresAt` (~60s). The session token lives
+// here only for that window; the row is removed the instant it is claimed.
+export const nativeAuthCodes = pgTable(
+  "native_auth_codes",
+  {
+    code: text("code").primaryKey(),
+    sessionToken: text("session_token").notNull(),
+    userId: text("user_id")
+      .notNull()
+      .references(() => usersSync.id, { onDelete: "cascade" }),
+    expiresAt: bigint("expires_at", { mode: "number" }).notNull(),
+    createdAt: bigint("created_at", { mode: "number" }).notNull(),
+  },
+  (t) => ({
+    expiresIdx: index("idx_native_auth_codes_expires").on(t.expiresAt),
+  }),
+);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -54,6 +54,12 @@ importers:
       '@capacitor/android':
         specifier: ^8.4.0
         version: 8.4.0(@capacitor/core@8.4.0)
+      '@capacitor/app':
+        specifier: ^8.1.0
+        version: 8.1.0(@capacitor/core@8.4.0)
+      '@capacitor/browser':
+        specifier: ^8.0.3
+        version: 8.0.3(@capacitor/core@8.4.0)
       '@capacitor/core':
         specifier: ^8.4.0
         version: 8.4.0
@@ -73,6 +79,12 @@ importers:
       '@anthropic-ai/sdk':
         specifier: ^0.104.1
         version: 0.104.1(zod@4.4.3)
+      '@capacitor/app':
+        specifier: ^8.1.0
+        version: 8.1.0(@capacitor/core@8.4.0)
+      '@capacitor/browser':
+        specifier: ^8.0.3
+        version: 8.0.3(@capacitor/core@8.4.0)
       '@capacitor/core':
         specifier: ^8.4.0
         version: 8.4.0
@@ -752,6 +764,16 @@ packages:
     resolution: {integrity: sha512-K1ZPkQzvRzPEALz9nBdLx5p5nAPzp5fsTYWk7LRiKZeH/NXqjDvqfTv7lrLgrziQNoDeaL6ijg64oBREzXiV+g==}
     peerDependencies:
       '@capacitor/core': ^8.4.0
+
+  '@capacitor/app@8.1.0':
+    resolution: {integrity: sha512-MlmttTOWHDedr/G4SrhNRxsXMqY+R75S4MM4eIgzsgCzOYhb/MpCkA5Q3nuOCfL1oHm26xjUzqZ5aupbOwdfYg==}
+    peerDependencies:
+      '@capacitor/core': '>=8.0.0'
+
+  '@capacitor/browser@8.0.3':
+    resolution: {integrity: sha512-WJWPHEPbweiFoHYmVlCbZf5yrqJ2Rchx2Xvbmd+3Lf+Zkpq3nXBThThY2CF69lYEg1NINGF9BcHThIOEU1gZlQ==}
+    peerDependencies:
+      '@capacitor/core': '>=8.0.0'
 
   '@capacitor/cli@8.4.0':
     resolution: {integrity: sha512-5Z9RKHxiqJYRTLrfMeZmzR4qrlg5B85MxsWZ5goyXsLkO3bgpW9a1qV/6fR1SX9s5gwLza5y7PZVwITl/hDJ7g==}
@@ -8137,6 +8159,14 @@ snapshots:
       css-tree: 3.2.1
 
   '@capacitor/android@8.4.0(@capacitor/core@8.4.0)':
+    dependencies:
+      '@capacitor/core': 8.4.0
+
+  '@capacitor/app@8.1.0(@capacitor/core@8.4.0)':
+    dependencies:
+      '@capacitor/core': 8.4.0
+
+  '@capacitor/browser@8.0.3(@capacitor/core@8.4.0)':
     dependencies:
       '@capacitor/core': 8.4.0
 


### PR DESCRIPTION
## What

In-app **native Google sign-in** for the Capacitor app, without self-hosting auth or putting a token in a URL. Google blocks OAuth inside embedded WebViews, so the sign-in runs in the **system browser (Custom Tab)** and the session returns via a **verified HTTPS App Link**.

Built on the Phase-0 spike findings (recorded in the PR thread): managed Neon Auth ignores native `idToken`, but `disableRedirect` works and the session token is an opaque ~7-day cookie (no short-lived-JWT refresh problem). So we keep the whole PKCE round-trip on our own origin in the Custom Tab and hand the app a one-time code.

## Flow
```
app "Continue with Google" (isNativePlatform)
  → Custom Tab → /auth/native-start   (runs Neon's Google flow in the system browser)
  → Google → /auth/native-bridge      (middleware exchanges the verifier; mints a one-time code)
  → HTTPS App Link …/auth/native-done?code=…  → opens the app (App Link, not custom scheme)
  → POST /api/native-auth/claim       (trades code → Neon session token, single-use)
  → saveAuthToken → reload authenticated (existing Bearer path)
```

## Phase 2a — server bridge
- `native_auth_codes` server-only table + migration `0018` (modelled on `mcp_auth_codes`).
- `lib/native-auth-bridge.ts`: mint/claim one-time codes — atomic single-use (`DELETE … RETURNING`), ~60s TTL, opportunistic expiry prune.
- `/api/native-auth/mint` (cookie-auth) + `/api/native-auth/claim` (public; the code is the credential), both `no-store`.
- `/auth/native-{start,bridge,done}` client pages (survive `output: export`).
- `public/.well-known/assetlinks.json` with the real release-keystore SHA-256 (pulled from the CI-built APK).

## Phase 2b — native client
- `@capacitor/browser` + `@capacitor/app` (apps/native + apps/web); `includePlugins` + gradle regenerated (all 4 plugins).
- AndroidManifest verified App Link intent-filter (`autoVerify`) for `/auth/native-done`.
- `lib/native-auth-return.ts`: opens the Custom Tab; catches the App Link return (warm `appUrlOpen` + cold `getLaunchUrl`); claims → stores token → reloads.
- Wired into `providers.tsx` + the "Continue with Google" button.

## Security
- **One-time code only crosses to the app — never the session token in a URL.** Single-use (deleted on claim) + ~60s TTL.
- **Verified HTTPS App Links, not a custom scheme** (custom schemes are hijackable by co-installed apps; per the research, no auto custom-scheme fallback).
- The whole PKCE exchange stays in the Custom Tab on our origin (challenge cookie locality).

## Validation
- Unit tests: claim route + return handler (claim/store/reload + failure paths); **real-Postgres integration test** (single-use, expiry, prune). Full suite **2058 pass**.
- typecheck + lint clean; capacitor static export builds; `capacitor-version-parity` covers the 2 new plugins.
- **Signed-APK CI build dispatched** on this branch: https://github.com/RyRy79261/intake-tracker/actions/runs/27823686475

## ⚠️ Needs on-device verification (can't be tested in CI)
1. **App Link `autoVerify`** resolves on a **sideloaded (Obtainium) install** — `adb shell pm get-app-links dev.ryanjnoble.intaketracker` should show `verified` once `assetlinks.json` is live on the domain.
2. The **Custom-Tab → app return** fires the App Link (the visible "Return to Intake Tracker" button is the fallback if the auto-redirect doesn't).
3. Google sign-in completes in-app; email/password remains unaffected.