### PR TITLE
build(android): v3/v4 APK signing + widen versionCode (Phase 3 hardening)

### DIFF
--- a/.github/workflows/android-release.yml
+++ b/.github/workflows/android-release.yml
@@ -77,11 +77,13 @@ jobs:
         run: |
           VERSION=$(node -p "require('./package.json').version")
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
-          # Generate versionCode from semver: major*10000 + minor*100 + patch
+          # versionCode from semver: major*1000000 + minor*1000 + patch — kept in
+          # sync with apps/native/scripts/sync.mjs, which writes the authoritative
+          # value into version.properties that build.gradle actually reads.
           MAJOR=$(echo "$VERSION" | cut -d. -f1)
           MINOR=$(echo "$VERSION" | cut -d. -f2)
           PATCH=$(echo "$VERSION" | cut -d. -f3)
-          VERSION_CODE=$((MAJOR * 10000 + MINOR * 100 + PATCH))
+          VERSION_CODE=$((MAJOR * 1000000 + MINOR * 1000 + PATCH))
           echo "version_code=$VERSION_CODE" >> "$GITHUB_OUTPUT"
 
       # Build the static export (apps/web/out) from apps/web, where

--- a/apps/native/android/app/build.gradle
+++ b/apps/native/android/app/build.gradle
@@ -67,9 +67,15 @@ android {
                 storePassword releaseStorePassword
                 keyAlias releaseKeyAlias
                 keyPassword releaseKeyPassword
-                // App Bundles for Play default to v1+v2; v2 also satisfies APK installs.
-                enableV1Signing true
+                // minSdk is 24, so v1 (JAR) signing is unnecessary — drop it and
+                // rely on v2 + v3 (v3 enables future signing-key rotation) + v4
+                // (incremental install). The signing KEY is unchanged, so existing
+                // installs update normally and the App Link cert fingerprint stays
+                // identical (assetlinks.json need not change).
+                enableV1Signing false
                 enableV2Signing true
+                enableV3Signing true
+                enableV4Signing true
             }
         }
     }

--- a/apps/native/scripts/sync.mjs
+++ b/apps/native/scripts/sync.mjs
@@ -17,8 +17,10 @@ const repoRoot = join(here, '..', '..', '..'); // monorepo root
 // owns it). apps/web + apps/native are 0.0.0 and must NOT be used here.
 const { version } = JSON.parse(readFileSync(join(repoRoot, 'package.json'), 'utf8'));
 const [major, minor, patch] = version.split('.').map(Number);
-// versionCode = major*10000 + minor*100 + patch (matches android-release.yml).
-const versionCode = major * 10000 + minor * 100 + patch;
+// versionCode = major*1000000 + minor*1000 + patch (matches android-release.yml).
+// Widened from *10000/*100, which collided at minor/patch >= 100; the new scheme
+// stays monotonically above already-released codes (v1.33.0 = 13300 < 1033000).
+const versionCode = major * 1000000 + minor * 1000 + patch;
 writeFileSync(
   join(nativeDir, 'android', 'app', 'version.properties'),
   `VERSION_NAME=${version}\nVERSION_CODE=${versionCode}\n`,


### PR DESCRIPTION
## What

Two research-confirmed Android build hardening items (Phase 3, no new dependencies):

### v3/v4 APK signing
minSdk is **24**, so v1 (JAR) signing is unnecessary. Drop it; add **v3** (enables future signing-key rotation) + **v4** (incremental install), keep v2.
- The signing **key is unchanged** → existing installs update normally, and the **App Link cert fingerprint (`assetlinks.json`) is unaffected**.

### versionCode overflow widening
`major*10000 + minor*100 + patch` collides at minor/patch ≥ 100 (e.g. `1.100.0` == `2.0.0`). Widened to `major*1000000 + minor*1000 + patch`.
- Stays **monotonically above the last released code** (v1.33.0 = 13300 < 1033000), so Obtainium update detection + any future Play upload keep working.
- Updated the authoritative formula in `apps/native/scripts/sync.mjs` (writes `version.properties`, which `build.gradle` reads) and the currently-unused mirror in `android-release.yml`.

## Validation
- YAML valid; versionCode monotonicity checked.
- **Signed-APK CI build dispatched** to confirm the v2+v3+v4 signing config assembles: https://github.com/RyRy79261/intake-tracker/actions/runs/27856781715

## Note
Deferred Phase 3 item still pending your call: moving the Bearer token from `localStorage` → Android Keystore needs a third-party secure-storage plugin (`@aparajita/capacitor-secure-storage`) — flagged separately for approval.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Android app signing configuration to use newer signing schemes (v2, v3, v4)
  * Enhanced version code calculation formula to support improved release versioning across future updates

<!-- end of auto-generated comment: release notes by coderabbit.ai -->