### PR TITLE
fix(mobile): harden native OAuth bridge (review follow-ups)

### DIFF
--- a/apps/web/src/app/api/native-auth/claim/route.ts
+++ b/apps/web/src/app/api/native-auth/claim/route.ts
@@ -12,6 +12,7 @@
  */
 import { NextResponse, type NextRequest } from "next/server";
 import { z } from "zod";
+import { createRateLimiter, getClientIp } from "@/app/api/_shared/rate-limit";
 import { claimNativeAuthCode } from "@/lib/native-auth-bridge";
 
 export const dynamic = "force-dynamic";
@@ -20,7 +21,19 @@ const NO_STORE = { "Cache-Control": "no-store", Pragma: "no-cache" } as const;
 
 const schema = z.object({ code: z.string().min(1).max(512) });
 
+// Best-effort, per-instance limiter (resets on cold start — see _shared/rate-limit).
+// The code is a 256-bit, 60s, single-use credential, so this is defense-in-depth
+// + consistency with the other public endpoints, not the primary guard.
+const rateLimiter = createRateLimiter(10);
+
 export async function POST(request: NextRequest) {
+  if (!rateLimiter.check(getClientIp(request))) {
+    return NextResponse.json(
+      { error: "rate_limited" },
+      { status: 429, headers: NO_STORE },
+    );
+  }
+
   let raw: unknown;
   try {
     raw = await request.json();

--- a/apps/web/src/app/api/native-auth/mint/route.test.ts
+++ b/apps/web/src/app/api/native-auth/mint/route.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const mockCookieGet = vi.fn();
+vi.mock("next/headers", () => ({
+  cookies: vi.fn(async () => ({ get: mockCookieGet })),
+}));
+vi.mock("@/lib/auth-middleware", () => ({
+  validateBearerToken: vi.fn(),
+}));
+vi.mock("@/lib/native-auth-bridge", () => ({
+  mintNativeAuthCode: vi.fn(),
+}));
+
+import { POST } from "@/app/api/native-auth/mint/route";
+import { validateBearerToken } from "@/lib/auth-middleware";
+import { mintNativeAuthCode } from "@/lib/native-auth-bridge";
+
+const mockValidate = vi.mocked(validateBearerToken);
+const mockMint = vi.mocked(mintNativeAuthCode);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockCookieGet.mockReturnValue(undefined);
+});
+
+describe("POST /api/native-auth/mint", () => {
+  it("401 no_session when the session cookie is absent", async () => {
+    mockCookieGet.mockReturnValue(undefined);
+    const res = await POST();
+    expect(res.status).toBe(401);
+    expect((await res.json()).error).toBe("no_session");
+    expect(res.headers.get("Cache-Control")).toBe("no-store");
+    expect(mockValidate).not.toHaveBeenCalled();
+    expect(mockMint).not.toHaveBeenCalled();
+  });
+
+  it("401 no_session when the cookie is present but the session is invalid", async () => {
+    mockCookieGet.mockReturnValue({ value: "stale-token" });
+    mockValidate.mockResolvedValue(null);
+    const res = await POST();
+    expect(res.status).toBe(401);
+    expect((await res.json()).error).toBe("no_session");
+    expect(mockMint).not.toHaveBeenCalled();
+  });
+
+  it("200 mints a code bound to the session for a valid cookie", async () => {
+    mockCookieGet.mockReturnValue({ value: "sess-token" });
+    mockValidate.mockResolvedValue({ userId: "user-1", email: "a@b.c" });
+    mockMint.mockResolvedValue("minted-code");
+    const res = await POST();
+    expect(res.status).toBe(200);
+    expect((await res.json()).code).toBe("minted-code");
+    expect(mockMint).toHaveBeenCalledWith({ sessionToken: "sess-token", userId: "user-1" });
+    expect(res.headers.get("Cache-Control")).toBe("no-store");
+    expect(res.headers.get("Pragma")).toBe("no-cache");
+  });
+});

--- a/apps/web/src/app/auth/native-bridge/page.test.tsx
+++ b/apps/web/src/app/auth/native-bridge/page.test.tsx
@@ -1,0 +1,53 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, waitFor, cleanup } from "@testing-library/react";
+import NativeSignInBridge from "@/app/auth/native-bridge/page";
+
+const APP_ORIGIN = "https://intake-tracker.ryanjnoble.dev";
+
+function jsonRes(status: number, body: unknown): Response {
+  return { ok: status >= 200 && status < 300, status, json: async () => body } as Response;
+}
+
+beforeEach(() => {
+  vi.restoreAllMocks();
+  Object.defineProperty(window, "location", {
+    configurable: true,
+    value: { replace: vi.fn() },
+  });
+});
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+});
+
+describe("NativeSignInBridge page", () => {
+  it("mints a code and auto-returns to the App Link carrying that exact code", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(jsonRes(200, { code: "abc123" })));
+    render(<NativeSignInBridge />);
+    await waitFor(() => expect(window.location.replace).toHaveBeenCalled());
+    expect(fetch).toHaveBeenCalledWith(
+      "/api/native-auth/mint",
+      expect.objectContaining({ method: "POST", credentials: "include" }),
+    );
+    // The ?code= contract must stay in sync with native-auth-return's RETURN_PATH.
+    expect(window.location.replace).toHaveBeenCalledWith(
+      `${APP_ORIGIN}/auth/native-done?code=abc123`,
+    );
+  });
+
+  it("renders the fallback 'Return to Intake Tracker' link pointing at the App Link", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(jsonRes(200, { code: "xyz" })));
+    render(<NativeSignInBridge />);
+    const link = await screen.findByRole("link", { name: /return to intake tracker/i });
+    expect(link).toHaveAttribute("href", `${APP_ORIGIN}/auth/native-done?code=xyz`);
+  });
+
+  it("shows the error UI and does not redirect when mint fails", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(jsonRes(401, { error: "no_session" })));
+    render(<NativeSignInBridge />);
+    expect(await screen.findByText(/sign-in error/i)).toBeInTheDocument();
+    expect(window.location.replace).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/app/auth/native-bridge/page.tsx
+++ b/apps/web/src/app/auth/native-bridge/page.tsx
@@ -24,11 +24,17 @@ export default function NativeSignInBridge() {
 
   useEffect(() => {
     let cancelled = false;
+    const controller = new AbortController();
+    // Surface the error UI promptly if the mint server accepts then hangs,
+    // instead of leaving the Custom Tab on a static screen until the OS socket
+    // timeout fires. The catch below already handles the resulting AbortError.
+    const timer = setTimeout(() => controller.abort(), 10_000);
     (async () => {
       try {
         const res = await fetch("/api/native-auth/mint", {
           method: "POST",
           credentials: "include",
+          signal: controller.signal,
         });
         if (!res.ok) {
           if (!cancelled) setError("Sign-in didn't complete. Please try again from the app.");
@@ -47,10 +53,13 @@ export default function NativeSignInBridge() {
         window.location.replace(link);
       } catch {
         if (!cancelled) setError("Something went wrong finishing sign-in.");
+      } finally {
+        clearTimeout(timer);
       }
     })();
     return () => {
       cancelled = true;
+      controller.abort();
     };
   }, []);
 

--- a/apps/web/src/app/auth/native-done/page.tsx
+++ b/apps/web/src/app/auth/native-done/page.tsx
@@ -6,10 +6,11 @@
  * When the app is installed and the App Link is verified, Android intercepts
  * this URL and opens the app directly (this web page never renders). It only
  * renders as a FALLBACK — opened in a browser when App Link verification didn't
- * take (e.g. a sideloaded install where autoVerify failed). In that case we tell
- * the user to return to the app; the app surfaces a manual code-entry recovery
- * (the `?code=` is intentionally not auto-actioned here — a web page must never
- * complete the sign-in).
+ * take (e.g. a sideloaded install where autoVerify failed). In that case it just
+ * tells the user to return to the app; the `?code=` is intentionally NOT
+ * auto-actioned here — a web page must never complete the sign-in. There is no
+ * web-side code-entry recovery by design; if the App Link never resolves on a
+ * device, email/password sign-in still works in the WebView.
  */
 export default function NativeSignInDone() {
   return (

--- a/apps/web/src/lib/native-auth-bridge.ts
+++ b/apps/web/src/lib/native-auth-bridge.ts
@@ -6,7 +6,7 @@
  * has minted a session there, the /auth/native-bridge page calls
  * {@link mintNativeAuthCode} and hands ONLY the resulting code back to the app
  * via a verified HTTPS App Link — never the session token in a URL. The app then
- * POSTs the code to /api/auth/native-claim, which calls
+ * POSTs the code to /api/native-auth/claim, which calls
  * {@link claimNativeAuthCode} to atomically trade it for the session token (for
  * the app's existing Authorization: Bearer path).
  *


### PR DESCRIPTION
## Why

#248 (in-app native Google sign-in) merged **without a CodeRabbit review** — CodeRabbit was rate-limited at the time and its incremental engine now treats those commits as "already reviewed," so it won't re-review them. I ran an **adversarial self-review** instead (4 reviewers across security / correctness / mobile-App-Link / data+tests, then per-finding verification).

**Verdict: the bridge is structurally sound** — 256-bit single-use codes, atomic `DELETE … RETURNING` claim, HttpOnly + SameSite CSRF safety, no token-in-URL. Nothing above medium. These are the confirmed follow-ups (hardening + test coverage + doc accuracy), not hole-plugging.

## Changes

| Sev | Fix |
|---|---|
| med | **Route test for `/api/native-auth/mint`** — the cookie-authed endpoint had no route-glue test while `claim` did (no-session 401s, valid-session mint, `no-store`). |
| low | **Regression test for `native-bridge` page** — mint POST → App Link `?code=` contract → redirect, plus the error path. |
| low | **Rate limiter on `/api/native-auth/claim`** — matches the 12+ other public endpoints. Best-effort/consistency only (resets on Vercel cold starts); the 256-bit/60s/single-use code is the real guard. |
| low | **10s `AbortController` on the mint fetch** — an accept-then-hang server now surfaces the error UI instead of a stuck Custom Tab; aborts on unmount. |
| low | **Two stale comments fixed** — `native-done` claimed a non-existent manual code-entry recovery; `native-auth-bridge` cited `/api/auth/native-claim` (real path `/api/native-auth/claim`). |

The review also flagged `native-auth-return.ts:11` for the same comment fix — a **false positive**; that comment is already correct, so no change.

Deliberately **not** done (settled design): no custom-scheme fallback, no web-side code-entry form, Bearer→Keystore stays a Phase 3 item.

## Validation
- 215 test files / **2064 tests pass**; typecheck + lint clean; capacitor static export builds.