### PR TITLE
fix(android): disable Auto Backup of on-device health data (allowBackup=false)

### DIFF
--- a/apps/native/android/app/src/main/AndroidManifest.xml
+++ b/apps/native/android/app/src/main/AndroidManifest.xml
@@ -1,8 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
+    <!-- allowBackup=false: keep the plaintext on-device Dexie health DB AND the
+         session token out of Android Auto Backup / `adb backup`, which a
+         device-access adversary could otherwise use to extract them. No user data
+         is lost: the data syncs to Neon Postgres (the device is not the system of
+         record), so a reinstall restores via sign-in + sync. -->
     <application
-        android:allowBackup="true"
+        android:allowBackup="false"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
         android:roundIcon="@mipmap/ic_launcher_round"


### PR DESCRIPTION
## Why (from the secure-storage investigation)

I investigated moving the Bearer token to Android Keystore (as you asked). The research **reframed the problem**: that move is medium-cost (a 7-file async refactor) for *marginal* protection on the cheapest secret (a re-obtainable ~7-day opaque token) — and it misses the real exposure.

**The actual currently-open hole:** `android:allowBackup="true"` means a device-access adversary can `adb backup` the app sandbox, which holds the **entire plaintext Dexie health-PII database** (intake, weight, blood pressure, eating, meds, dose logs, …) *plus* the session token. Encrypting only the token would leave the crown jewels exposed.

**This one-line fix** (`allowBackup="false"`) closes that vector for **both** the DB and the token, on all Android versions, **zero dependencies** — a strictly larger security win than the whole Keystore project.

## Trade-off (your call to merge)
- Android cloud / `adb` backup of app data is **disabled**. For a health-PII app this is the privacy-correct default (you don't want health data in Google cloud backup).
- **No data loss:** the data syncs to Neon Postgres (the device isn't the system of record), so a reinstall/new device restores via sign-in + sync.
- ⚠️ Flagging because it's a data-handling change — confirm you're comfortable that Neon sync is the recovery path before merging.

## Deferred (deliberately)
- Keystore secure-storage plugin: not worth it for a bundled local-assets app (the only real token threat is in-bundle XSS, which Keystore doesn't stop — it decrypts into JS memory). If on-device encryption is ever wanted, target the **Dexie DB**, not the token. Recommended plugin if you override: `@aparajita/capacitor-secure-storage`.
- Token-logging audit: **already clean** (`error-log-service` logs path-only; `captureFailure` never includes headers/token).

## Validation
- Manifest XML valid; **signed-APK CI build dispatched**: https://github.com/RyRy79261/intake-tracker/actions/runs/27857490043